### PR TITLE
twoliter container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,16 +67,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -118,6 +145,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,10 +179,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -151,12 +209,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys",
 ]
@@ -167,7 +240,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -186,10 +259,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
+name = "log"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "proc-macro2"
@@ -210,6 +322,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
 name = "rustix"
 version = "0.37.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +359,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -241,11 +388,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "tokio"
+version = "1.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "twoliter"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "env_logger",
+ "log",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -259,6 +461,43 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ exclude = ["/design", "/target", "/dockerfiles", "/scripts"]
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "std"] }
+env_logger = "0.10"
+log = "0.4"
+tempfile = "3"
+tokio = { version = "1", default-features = false, features = ["fs", "macros", "process", "rt-multi-thread"] }

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -1,0 +1,50 @@
+use crate::docker;
+use crate::docker::default_sdk;
+use anyhow::Result;
+use clap::Parser;
+use log::LevelFilter;
+
+/// A tool for building custom variants of Bottlerocket.
+#[derive(Debug, Parser)]
+#[clap(about, long_about = None)]
+pub(crate) struct Args {
+    /// Set the logging level. One of [off|error|warn|info|debug|trace]. Defaults to warn. You can
+    /// also leave this unset and use the RUST_LOG env variable. See
+    /// https://github.com/rust-cli/env_logger/
+    #[clap(long = "log-level")]
+    pub(crate) log_level: Option<LevelFilter>,
+
+    #[clap(subcommand)]
+    pub(crate) subcommand: Subcommand,
+}
+
+#[derive(Debug, Parser)]
+pub(crate) enum Subcommand {
+    /// Build something, such as a Bottlerocket image or a kit of packages.
+    #[clap(subcommand)]
+    Build(BuildCommand),
+}
+
+#[derive(Debug, Parser)]
+pub(crate) enum BuildCommand {
+    Variant(BuildVariant),
+}
+
+impl BuildCommand {
+    pub(crate) async fn run(self) -> Result<()> {
+        match self {
+            BuildCommand::Variant(build_variant) => build_variant.run().await,
+        }
+    }
+}
+
+/// Build a Bottlerocket variant image.
+#[derive(Debug, Parser)]
+pub(crate) struct BuildVariant {}
+
+impl BuildVariant {
+    pub(super) async fn run(&self) -> Result<()> {
+        let _ = docker::create_twoliter_image_if_not_exists(&default_sdk()).await?;
+        Ok(())
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,14 +1,34 @@
-use anyhow::Result;
-use clap::Parser;
+mod args;
 
-pub(super) fn run(_: Args) -> Result<()> {
-    println!("This program is a placeholder for a Bottlerocket build tool.");
-    Ok(())
+pub(crate) use self::args::{Args, Subcommand};
+use anyhow::Result;
+use env_logger::Builder;
+use log::LevelFilter;
+
+const DEFAULT_LEVEL_FILTER: LevelFilter = LevelFilter::Warn;
+
+/// Entrypoint for the `twoliter` command line program.
+pub(super) async fn run(args: Args) -> Result<()> {
+    match args.subcommand {
+        Subcommand::Build(build_command) => build_command.run().await,
+    }
 }
 
-/// A tool for building custom variants of Bottlerocket!
-///
-/// This tool is under construction and not ready for use. Please check back with the project later!
-#[derive(Parser, Debug)]
-#[clap(about, long_about = None)]
-pub(super) struct Args {}
+/// use `level` if present, or else use `RUST_LOG` if present, or else use a default.
+pub(super) fn init_logger(level: Option<LevelFilter>) {
+    match (std::env::var(env_logger::DEFAULT_FILTER_ENV).ok(), level) {
+        (Some(_), None) => {
+            // RUST_LOG exists and level does not; use the environment variable.
+            Builder::from_default_env().init();
+        }
+        _ => {
+            // use provided log level or default for this crate only.
+            Builder::new()
+                .filter(
+                    Some(env!("CARGO_CRATE_NAME")),
+                    level.unwrap_or(DEFAULT_LEVEL_FILTER),
+                )
+                .init();
+        }
+    }
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,43 @@
+pub(crate) const DEFAULT_ARCH: &str = "x86_64";
+use anyhow::{ensure, Context, Result};
+use log::{self, debug, LevelFilter};
+use tokio::process::Command;
+
+/// Run a `tokio::process::Command` and return a `Result` letting us know whether or not it worked.
+pub(crate) async fn exec(cmd: &mut Command) -> Result<()> {
+    debug!("Running: {:?}", cmd);
+
+    match log::max_level() {
+        // For non-debugging levels of logging we capture stdout and stderr
+        LevelFilter::Off | LevelFilter::Error | LevelFilter::Warn | LevelFilter::Info => {
+            let output = cmd
+                .output()
+                .await
+                .context(format!("Unable to start command '{:?}'", cmd))?;
+            ensure!(
+                output.status.success(),
+                "Command '{:?}' was unsuccessful, exit code {}:\n{}\n{}",
+                cmd,
+                output.status.code().unwrap_or(1),
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        // For debugging we stream to stdout and stderr.
+        LevelFilter::Debug | LevelFilter::Trace => {
+            let status = cmd
+                .status()
+                .await
+                .context(format!("Unable to start command '{:?}'", cmd))?;
+
+            ensure!(
+                status.success(),
+                "Command '{:?}' was unsuccessful, exit code {:?}",
+                cmd,
+                status.code().unwrap_or(1),
+            );
+        }
+    }
+    Ok(())
+}

--- a/src/docker/Twoliter.dockerfile
+++ b/src/docker/Twoliter.dockerfile
@@ -1,0 +1,5 @@
+# syntax=docker/dockerfile:1.4.3
+ARG BASE
+FROM ${BASE} as base
+
+COPY --chmod=755 buildsys /usr/local/bin

--- a/src/docker/docker_build.rs
+++ b/src/docker/docker_build.rs
@@ -1,0 +1,93 @@
+use crate::common::exec;
+use crate::docker::ImageUri;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio::process::Command;
+
+/// Can execute a `docker build` command. This follows the builder pattern, for example:
+///
+/// ```
+/// let build = DockerBuild.dockerfile("./Dockerfile").context(".").execute().await?;
+/// ```
+pub(crate) struct DockerBuild {
+    dockerfile: Option<PathBuf>,
+    context_dir: PathBuf,
+    tag: Option<ImageUri>,
+    build_args: HashMap<String, String>,
+}
+
+impl Default for DockerBuild {
+    fn default() -> Self {
+        Self {
+            dockerfile: None,
+            context_dir: PathBuf::from("."),
+            tag: None,
+            build_args: Default::default(),
+        }
+    }
+}
+
+impl DockerBuild {
+    /// Add a value for the `--file` argument.
+    pub(crate) fn dockerfile<P: Into<PathBuf>>(mut self, dockerfile: P) -> Self {
+        self.dockerfile = Some(dockerfile.into());
+        self
+    }
+
+    /// Required: the directory to be passed to the build as the context.
+    pub(crate) fn context_dir<P: Into<PathBuf>>(mut self, context_dir: P) -> Self {
+        self.context_dir = context_dir.into();
+        self
+    }
+
+    /// Add a value for the `--tag` argument.
+    pub(crate) fn tag<T: Into<ImageUri>>(mut self, tag: T) -> Self {
+        self.tag = Some(tag.into());
+        self
+    }
+
+    /// Add a build arg, where `("KEY", value)` becomes `--build-arg=KEY=value`.
+    pub(crate) fn build_arg<S1, S2>(mut self, key: S1, value: S2) -> Self
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+    {
+        self.build_args.insert(key.into(), value.into());
+        self
+    }
+
+    /// Add multiple build args, where `("KEY", value)` becomes `--build-arg=KEY=value`.
+    pub(crate) fn _build_args<I: IntoIterator<Item = (String, String)>>(
+        mut self,
+        build_args: I,
+    ) -> Self {
+        self.build_args.extend(build_args.into_iter());
+        self
+    }
+
+    /// Run the `docker build` command.
+    pub(crate) async fn execute(self) -> Result<()> {
+        let mut args = vec!["build".to_string()];
+        if let Some(dockerfile) = self.dockerfile.as_ref() {
+            args.push("--file".to_string());
+            args.push(dockerfile.display().to_string());
+        }
+        if let Some(tag) = self.tag.as_ref() {
+            args.push("--tag".to_string());
+            args.push(tag.uri());
+        }
+        args.extend(
+            self.build_args
+                .iter()
+                .map(|(k, v)| format!("--build-arg={}={}", k, v)),
+        );
+        args.push(self.context_dir.display().to_string());
+        exec(
+            Command::new("docker")
+                .args(args.into_iter())
+                .env("DOCKER_BUILDKIT", "1"),
+        )
+        .await
+    }
+}

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -1,0 +1,115 @@
+/// Represents a docker image URI such as `public.ecr.aws/myregistry/myrepo:v0.1.0`. The registry is
+/// optional as it is when using `docker`. That is, it will be looked for locally first, then at
+/// `dockerhub.io` when the registry is absent.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub(crate) struct ImageUri {
+    /// e.g. public.ecr.aws/bottlerocket
+    registry: Option<String>,
+    /// e.g. my-repo
+    repo: String,
+    /// e.g. v0.31.0
+    tag: String,
+}
+
+impl ImageUri {
+    /// Create a new `ImageUri`.
+    pub(crate) fn new<S1, S2>(registry: Option<String>, repo: S1, tag: S2) -> Self
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+    {
+        Self {
+            registry,
+            repo: repo.into(),
+            tag: tag.into(),
+        }
+    }
+
+    /// Returns the `ImageUri` for use with docker, e.g. `public.ecr.aws/myregistry/myrepo:v0.1.0`
+    pub(crate) fn uri(&self) -> String {
+        match &self.registry {
+            None => format!("{}:{}", self.repo, self.tag),
+            Some(registry) => format!("{}/{}:{}", registry, self.repo, self.tag),
+        }
+    }
+}
+
+#[test]
+fn image_uri_no_registry() {
+    let uri = ImageUri::new(None, "foo", "v1.2.3");
+    let formatted = uri.uri();
+    let expected = "foo:v1.2.3";
+    assert_eq!(expected, formatted);
+}
+
+#[test]
+fn image_uri_with_registry() {
+    let uri = ImageUri::new(Some("example.com/a/b/c".to_string()), "foo", "v1.2.3");
+    let formatted = uri.uri();
+    let expected = "example.com/a/b/c/foo:v1.2.3";
+    assert_eq!(expected, formatted);
+}
+
+/// Represents a container URI that is specialized for a target compilation architecture. For
+/// example: `public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.1.0`. The registry is
+/// optional as it is when using `docker`. That is, it will be looked for locally first, then at
+/// `dockerhub.io` when the registry is absent. The `name` is automatically suffixed with the target
+/// architecture when creating a docker image URI.
+#[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub(crate) struct ImageArchUri {
+    /// e.g. public.ecr.aws/bottlerocket
+    registry: Option<String>,
+    /// e.g. bottlerocket-sdk
+    name: String,
+    /// e.g. x86_64
+    arch: String,
+    /// e.g. v0.31.0
+    tag: String,
+}
+
+impl ImageArchUri {
+    /// Create a new `ImageArchUri`.
+    pub(crate) fn new<S1, S2, S3>(registry: Option<String>, name: S1, arch: S2, tag: S3) -> Self
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+        S3: Into<String>,
+    {
+        Self {
+            registry,
+            name: name.into(),
+            arch: arch.into(),
+            tag: tag.into(),
+        }
+    }
+
+    /// Returns the `ImageArchUri` for use with docker, e.g.
+    /// `public.ecr.aws/bottlerocket/bottlerocket-sdk-x86_64:v0.1.0`
+    pub(crate) fn uri(&self) -> String {
+        match &self.registry {
+            None => format!("{}-{}:{}", self.name, self.arch, self.tag),
+            Some(registry) => format!("{}/{}-{}:{}", registry, self.name, self.arch, self.tag),
+        }
+    }
+}
+
+#[test]
+fn image_arch_uri_no_registry() {
+    let uri = ImageArchUri::new(None, "my-sdk", "i386", "v0.33.1");
+    let formatted = uri.uri();
+    let expected = "my-sdk-i386:v0.33.1";
+    assert_eq!(expected, formatted);
+}
+
+#[test]
+fn image_arch_uri_with_registry() {
+    let uri = ImageArchUri::new(
+        Some("example.com/a/b/c".to_string()),
+        "my-sdk",
+        "i386",
+        "v0.33.1",
+    );
+    let formatted = uri.uri();
+    let expected = "example.com/a/b/c/my-sdk-i386:v0.33.1";
+    assert_eq!(expected, formatted);
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,0 +1,22 @@
+mod docker_build;
+mod image;
+mod twoliter;
+
+pub(crate) use self::docker_build::DockerBuild;
+pub(crate) use self::image::{ImageArchUri, ImageUri};
+pub(crate) use self::twoliter::create_twoliter_image_if_not_exists;
+use crate::common::DEFAULT_ARCH;
+
+pub(super) const DEFAULT_REGISTRY: &str = "public.ecr.aws/bottlerocket";
+pub(super) const DEFAULT_SDK_NAME: &str = "bottlerocket-sdk";
+// TODO - get this from lock file: https://github.com/bottlerocket-os/twoliter/issues/11
+pub(super) const DEFAULT_SDK_VERSION: &str = "v0.33.0";
+
+pub(crate) fn default_sdk() -> ImageArchUri {
+    ImageArchUri::new(
+        Some(DEFAULT_REGISTRY.into()),
+        DEFAULT_SDK_NAME,
+        DEFAULT_ARCH,
+        DEFAULT_SDK_VERSION,
+    )
+}

--- a/src/docker/twoliter.rs
+++ b/src/docker/twoliter.rs
@@ -1,0 +1,47 @@
+use crate::docker::{DockerBuild, ImageArchUri, ImageUri};
+use anyhow::{Context, Result};
+use tempfile::TempDir;
+use tokio::fs;
+
+const TWOLITER_DOCKERFILE: &str = include_str!("Twoliter.dockerfile");
+
+/// Creates the container needed for twoliter to use as its build environment.
+pub(crate) async fn create_twoliter_image_if_not_exists(sdk: &ImageArchUri) -> Result<ImageUri> {
+    let temp_dir = TempDir::new()
+        .context("Unable to create a temporary directory for Twoliter image creation")?;
+    let empty_dir = temp_dir.path().join("context");
+    fs::create_dir_all(&empty_dir).await.context(format!(
+        "Unable to create directory '{}'",
+        empty_dir.display()
+    ))?;
+
+    // TODO - copy buildsys, etc https://github.com/bottlerocket-os/twoliter/issues/9
+    fs::write(empty_dir.join("buildsys"), "echo \"Hello from buildsys!\"")
+        .await
+        .context(format!(
+            "Unable to write to '{}'",
+            empty_dir.join("buildsys").display()
+        ))?;
+
+    let dockerfile_path = temp_dir.path().join("Twoliter.dockerfile");
+    fs::write(&dockerfile_path, TWOLITER_DOCKERFILE)
+        .await
+        .context(format!(
+            "Unable to write to '{}'",
+            dockerfile_path.display()
+        ))?;
+
+    // TODO - correctly tag https://github.com/bottlerocket-os/twoliter/issues/12
+    let image_uri = ImageUri::new(None, "twoliter", "latest");
+
+    DockerBuild::default()
+        .dockerfile(dockerfile_path)
+        .context_dir(empty_dir)
+        .build_arg("BASE", sdk.uri())
+        .tag(image_uri.clone())
+        .execute()
+        .await
+        .context("Unable to build the twoliter container")?;
+
+    Ok(image_uri)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,16 @@
-use crate::cmd::Args;
+use crate::cmd::{init_logger, Args};
 use anyhow::Result;
 use clap::Parser;
 
 mod cmd;
+mod common;
+mod docker;
 
 /// `anyhow` prints a nicely formatted error message with `Debug`, so we can return a result from
 /// the `main` function.
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let args = Args::parse();
-    cmd::run(args)
+    init_logger(args.log_level);
+    cmd::run(args).await
 }


### PR DESCRIPTION
Implement on-the-fly creation of the twoliter bootstrapping container.

In order to do this, we have added a very basic stub of the twoliter build variant command. For now all this command does is create the bootstrapping container.

*Issue #, if available:*

Closes #10

*Description of changes:*

```
    twoliter container

    Implement on-the-fly creation of the twoliter bootstrapping container.

    In order to do this, we have added a very basic stub of the twoliter
    build variant command. For now all this command does is create the
    bootstrapping container.
```

*Testing done*

`cargo run -- build variant` creates a `twoliter:latest` container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
