### PR TITLE
simplify project file

### DIFF
--- a/twoliter/src/project.rs
+++ b/twoliter/src/project.rs
@@ -32,8 +32,6 @@ pub(crate) struct Project {
     #[serde(skip)]
     project_dir: PathBuf,
     pub(crate) schema_version: SchemaVersion<1>,
-    pub(crate) project_name: String,
-    pub(crate) project_version: String,
 }
 
 impl Project {


### PR DESCRIPTION


*Issue #, if available:*

#7

*Description of changes:*

At the moment, when we are only using Twoliter as a wrapper for cargo make, the project file does nothing other than establish the location of the build root. For now, instead of causing Bottlerocket to check in confusing data in its Twoliter.toml file, let's simplify remove all keys from the schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
