### PR TITLE
Update docker run `--security-opt` command format

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -506,7 +506,7 @@ rc=0
 if ! docker run --rm \
   --network=none \
   --user "$(id -u):$(id -g)" \
-  --security-opt label:disable \
+  --security-opt="label=disable" \
   -v "${BUILDSYS_TOOLS_DIR}":/tmp/tools \
   "${BUILDSYS_SDK_IMAGE}" \
   bash -c \
@@ -782,7 +782,7 @@ fi
 docker run --rm \
    --network=none \
    --user "$(id -u):$(id -g)" \
-   --security-opt label:disable \
+   --security-opt="label=disable" \
    -v "${BOOT_CONFIG_INPUT}":/tmp/bootconfig-input \
    -v "${boot_config}":/tmp/bootconfig.data \
    "${BUILDSYS_SDK_IMAGE}" \
@@ -803,7 +803,7 @@ script = [
 docker run --rm \
    --network=none \
    --user "$(id -u):$(id -g)" \
-   --security-opt label:disable \
+   --security-opt="label=disable" \
    -v "${BOOT_CONFIG}":/tmp/bootconfig.data \
    "${BUILDSYS_SDK_IMAGE}" \
    bootconfig -l /tmp/bootconfig.data
@@ -884,7 +884,7 @@ set +e
 docker run --rm \
   --network=none \
   --user "$(id -u):$(id -g)" \
-  --security-opt label:disable \
+  --security-opt="label=disable" \
   -e CARGO_HOME="/tmp/.cargo" \
   -v "${CARGO_HOME}":/tmp/.cargo \
   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
@@ -922,7 +922,7 @@ set +e
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \
-  --security-opt label:disable \
+  --security-opt="label=disable" \
   -e CARGO_HOME="/tmp/.cargo" \
   -v "${CARGO_HOME}":/tmp/.cargo \
   -v "${BUILDSYS_ROOT_DIR}/licenses:/tmp/licenses" \


### PR DESCRIPTION


*Issue #, if available:*

Closes #34 

*Description of changes:*

Bring in a patch from Bottlerocket's Makefile.toml that was missing.

```
During our build process we have several places where we use the Bottlerocket SDK to perform the build. In these `docker run` commands we pass `--security-opt label:disable` to avoid labeling a large number of files.

It appears this syntax may have changed since we started using it, and the correct syntax is no `label=disable`. Based on reports in the Docker repo, the way we had it of `label:disable` may not actually work.

While there are other issues to be addressed, the older format generates an error when trying to build with finch, while the newer format - though not recognized - only generates a warning message.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
