### PR TITLE
add bottlerocket tools to twoliter binary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[unstable]
+bindeps = true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,9 @@ on:
       - "**.svg"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
       - run: cargo build --locked

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 /target/
 .ignore/
-
-# generated file
-twoliter/src/tools_hash.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -42,34 +42,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
 
 [[package]]
 name = "anstyle-parse"
@@ -91,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -124,7 +114,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -148,13 +138,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -165,7 +155,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -187,21 +177,50 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3d1e2a1f1ab3ac6c4b884e37413eaa03eb9d901e4fc68ee8f5c1d49721680e"
+dependencies = [
+ "aws-credential-types 0.54.1",
+ "aws-http 0.54.1",
+ "aws-sdk-sso 0.24.0",
+ "aws-sdk-sts 0.24.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "aws-types 0.54.1",
+ "bytes",
+ "hex",
+ "http",
+ "hyper",
+ "ring",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-config"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
 dependencies = [
- "aws-credential-types",
- "aws-http",
- "aws-sdk-sso",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sdk-sso 0.28.0",
+ "aws-sdk-sts 0.28.0",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "fastrand 1.9.0",
  "hex",
@@ -217,12 +236,25 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0696a0523a39a19087747e4dafda0362dc867531e3d72a3f195564c84e5e08"
+dependencies = [
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-types 0.55.3",
  "fastrand 1.9.0",
  "tokio",
  "tracing",
@@ -231,15 +263,48 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a4f935ab6a1919fbfd6102a80c4fccd9ff5f47f94ba154074afe1051903261"
+dependencies = [
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "aws-types 0.54.1",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-endpoint"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "http",
  "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82976ca4e426ee9ca3ffcf919d9b2c8d14d0cd80d43cc02173737a8f07f28d4d"
+dependencies = [
+ "aws-credential-types 0.54.1",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "aws-types 0.54.1",
+ "bytes",
+ "http",
+ "http-body",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project-lite",
  "tracing",
 ]
 
@@ -249,10 +314,10 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "http",
  "http-body",
@@ -268,19 +333,19 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f32bb66da99e2955ce49e346200cb14421784755a39c74fe2c043536b2d57ba"
 dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-query",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-query 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "fastrand 1.9.0",
  "http",
@@ -296,17 +361,17 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c44666651c93b43b78bc3d0bc280efffa64ab6c23ecb3370ed0760d6e69d417"
 dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "fastrand 1.9.0",
  "http",
@@ -322,21 +387,46 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab2493c5857725eeafe12ec66ba4ce6feb3355e3af6828d9ef28d6152972a27"
 dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-query",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-query 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "fastrand 1.9.0",
+ "http",
+ "regex",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434d7097fc824eee1d94cf6c5e3a30714da15b81a5b99618f8feb67f8eb2f70a"
+dependencies = [
+ "aws-credential-types 0.54.1",
+ "aws-endpoint 0.54.1",
+ "aws-http 0.54.1",
+ "aws-sig-auth 0.54.1",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "aws-types 0.54.1",
+ "bytes",
  "http",
  "regex",
  "tokio-stream",
@@ -350,17 +440,17 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545335abd7c6ef7285d2972a67b9f8279ff5fec8bbb3ffc637fa436ba1e6e434"
 dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "http",
  "regex",
@@ -375,21 +465,21 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fba197193cbb4bcb6aad8d99796b2291f36fa89562ded5d4501363055b0de89f"
 dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-sigv4",
- "aws-smithy-async",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
+ "aws-sigv4 0.55.3",
+ "aws-smithy-async 0.55.3",
  "aws-smithy-checksums",
- "aws-smithy-client",
+ "aws-smithy-client 0.55.3",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "http",
  "http-body",
@@ -404,21 +494,46 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssm"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a1993b71d6301d8f68f2ce6d87768b2f76130709b3c666d00e7fee52adb73c"
+dependencies = [
+ "aws-credential-types 0.54.1",
+ "aws-endpoint 0.54.1",
+ "aws-http 0.54.1",
+ "aws-sig-auth 0.54.1",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "aws-types 0.54.1",
+ "bytes",
+ "fastrand 1.9.0",
+ "http",
+ "regex",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-ssm"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "014a095ed73c1f789699dfeb45a2b1debb03119910392bd7fcda4a07a72b3af4"
 dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "fastrand 1.9.0",
  "http",
@@ -430,21 +545,45 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0119bacf0c42f587506769390983223ba834e605f049babe514b2bd646dbb2"
+dependencies = [
+ "aws-credential-types 0.54.1",
+ "aws-endpoint 0.54.1",
+ "aws-http 0.54.1",
+ "aws-sig-auth 0.54.1",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "aws-types 0.54.1",
+ "bytes",
+ "http",
+ "regex",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-sso"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8b812340d86d4a766b2ca73f740dfd47a97c2dff0c06c8517a16d88241957e4"
 dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "http",
  "regex",
@@ -455,23 +594,49 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "270b6a33969ebfcb193512fbd5e8ee5306888ad6c6d5d775cdbfb2d50d94de26"
+dependencies = [
+ "aws-credential-types 0.54.1",
+ "aws-endpoint 0.54.1",
+ "aws-http 0.54.1",
+ "aws-sig-auth 0.54.1",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json 0.54.4",
+ "aws-smithy-query 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "aws-smithy-xml 0.54.4",
+ "aws-types 0.54.1",
+ "bytes",
+ "http",
+ "regex",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
 dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-query",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-query 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "http",
  "regex",
@@ -481,16 +646,49 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660a02a98ab1af83bd8d714afbab2d502ba9b18c49e7e4cddd6bf8837ff778cb"
+dependencies = [
+ "aws-credential-types 0.54.1",
+ "aws-sigv4 0.54.2",
+ "aws-smithy-http 0.54.4",
+ "aws-types 0.54.1",
+ "http",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sig-auth"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
 dependencies = [
- "aws-credential-types",
- "aws-sigv4",
+ "aws-credential-types 0.55.3",
+ "aws-sigv4 0.55.3",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-types",
+ "aws-smithy-http 0.55.3",
+ "aws-types 0.55.3",
  "http",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.54.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86529e7b64d902efea8fff52c1b2529368d04f90305cf632729e3713f6b57dc0"
+dependencies = [
+ "aws-smithy-http 0.54.4",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2",
+ "time",
  "tracing",
 ]
 
@@ -501,7 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
 dependencies = [
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.55.3",
  "bytes",
  "form_urlencoded",
  "hex",
@@ -513,6 +711,18 @@ dependencies = [
  "sha2",
  "time",
  "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c712a28a4f2f2139759235c08bf98aca99d4fdf1b13c78c5f95613df0a5db9"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -533,8 +743,8 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ed8b96d95402f3f6b8b57eb4e0e45ee365f78b1a924faf20ff6e97abf1eae6"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "crc32c",
  "crc32fast",
@@ -550,14 +760,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.55.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
+checksum = "104ca17f56cde00a10207169697dfe9c6810db339d52fb352707e64875b30a44"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-types",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-types 0.54.4",
  "bytes",
  "fastrand 1.9.0",
  "http",
@@ -566,7 +776,30 @@ dependencies = [
  "hyper-rustls 0.23.2",
  "lazy_static",
  "pin-project-lite",
- "rustls 0.20.8",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
+dependencies = [
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "fastrand 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.23.2",
+ "lazy_static",
+ "pin-project-lite",
+ "rustls 0.20.9",
  "tokio",
  "tower",
  "tracing",
@@ -578,9 +811,31 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460c8da5110835e3d9a717c61f5556b20d03c32a1dec57f8fc559b360f733bb8"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873f316f1833add0d3aa54ed1b0cd252ddd88c792a0cf839886400099971e844"
+dependencies = [
+ "aws-smithy-types 0.54.4",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -590,7 +845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
 dependencies = [
  "aws-smithy-eventstream",
- "aws-smithy-types",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -608,12 +863,28 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38231d3f5dac9ac7976f44e12803add1385119ffca9e5f050d8e980733d164"
+dependencies = [
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "http",
  "http-body",
@@ -624,11 +895,30 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd83ff2b79e9f729746fcc8ad798676b68fe6ea72986571569a5306a277a182"
+dependencies = [
+ "aws-smithy-types 0.54.4",
+]
+
+[[package]]
+name = "aws-smithy-json"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.55.3",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f0445dafe9d2cd50b44339ae3c3ed46549aad8ac696c52ad660b3e7ae8682b"
+dependencies = [
+ "aws-smithy-types 0.54.4",
+ "urlencoding",
 ]
 
 [[package]]
@@ -637,8 +927,21 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.55.3",
  "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8161232eda10290f5136610a1eb9de56aceaccd70c963a26a260af20ac24794f"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time",
 ]
 
 [[package]]
@@ -656,6 +959,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343ffe9a9bb3f542675f4df0e0d5933513d6ad038ca3907ad1767ba690a99684"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-smithy-xml"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
@@ -665,15 +977,31 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f15b34253b68cde08e39b0627cc6101bcca64351229484b4743392c035d057"
+dependencies = [
+ "aws-credential-types 0.54.1",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "http",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
+name = "aws-types"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-credential-types 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
  "http",
  "rustc_version",
  "tracing",
@@ -708,9 +1036,9 @@ checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64-simd"
@@ -768,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
 dependencies = [
  "memchr",
  "serde",
@@ -828,9 +1156,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bytes-utils"
@@ -844,17 +1172,16 @@ dependencies = [
 
 [[package]]
 name = "cargo-readme"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66dbfc9307f5b2429656e07533613cd3f26803fd2857fc33be22aa2711181d58"
+checksum = "10217a8c6eb2ad03cacb4ef2e2839b69abcc7cefb37a83906b331418eb8f6f0a"
 dependencies = [
- "clap 2.34.0",
+ "clap 4.4.3",
  "lazy_static",
  "percent-encoding",
  "regex",
  "serde",
- "serde_derive",
- "toml 0.5.11",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -874,72 +1201,95 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim 0.8.0",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
 dependencies = [
  "clap_builder",
- "clap_derive",
- "once_cell",
+ "clap_derive 4.4.2",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
- "strsim 0.10.0",
+ "clap_lex 0.5.1",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "coldsnap"
@@ -949,11 +1299,11 @@ checksum = "faa54b44a1a199e3f37ba30ffb7391ed2fe1e4deb15cc55232786b2ca228cb33"
 dependencies = [
  "argh",
  "async-trait",
- "aws-config",
+ "aws-config 0.55.3",
  "aws-sdk-ebs",
  "aws-sdk-ec2",
- "aws-smithy-http",
- "aws-types",
+ "aws-smithy-http 0.55.3",
+ "aws-types 0.55.3",
  "base64 0.13.1",
  "bytes",
  "env_logger",
@@ -1111,7 +1461,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.109",
 ]
 
@@ -1128,12 +1478,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1215,9 +1565,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -1243,9 +1593,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1370,7 +1720,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1496,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.7"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c3372087601b532857d332f5957cbae686da52bb7810bf038c3e3c3cc2fa0d"
+checksum = "c39b3bc2a8f715298032cf5087e58573809374b08160aa7d750582bdb82d2683"
 dependencies = [
  "log",
  "pest",
@@ -1628,7 +1978,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1644,7 +1994,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
@@ -1660,7 +2010,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -1756,16 +2106,16 @@ version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "aws-config",
+ "aws-config 0.55.3",
  "aws-sdk-cloudformation",
  "aws-sdk-s3",
- "aws-types",
- "clap 4.3.23",
+ "aws-types 0.55.3",
+ "clap 4.4.3",
  "hex",
  "log",
  "pubsys-config",
  "serde_json",
- "serde_yaml 0.9.21",
+ "serde_yaml 0.9.25",
  "sha2",
  "shell-words",
  "simplelog",
@@ -1817,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
+checksum = "4f7765dccf8c39c3a470fc694efe322969d791e713ca46bc7b5c506886157572"
 dependencies = [
  "serde",
  "serde_json",
@@ -1844,7 +2194,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "chrono",
  "serde",
@@ -1887,12 +2237,12 @@ dependencies = [
  "pem",
  "pin-project",
  "rand",
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml 0.9.21",
+ "serde_yaml 0.9.25",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -1941,9 +2291,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "linked-hash-map"
@@ -1953,9 +2303,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -1999,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -2040,14 +2390,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -2108,9 +2457,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -2156,6 +2505,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "outref"
@@ -2208,18 +2563,18 @@ dependencies = [
 
 [[package]]
 name = "path-absolutize"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43eb3595c63a214e1b37b44f44b0a84900ef7ae0b4c5efce59e123d246d7a0de"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
 dependencies = [
  "path-dedot",
 ]
 
 [[package]]
 name = "path-dedot"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d55e486337acb9973cdea3ec5638c1b3bcb22e573b2b7b41969e0c744d5a15e"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
 dependencies = [
  "once_cell",
 ]
@@ -2241,19 +2596,20 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
+checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
+checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2261,22 +2617,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
+checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
+checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
 dependencies = [
  "once_cell",
  "pest",
@@ -2300,14 +2656,14 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -2317,9 +2673,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "ppv-lite86"
@@ -2353,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -2364,18 +2720,18 @@ dependencies = [
 name = "pubsys"
 version = "0.1.0"
 dependencies = [
- "aws-config",
- "aws-credential-types",
+ "aws-config 0.55.3",
+ "aws-credential-types 0.55.3",
  "aws-sdk-ebs",
  "aws-sdk-ec2",
- "aws-sdk-kms",
- "aws-sdk-ssm",
- "aws-sdk-sts",
- "aws-smithy-types",
- "aws-types",
+ "aws-sdk-kms 0.28.0",
+ "aws-sdk-ssm 0.28.0",
+ "aws-sdk-sts 0.28.0",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "buildsys",
  "chrono",
- "clap 4.3.23",
+ "clap 4.4.3",
  "coldsnap",
  "duct",
  "futures",
@@ -2401,9 +2757,9 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.5.11",
- "tough",
- "tough-kms",
- "tough-ssm",
+ "tough 0.14.0",
+ "tough-kms 0.6.0",
+ "tough-ssm 0.9.0",
  "update-metadata",
  "url",
 ]
@@ -2418,7 +2774,7 @@ dependencies = [
  "log",
  "parse-datetime",
  "serde",
- "serde_yaml 0.9.21",
+ "serde_yaml 0.9.25",
  "snafu",
  "toml 0.5.11",
  "url",
@@ -2428,7 +2784,7 @@ dependencies = [
 name = "pubsys-setup"
 version = "0.1.0"
 dependencies = [
- "clap 4.3.23",
+ "clap 4.4.3",
  "hex",
  "log",
  "pubsys-config",
@@ -2558,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2570,9 +2926,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2581,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
@@ -2591,7 +2947,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2608,7 +2964,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2656,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2669,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
  "ring",
@@ -2681,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -2709,14 +3065,14 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
  "ring",
  "untrusted",
@@ -2830,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -2849,13 +3205,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2871,11 +3227,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
@@ -2883,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "serde_plain"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
 dependencies = [
  "serde",
 ]
@@ -2925,11 +3281,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.21"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
@@ -3043,22 +3399,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -3085,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3166,12 +3520,12 @@ name = "testsys"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "aws-config",
+ "aws-config 0.55.3",
  "aws-sdk-ec2",
  "base64 0.20.0",
  "bottlerocket-types",
  "bottlerocket-variant",
- "clap 4.3.23",
+ "clap 4.4.3",
  "env_logger",
  "fastrand 1.9.0",
  "futures",
@@ -3182,7 +3536,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "serde_yaml 0.9.21",
+ "serde_yaml 0.9.25",
  "snafu",
  "term_size",
  "testsys-config",
@@ -3203,7 +3557,7 @@ dependencies = [
  "maplit",
  "serde",
  "serde_plain",
- "serde_yaml 0.9.21",
+ "serde_yaml 0.9.25",
  "snafu",
  "testsys-model",
  "toml 0.5.11",
@@ -3242,38 +3596,35 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "itoa",
@@ -3292,9 +3643,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
 dependencies = [
  "time-core",
 ]
@@ -3326,11 +3677,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -3339,7 +3689,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -3362,7 +3712,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3371,7 +3721,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "tokio",
  "webpki",
 ]
@@ -3382,7 +3732,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.6",
+ "rustls 0.21.7",
  "tokio",
 ]
 
@@ -3474,6 +3824,33 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tough"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c259b2bd13fdff3305a5a92b45befb1adb315d664612c8991be57fb6a83dc126"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "globset",
+ "hex",
+ "log",
+ "olpc-cjson",
+ "path-absolutize",
+ "pem",
+ "percent-encoding",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "snafu",
+ "tempfile",
+ "untrusted",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "tough"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda3efa9005cf9c1966984c3b9a44c3f37b7ed2c95ba338d6ad51bba70e989a0"
@@ -3501,17 +3878,47 @@ dependencies = [
 
 [[package]]
 name = "tough-kms"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc49c1a5300e54484604162ec78417fc39306f0c9e2c98166df3ebfa203d6800"
+checksum = "72673807e50c73071b1f522f1fc53410bb66ae9958d572e70e6581af35beaa90"
 dependencies = [
- "aws-config",
- "aws-sdk-kms",
+ "aws-config 0.54.1",
+ "aws-sdk-kms 0.24.0",
  "pem",
  "ring",
  "snafu",
  "tokio",
- "tough",
+ "tough 0.13.0",
+]
+
+[[package]]
+name = "tough-kms"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc49c1a5300e54484604162ec78417fc39306f0c9e2c98166df3ebfa203d6800"
+dependencies = [
+ "aws-config 0.55.3",
+ "aws-sdk-kms 0.28.0",
+ "pem",
+ "ring",
+ "snafu",
+ "tokio",
+ "tough 0.14.0",
+]
+
+[[package]]
+name = "tough-ssm"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f66050278d78786eae031e26d0d290be173da16bda6cf613546a8ec70df13e2"
+dependencies = [
+ "aws-config 0.54.1",
+ "aws-sdk-ssm 0.24.0",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tough 0.13.0",
 ]
 
 [[package]]
@@ -3520,11 +3927,11 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcf4932265842607b42840e65f3fde9dde2834eaa97209b994d6c1a7ff9f3fd7"
 dependencies = [
- "aws-config",
- "aws-sdk-ssm",
+ "aws-config 0.55.3",
+ "aws-sdk-ssm 0.28.0",
  "snafu",
  "tokio",
- "tough",
+ "tough 0.14.0",
 ]
 
 [[package]]
@@ -3546,11 +3953,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "bitflags 2.4.0",
  "bytes",
  "futures-core",
@@ -3598,7 +4005,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3626,6 +4033,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tuftool"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ea883fbc5923a59fd28ea9e0ad11c8899827de27837676fcfc5a427e91de51"
+dependencies = [
+ "aws-config 0.54.1",
+ "aws-sdk-kms 0.24.0",
+ "aws-sdk-ssm 0.24.0",
+ "chrono",
+ "clap 3.2.25",
+ "hex",
+ "log",
+ "maplit",
+ "olpc-cjson",
+ "pem",
+ "rayon",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "tough 0.13.0",
+ "tough-kms 0.5.0",
+ "tough-ssm 0.8.0",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,16 +4089,23 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-recursion",
+ "buildsys",
  "bytes",
- "clap 4.3.23",
+ "clap 4.4.3",
  "env_logger",
  "flate2",
+ "hex",
  "log",
+ "pubsys",
+ "pubsys-setup",
  "serde",
+ "sha2",
  "tar",
  "tempfile",
+ "testsys",
  "tokio",
  "toml 0.7.8",
+ "tuftool",
 ]
 
 [[package]]
@@ -3688,9 +4134,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -3736,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3765,12 +4211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3784,9 +4224,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3834,7 +4274,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
  "wasm-bindgen-shared",
 ]
 
@@ -3868,7 +4308,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,6 +4106,7 @@ dependencies = [
  "tokio",
  "toml 0.7.8",
  "tuftool",
+ "uuid",
 ]
 
 [[package]]
@@ -4209,6 +4210,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ members = [
     "tools/update-metadata",
     "twoliter",
 ]
+
+[profile.release]
+strip = "debuginfo"
+codegen-units = 1
+lto = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# This file locks the build to a specific nightly compiler. There is nothing special about the
+# particular date of the nightly compiler, but we want builds to be reproducable so we lock to a
+# specific, recent instance of nightly.
+[toolchain]
+channel = "nightly-2023-09-12"
+profile = "default"

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -146,7 +146,7 @@ impl GoMod {
                 .context(error::WriteFileSnafu { path: &script_path })?;
         }
 
-        let res = docker_go(root_dir, &args);
+        let res = docker_go(&args);
         fs::remove_file(&script_path).context(error::RemoveFileSnafu { path: &script_path })?;
         res
     }
@@ -170,7 +170,7 @@ struct DockerGoArgs<'a> {
 }
 
 /// Run `docker-go` with the specified arguments.
-fn docker_go(root_dir: &Path, dg_args: &DockerGoArgs) -> Result<()> {
+fn docker_go(dg_args: &DockerGoArgs) -> Result<()> {
     let args = vec![
         "--module-path",
         dg_args
@@ -188,8 +188,11 @@ fn docker_go(root_dir: &Path, dg_args: &DockerGoArgs) -> Result<()> {
         &dg_args.command,
     ];
     let arg_string = args.join(" ");
-    let program = root_dir.join("tools/docker-go");
-    println!("program: {}", program.to_string_lossy());
+    let twoliter_tools_dir = env::var("TWOLITER_TOOLS_DIR").context(error::EnvironmentSnafu {
+        var: "TWOLITER_TOOLS_DIR",
+    })?;
+    let program = PathBuf::from(twoliter_tools_dir).join("docker-go");
+    eprintln!("program: {}", program.to_string_lossy());
     let output = cmd(program, args)
         .stderr_to_stdout()
         .stdout_capture()

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -22,6 +22,7 @@ tar = "0.4"
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["fs", "macros", "process", "rt-multi-thread"] }
 toml = "0.7"
+uuid = { version = "1", features = [ "v4" ] }
 
 # Binary dependencies. These are binaries that we want to embed in the Twoliter binary.
 buildsys = { version = "0.1.0", artifact = [ "bin:buildsys", "bin:bottlerocket-variant" ], path = "../tools/buildsys" }

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -14,12 +14,21 @@ async-recursion = "1"
 clap = { version = "4", features = ["derive", "env", "std"] }
 env_logger = "0.10"
 flate2 = "1"
+hex = "0.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
 tar = "0.4"
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["fs", "macros", "process", "rt-multi-thread"] }
 toml = "0.7"
+
+# Binary dependencies. These are binaries that we want to embed in the Twoliter binary.
+buildsys = { version = "0.1.0", artifact = [ "bin:buildsys", "bin:bottlerocket-variant" ], path = "../tools/buildsys" }
+pubsys = { version = "0.1.0", artifact = [ "bin:pubsys" ], path = "../tools/pubsys" }
+pubsys-setup = { version = "0.1.0", artifact = [ "bin:pubsys-setup" ], path = "../tools/pubsys-setup" }
+testsys = { version = "0.1.0", artifact = [ "bin:testsys" ], path = "../tools/testsys" }
+tuftool = { version = "0.9", artifact = [ "bin:tuftool" ] }
 
 [build-dependencies]
 bytes = "1"

--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -11,56 +11,84 @@ use bytes::BufMut;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 use std::{env, fs};
 
 const DATA_INPUT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/embedded");
 
 fn main() {
-    println!("cargo:rerun-if-changed={}", DATA_INPUT_DIR);
-    // Make sure we run again if the target triple (i.e. aarch64-unknown-linux-gnu) changes.
-    println!("cargo:rerun-if-env-changed=TARGET");
-    let data_input_dir = PathBuf::from(DATA_INPUT_DIR);
+    let paths = Paths::new();
+    println!("cargo:rerun-if-changed={}", paths.data_input_dir.display());
 
-    // This is the directory that cargo creates for us so that we can pass things from the build
-    // script to the main compilation phase.
-    let out_dir =
-        PathBuf::from(env::var("OUT_DIR").expect("The cargo variable 'OUT_DIR' is missing"));
-
-    // This is where we will copy all of the things we want to add to our tarball. We will then
-    // compress and tar this directory.
-    let tools_dir = out_dir.join("tools");
-    fs::create_dir_all(&tools_dir).expect(&format!(
+    fs::create_dir_all(&paths.prep_dir).expect(&format!(
         "Unable to create directory '{}'",
-        tools_dir.display()
+        paths.prep_dir.display()
     ));
 
-    // This is the filepath to the tarball we will create.
-    let tar_path = out_dir.join("tools.tar.gz");
-
-    copy_file(
-        data_input_dir.join("Makefile.toml"),
-        tools_dir.join("Makefile.toml"),
-    );
+    paths.copy_file("Dockerfile");
+    paths.copy_file("Makefile.toml");
+    paths.copy_file("docker-go");
+    paths.copy_file("partyplanner");
+    paths.copy_file("rpm2img");
+    paths.copy_file("rpm2kmodkit");
+    paths.copy_file("rpm2migrations");
 
     // Create tarball in memory.
+    println!("Starting tarball creation at {:?}", SystemTime::now());
     let mut buf_writer = Vec::new().writer();
     let enc = ZlibEncoder::new(&mut buf_writer, Compression::default());
     let mut tar = tar::Builder::new(enc);
-    tar.append_dir_all("", &tools_dir).unwrap();
+    tar.append_dir_all("", &paths.prep_dir).unwrap();
 
     // Drop tar object to ensure any finalizing steps are done.
     drop(tar);
 
     // Get a reference to the tarball bytes.
     let tar_gz_data = buf_writer.get_ref();
+    println!("tar_gz is {} megabytes", tar_gz_data.len() / 1024);
 
     // Write the tarball to the OUT_DIR where it can be imported during the build.
-    fs::write(&tar_path, tar_gz_data)
-        .expect(&format!("Unable to write to file '{}'", tar_path.display()));
+    fs::write(&paths.tar_gz, tar_gz_data).expect(&format!(
+        "Unable to write to file '{}'",
+        paths.tar_gz.display()
+    ));
+    println!("Done at {:?}", SystemTime::now());
+}
+
+struct Paths {
+    /// The directory where our scripts, Makefile.toml etc. are located.
+    data_input_dir: PathBuf,
+    /// The directory that we will copy everything to before creating a tarball.
+    prep_dir: PathBuf,
+    /// The path to tools.tar.gz
+    tar_gz: PathBuf,
+}
+
+impl Paths {
+    fn new() -> Self {
+        // This is the directory that cargo creates for us so that we can pass things from the build
+        // script to the main compilation phase.
+        let out_dir =
+            PathBuf::from(env::var("OUT_DIR").expect("The cargo variable 'OUT_DIR' is missing"));
+
+        Self {
+            data_input_dir: PathBuf::from(DATA_INPUT_DIR),
+            prep_dir: out_dir.join("tools"),
+            tar_gz: out_dir.join("tools.tar.gz"),
+        }
+    }
+
+    /// Copy a file from the `data_input_dir` to the `prep_dir`.
+    fn copy_file(&self, filename: &str) {
+        copy_file_impl(
+            self.data_input_dir.join(filename),
+            self.prep_dir.join(filename),
+        );
+    }
 }
 
 // Copy a file and provide a useful error message if it fails.
-fn copy_file<P1, P2>(source: P1, dest: P2)
+fn copy_file_impl<P1, P2>(source: P1, dest: P2)
 where
     P1: AsRef<Path>,
     P2: AsRef<Path>,

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -13,6 +13,16 @@ ARG ARCH
 ARG GOARCH
 
 FROM ${SDK} as sdk
+USER root
+RUN \
+     --mount=type=secret,id=tools-docker-go,mode=755,target=/tmp/tools/docker-go \
+     --mount=type=secret,id=tools-partyplanner,mode=755,target=/tmp/tools/partyplanner \
+     --mount=type=secret,id=tools-rpm2img,mode=755,target=/tmp/tools/rpm2img \
+     --mount=type=secret,id=tools-rpm2kmodkit,mode=755,target=/tmp/tools/rpm2kmodkit \
+     --mount=type=secret,id=tools-rpm2migrations,mode=755,target=/tmp/tools/rpm2migrations \
+     cp -a /tmp/tools/ /tools/
+USER builder
+
 FROM --platform=linux/${GOARCH} ${TOOLCHAIN}-${ARCH} as toolchain
 
 ############################################################################################
@@ -223,7 +233,7 @@ RUN --mount=target=/host \
     --mount=type=secret,id=aws-access-key-id.env,target=/root/.aws/aws-access-key-id.env \
     --mount=type=secret,id=aws-secret-access-key.env,target=/root/.aws/aws-secret-access-key.env \
     --mount=type=secret,id=aws-session-token.env,target=/root/.aws/aws-session-token.env \
-    /host/tools/rpm2img \
+    /tools/rpm2img \
       --package-dir=/local/rpms \
       --output-dir=/local/output \
       --output-fmt="${IMAGE_FORMAT}" \
@@ -256,7 +266,7 @@ RUN --mount=target=/host \
         -name "bottlerocket-migrations-*.rpm" \
         -not -iname '*debuginfo*' \
         -exec cp '{}' '/local/migrations/' ';' \
-    && /host/tools/rpm2migrations \
+    && /tools/rpm2migrations \
         --package-dir=/local/migrations \
         --output-dir=/local/output \
     && echo ${NOCACHE}
@@ -282,7 +292,7 @@ RUN --mount=target=/host \
     && find /host/build/rpms/ -maxdepth 1 -type f \
         -name "bottlerocket-${KERNEL}-archive-*.rpm" \
         -exec cp '{}' '/local/archives/' ';' \
-    && /host/tools/rpm2kmodkit \
+    && /tools/rpm2kmodkit \
         --archive-dir=/local/archives \
         --toolchain-dir=/local/toolchain \
         --output-dir=/local/output \

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -2,6 +2,10 @@
 skip_core_tasks = true
 
 [env]
+# The directory into which Twoliter has installed tools (e.g. buildsys,
+# rpm2img, etc.) There can be no reasonable default for this, it must be
+# specified when running cargo make.
+TWOLITER_TOOLS_DIR = ""
 BUILDSYS_ARCH = { script = ['echo "${BUILDSYS_ARCH:-$(uname -m)}"'] }
 BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 BUILDSYS_BUILD_DIR = "${BUILDSYS_ROOT_DIR}/build"
@@ -44,9 +48,6 @@ PUBLISH_WAVE_POLICY_PATH = "${BUILDSYS_ROOT_DIR}/sources/updater/waves/default-w
 PUBLISH_INFRA_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Infra.toml"
 # Default repo to read from PUBLISH_INFRA_CONFIG_PATH
 PUBLISH_REPO = "default"
-# The version of tuftool (without the 'v') that we will install and use for
-# publishing-related steps
-PUBLISH_TUFTOOL_VERSION="0.8.1"
 
 # This can be overridden with -e to change the path to the file containing SSM
 # parameter templates.  This file determines the parameter names and values
@@ -245,6 +246,12 @@ case "${BUILDSYS_ARCH}" in
       ;;
 esac
 
+# Ensure the tools directory has been set
+if [ -z "${TWOLITER_TOOLS_DIR}" ];then
+   echo "TWOLITER_TOOLS_DIR must be defined and must be non-zero in length."
+   exit 1
+fi
+
 mkdir -p ${BUILDSYS_BUILD_DIR}
 mkdir -p ${BUILDSYS_OUTPUT_DIR}
 mkdir -p ${BUILDSYS_PACKAGES_DIR}
@@ -322,7 +329,7 @@ dependencies = ["setup"]
 script_runner = "bash"
 script = [
 '''
-for ws in sources variants tools; do
+for ws in sources variants; do
   [ -d "${ws}" ] || continue
   cargo fetch --locked --manifest-path ${ws}/Cargo.toml
 done
@@ -337,7 +344,7 @@ script = [
 go_fetch() {
   local module
   module="${1:?}"
-  ${BUILDSYS_TOOLS_DIR}/docker-go \
+  ${TWOLITER_TOOLS_DIR}/docker-go \
     --module-path "${BUILDSYS_SOURCES_DIR}/${module}" \
     --sdk-image ${BUILDSYS_SDK_IMAGE} \
     --go-mod-cache ${GO_MOD_CACHE} \
@@ -366,7 +373,7 @@ cargo test \
 test_go_module() {
   local module
   module="${1:?}"
-  ${BUILDSYS_TOOLS_DIR}/docker-go \
+  ${TWOLITER_TOOLS_DIR}/docker-go \
     --module-path "${BUILDSYS_SOURCES_DIR}/${module}" \
     --sdk-image ${BUILDSYS_SDK_IMAGE} \
     --go-mod-cache ${GO_MOD_CACHE} \
@@ -397,7 +404,7 @@ rc=0
 go_fmt() {
   local module
   module="${1:?}"
-  ${BUILDSYS_TOOLS_DIR}/docker-go \
+  ${TWOLITER_TOOLS_DIR}/docker-go \
     --module-path "${BUILDSYS_SOURCES_DIR}/${module}" \
     --sdk-image ${BUILDSYS_SDK_IMAGE} \
     --go-mod-cache ${GO_MOD_CACHE} \
@@ -427,21 +434,6 @@ if ! docker run --rm \
   rc=1
 fi
 
-if ! docker run --rm \
-   -u $(id -u):$(id -g) \
-   -e CARGO_HOME="/tmp/.cargo" \
-   -v "${CARGO_HOME}":/tmp/.cargo \
-   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
-   -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
-   "${BUILDSYS_SDK_IMAGE}" \
-   cargo fmt \
-  --manifest-path /tmp/tools/Cargo.toml \
-  --message-format short \
-  --all \
-  -- --check; then
-  rc=1
-fi
-
 if [ "${rc}" -ne 0 ]; then
   echo "Found unformatted source files listed above. First-party source code is checked with gofmt and rustfmt." >&2
   exit $rc
@@ -464,19 +456,6 @@ rc=0
 export VARIANT="${BUILDSYS_VARIANT}"
 
 # For rust first-party source code
-if ! docker run --rm \
-   -u $(id -u):$(id -g) \
-   -e CARGO_HOME="/tmp/.cargo" \
-   -v "${CARGO_HOME}":/tmp/.cargo \
-   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
-   -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
-   "${BUILDSYS_SDK_IMAGE}" \
-   cargo clippy \
-  --manifest-path /tmp/tools/Cargo.toml \
-  --locked -- -D warnings --no-deps; then
-  rc=1
-fi
-
 if ! docker run --rm \
    -u $(id -u):$(id -g) \
    -e CARGO_HOME="/tmp/.cargo" \
@@ -633,60 +612,6 @@ fi
 '''
 ]
 
-[tasks.build-tools]
-dependencies = ["setup", "fetch-sources"]
-script = [
-'''
-cargo install \
-  ${CARGO_MAKE_CARGO_ARGS} \
-  --path tools/buildsys \
-  --root tools \
-  --force \
-  --quiet
-'''
-]
-
-# Note: this is separate from publish-tools because publish-tools takes a while
-# to build and isn't needed to build an image.
-[tasks.publish-setup-tools]
-dependencies = ["setup", "fetch-sources", "tuftool"]
-script = [
-'''
-cargo install \
-  ${CARGO_MAKE_CARGO_ARGS} \
-  --path tools/pubsys-setup \
-  --root tools \
-  --force \
-  --quiet
-'''
-]
-
-[tasks.infra-tools]
-dependencies = ["setup", "fetch-sources", "tuftool"]
-script = [
-'''
-cargo install \
-  ${CARGO_MAKE_CARGO_ARGS} \
-  --path tools/infrasys \
-  --root tools \
-  --force \
-  --quiet
-'''
-]
-
-[tasks.publish-tools]
-dependencies = ["setup", "fetch-sources"]
-script = [
-'''
-cargo install \
-  ${CARGO_MAKE_CARGO_ARGS} \
-  --path tools/pubsys \
-  --root tools \
-  --force \
-  --quiet
-'''
-]
-
 [tasks.build-sbkeys]
 dependencies = ["fetch"]
 script_runner = "bash"
@@ -812,7 +737,7 @@ docker run --rm \
 
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
-dependencies = ["check-cargo-version", "fetch-sdk", "build-tools", "publish-setup", "fetch-licenses"]
+dependencies = ["check-cargo-version", "fetch-sdk", "publish-setup", "fetch-licenses"]
 script_runner = "bash"
 script = [
 '''
@@ -823,7 +748,7 @@ if [ -z "${PACKAGE}" ]; then
     exit 1
 fi
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 # Parse the variant into its components and set additional variables.
 eval "$(bottlerocket-variant)"
@@ -846,10 +771,10 @@ cargo build \
 ]
 
 [tasks.build-variant]
-dependencies = ["fetch-sdk", "build-tools", "build-sbkeys", "publish-setup"]
+dependencies = ["fetch-sdk", "build-sbkeys", "publish-setup"]
 script = [
 '''
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 # Parse the variant into its components and set additional variables.
 eval "$(bottlerocket-variant)"
@@ -877,8 +802,7 @@ dependencies = ["fetch"]
 script = [
 '''
 run_cargo_deny="
-(cd /tmp/sources && cargo deny --all-features check --disable-fetch licenses bans sources) &&
-(cd /tmp/tools && cargo deny --all-features check --disable-fetch licenses bans sources)
+(cd /tmp/sources && cargo deny --all-features check --disable-fetch licenses bans sources)
 "
 set +e
 docker run --rm \
@@ -888,7 +812,6 @@ docker run --rm \
   -e CARGO_HOME="/tmp/.cargo" \
   -v "${CARGO_HOME}":/tmp/.cargo \
   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
-  -v "${BUILDSYS_ROOT_DIR}/tools":/tmp/tools \
   "${BUILDSYS_SDK_IMAGE}" \
   bash -c "${run_cargo_deny}"
 [ "${?}" -eq 0 ] || [ "${BUILDSYS_ALLOW_FAILED_LICENSE_CHECK}" = "true" ]
@@ -939,40 +862,11 @@ dependencies = [
     "build-variant",
 ]
 
-[tasks.tuftool]
-script = [
-'''
-cargo install \
-  --locked \
-  --root tools \
-  --quiet \
-  --version ${PUBLISH_TUFTOOL_VERSION} \
-  tuftool
-'''
-]
-
-[tasks.create-infra]
-dependencies = ["infra-tools"]
-script = [
-'''
-set -e
-
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
-
-infrasys \
-   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}"  \
-   \
-   create-infra \
-   --root-role-path "${PUBLISH_REPO_ROOT_JSON}"
-'''
-]
-
 [tasks.publish-setup]
-dependencies = ["publish-setup-tools"]
 script = [
 '''
 set -e
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 if [ "${ALLOW_MISSING_KEY}" = "true" ]; then
    ALLOW_MISSING_KEY_ARG="--allow-missing-key"
@@ -998,7 +892,7 @@ run_task = "publish-setup"
 # Rather than depend on "build", which currently rebuilds images each run, we
 # check for the image files below to save time.  This does mean that `cargo
 # make` must be run before `cargo make repo`.
-dependencies = ["publish-setup", "publish-tools"]
+dependencies = ["publish-setup", "fetch-sources"]
 script_runner = "bash"
 script = [
 '''
@@ -1009,7 +903,7 @@ cleanup() {
 }
 trap 'cleanup' EXIT
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 bootlz4="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-boot.ext4.lz4"
 rootlz4="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-root.ext4.lz4"
@@ -1094,13 +988,13 @@ ln -sfn "${PUBLISH_REPO_OUTPUT_DIR##*/}" "${PUBLISH_REPO_OUTPUT_DIR%/*}/latest"
 ]
 
 [tasks.validate-repo]
-dependencies = ["publish-setup-without-key", "publish-tools"]
+dependencies = ["publish-setup-without-key", "fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 if [ "${REPO_VALIDATE_TARGETS}" = "true" ]; then
    REPO_VALIDATE_TARGETS_ARG="--validate-targets"
@@ -1121,13 +1015,13 @@ pubsys \
 ]
 
 [tasks.check-repo-expirations]
-dependencies = ["publish-setup-without-key", "publish-tools"]
+dependencies = ["publish-setup-without-key", "fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 pubsys \
    --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
@@ -1144,13 +1038,13 @@ pubsys \
 ]
 
 [tasks.refresh-repo]
-dependencies = ["publish-setup", "publish-tools"]
+dependencies = ["publish-setup", "fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 if [ "${REPO_UNSAFE_REFRESH}" = "true" ]; then
    REPO_UNSAFE_REFRESH_ARG="--unsafe-refresh"
@@ -1177,13 +1071,13 @@ pubsys \
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the image files below to save time.
 # This does mean that `cargo make` must be run before `cargo make ami`.
-dependencies = ["setup-build", "publish-tools"]
+dependencies = ["setup-build", "fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 cleanup() {
    ([ -f "${os_image}" ] && rm -f "${os_image}") ||:
@@ -1249,13 +1143,13 @@ ln -snf "${ami_output##*/}" "${ami_output_latest}"
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the input file below to save time.
 # This does mean that `cargo make ami` must be run before `cargo make ami-public`.
-dependencies = ["publish-tools"]
+dependencies = ["fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 ami_input="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-${AMI_DATA_FILE_SUFFIX}"
 if [ ! -s "${ami_input}" ]; then
@@ -1279,13 +1173,13 @@ pubsys \
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the input file below to save time.
 # This does mean that `cargo make ami` must be run before `cargo make ami-private`.
-dependencies = ["publish-tools"]
+dependencies = ["fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 ami_input="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-${AMI_DATA_FILE_SUFFIX}"
 if [ ! -s "${ami_input}" ]; then
@@ -1309,13 +1203,13 @@ pubsys \
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the input file below to save time.
 # This does mean that `cargo make ami` must be run before `cargo make grant-ami`.
-dependencies = ["publish-tools"]
+dependencies = ["fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 if [ -z "${GRANT_TO_USERS}" ] && [ -z "${GRANT_TO_GROUPS}" ] && [ -z "${GRANT_TO_ORGS}" ] && [ -z "${GRANT_TO_ORG_UNITS}" ]; then
    echo "GRANT_TO_USERS, GRANT_TO_GROUPS, GRANT_TO_ORGs, and/or GRANT_TO_ORG_UNITS is mandatory for grant-ami; please give a comma-separated list of user IDs, group names, organizations, or organizational units" >&2
@@ -1347,13 +1241,13 @@ pubsys \
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the input file below to save time.
 # This does mean that `cargo make ami` must be run before `cargo make revoke-ami`.
-dependencies = ["publish-tools"]
+dependencies = ["fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 if [ -z "${REVOKE_FROM_USERS}" ] && [ -z "${REVOKE_FROM_GROUPS}" ] && [ -z "${REVOKE_FROM_ORGS}" ] && [ -z "${REVOKE_FROM_ORG_UNITS}" ]; then
    echo "REVOKE_FROM_USERS, REVOKE_FROM_GROUPS, REVOKE_FROM_ORGS, and/or REVOKE_FROM_ORG_UNITS is mandatory for revoke-ami; please give a comma-separated list of user IDs, group names, organizations, or organizational units" >&2
@@ -1385,13 +1279,13 @@ pubsys \
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the input file below to save time.
 # This does mean that `cargo make ami` must be run before `cargo make validate-ami`.
-dependencies = ["publish-tools"]
+dependencies = ["fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 expected_amis_path="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-${AMI_DATA_FILE_SUFFIX}"
 if [ ! -s "${expected_amis_path}" ]; then
@@ -1415,13 +1309,13 @@ pubsys \
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the input file below to save time.
 # This does mean that `cargo make ami` must be run before `cargo make ssm`.
-dependencies = ["publish-tools"]
+dependencies = ["fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 ami_input="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-${AMI_DATA_FILE_SUFFIX}"
 if [ ! -s "${ami_input}" ]; then
@@ -1449,13 +1343,13 @@ pubsys \
 ]
 
 [tasks.promote-ssm]
-dependencies = ["publish-tools"]
+dependencies = ["fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 source="${SSM_SOURCE:-${BUILDSYS_VERSION_FULL}}"
 target="${SSM_TARGET}"
@@ -1486,13 +1380,13 @@ pubsys \
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the input file below to save time.
 # This does mean that `cargo make ssm` must be run before `cargo make validate-ssm`.
-dependencies = ["publish-tools"]
+dependencies = ["fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 expected_parameters_path="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-${SSM_DATA_FILE_SUFFIX}"
 if [ ! -s "${expected_parameters_path}" ]; then
@@ -1517,13 +1411,13 @@ pubsys \
 # depend on publish-tools and check for the image files below to save time.
 # This does mean that `cargo make` must be run before
 # `cargo make _upload-ova-base`.
-dependencies = ["setup-build", "publish-tools"]
+dependencies = ["setup-build", "fetch-sources"]
 script_runner = "bash"
 script = [
 '''
 set -e
 
-export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
 ova_path="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}.ova"
 if [ ! -s "${ova_path}" ]; then
@@ -1575,7 +1469,7 @@ dependencies = [
 script_runner = "bash"
 script = [
 '''
-for ws in sources tools; do
+for ws in sources; do
   [ -d "${ws}" ] || continue
   cargo clean --manifest-path ${ws}/Cargo.toml
 done
@@ -1649,25 +1543,11 @@ script = [
     '''
 ]
 
-[tasks.test-tools]
-dependencies = ["setup", "fetch-sources"]
-script = [
-    '''
-    cargo install \
-    ${CARGO_MAKE_CARGO_ARGS} \
-    --path tools/testsys \
-    --root tools \
-    --force \
-    --quiet
-    '''
-]
-
 [tasks.setup-test]
-dependencies = ["test-tools"]
 script = [
     '''
     set -eu
-    export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
     testsys ${CARGO_MAKE_TESTSYS_ARGS} install
     '''
 ]
@@ -1675,7 +1555,6 @@ script = [
 # This task is used to test bottlerocket build artifacts. By default the region first listed in Infra.toml
 # is used for testing; however, `TESTSYS_REGION` can be used to test in a different region.
 [tasks.test]
-dependencies = ["test-tools"]
 script = [
     '''
     set -eu
@@ -1684,7 +1563,7 @@ script = [
     if [ -s "${ami_input}" ]; then
       testsys_ami_input="--ami-input ${ami_input}"
     fi
-    export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
     # The ami that is selected from `amis.json` is determined by `TESTSYS_REGION` if set; otherwise,
     # it is the first region listed in `Infra.toml` (for aws variants).
     testsys ${CARGO_MAKE_TESTSYS_ARGS} run ${TESTSYS_TEST} \
@@ -1699,51 +1578,47 @@ script = [
 # To delete all failed tests use `cargo make clean-test --failed`
 # To delete all incomplete tests use `cargo make clean-test --running`
 [tasks.clean-test]
-dependencies = ["test-tools"]
 script = [
     '''
     set -eu
-    export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
     testsys ${CARGO_MAKE_TESTSYS_ARGS} delete --test ${@}
     '''
 ]
 
 # This task will clear all tests and resources from the testsys cluster.
 [tasks.reset-test]
-dependencies = ["test-tools"]
 script = [
     '''
     set -eu
-    export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
     testsys ${CARGO_MAKE_TESTSYS_ARGS} delete ${@}
     '''
 ]
 
 # This task will clear all testsys components from the testsys cluster.
 [tasks.uninstall-test]
-dependencies = ["test-tools"]
 script = [
    '''
    set -eu
-   export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+   export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
    testsys ${CARGO_MAKE_TESTSYS_ARGS} uninstall
    '''
 ]
 
 # This task will clear all testsys components from the testsys cluster.
 [tasks.purge-test]
-dependencies = ["test-tools","reset-test","uninstall-test"]
+dependencies = ["reset-test","uninstall-test"]
 
 # This task will call watch on the `status` testsys command to show the results of all tests.
 # To see all passed tests use `cargo make watch-test --passed`
 # To see all failed tests use `cargo make watch-test --failed`
 # To see all incomplete tests use `cargo make watch-test --running`
 [tasks.watch-test]
-dependencies = ["test-tools"]
 script = [
    '''
    set -eu
-   export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+   export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
    watch -- testsys ${CARGO_MAKE_TESTSYS_ARGS} status --test ${@}
    '''
 ]
@@ -1752,11 +1627,10 @@ script = [
 # resources.
 # To see all incomplete crds use `cargo make watch-test-all --running` 
 [tasks.watch-test-all]
-dependencies = ["test-tools"]
 script = [
    '''
    set -eu
-   export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+   export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
    watch -- testsys ${CARGO_MAKE_TESTSYS_ARGS} status ${@}
    '''
 ]
@@ -1764,22 +1638,20 @@ script = [
 # This task will retrieve testsys logs from a test. You can add `--follow` to continue to receive
 # logs as they come in.
 [tasks.log-test]
-dependencies = ["test-tools"]
 script = [
    '''
    set -eu
-   export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+   export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
    testsys ${CARGO_MAKE_TESTSYS_ARGS} logs --test ${@}
    '''
 ]
 
 # This task is useful for using the current tree's testsys without symlinks
 [tasks.testsys]
-dependencies = ["test-tools"]
 script = [
    '''
    set -eu
-   export PATH="${BUILDSYS_TOOLS_DIR}/bin:${PATH}"
+   export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
    testsys ${CARGO_MAKE_TESTSYS_ARGS} ${@}
    '''
 ]

--- a/twoliter/src/cmd/debug.rs
+++ b/twoliter/src/cmd/debug.rs
@@ -1,0 +1,59 @@
+use crate::tools::install_tools;
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::env;
+use std::path::PathBuf;
+use tokio::fs;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Parser)]
+pub(crate) struct Debug {
+    #[clap(subcommand)]
+    debug_action: DebugAction,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub(crate) enum DebugAction {
+    CheckTools(CheckToolArgs),
+}
+
+impl DebugAction {
+    pub(crate) async fn run(&self) -> Result<()> {
+        match self {
+            DebugAction::CheckTools(c) => c.run().await,
+        }
+    }
+}
+
+/// Installs the tools into a directory and leaves them there for further inspection. This is useful
+/// for troubleshooting a problem with the tools because during normal execution flow the tools are
+/// cleaned up before Twoliter exits.
+#[derive(Debug, Default, Clone, Parser)]
+pub(crate) struct CheckToolArgs {
+    /// The directory where the tools will be installed (and left behind for your further
+    /// inspection). If not specified, a directory in the tempdir will be used. The directory will
+    /// be created if it does not exist. Outputs the name of the directory to stdout.
+    #[clap(long)]
+    install_dir: Option<PathBuf>,
+}
+
+fn unique_name() -> String {
+    let uuid = format!("{}", Uuid::new_v4());
+    let slug = &uuid[0..8];
+    format!("twoliter-tools-{}", slug)
+}
+
+impl CheckToolArgs {
+    pub(crate) async fn run(&self) -> Result<()> {
+        let dir = self
+            .install_dir
+            .clone()
+            .unwrap_or_else(|| env::temp_dir().join(unique_name()));
+        fs::create_dir_all(&dir)
+            .await
+            .context(format!("Unable to create directory '{}'", dir.display()))?;
+        install_tools(&dir).await?;
+        println!("{}", dir.display());
+        Ok(())
+    }
+}

--- a/twoliter/src/cmd/mod.rs
+++ b/twoliter/src/cmd/mod.rs
@@ -14,7 +14,7 @@ const DEFAULT_LEVEL_FILTER: LevelFilter = LevelFilter::Info;
 
 /// A tool for building custom variants of Bottlerocket.
 #[derive(Debug, Parser)]
-#[clap(about, long_about = None)]
+#[clap(about, long_about = None, version)]
 pub(crate) struct Args {
     /// Set the logging level. One of [off|error|warn|info|debug|trace]. Defaults to warn. You can
     /// also leave this unset and use the RUST_LOG env variable. See

--- a/twoliter/src/cmd/mod.rs
+++ b/twoliter/src/cmd/mod.rs
@@ -1,7 +1,9 @@
 mod build;
+mod debug;
 mod make;
 
 use self::build::BuildCommand;
+use crate::cmd::debug::DebugAction;
 use crate::cmd::make::Make;
 use anyhow::Result;
 use clap::Parser;
@@ -31,6 +33,10 @@ pub(crate) enum Subcommand {
     Build(BuildCommand),
 
     Make(Make),
+
+    /// Commands that are used for checking and troubleshooting Twoliter's internals.
+    #[clap(subcommand)]
+    Debug(DebugAction),
 }
 
 /// Entrypoint for the `twoliter` command line program.
@@ -38,6 +44,7 @@ pub(super) async fn run(args: Args) -> Result<()> {
     match args.subcommand {
         Subcommand::Build(build_command) => build_command.run().await,
         Subcommand::Make(make_args) => make_args.run().await,
+        Subcommand::Debug(debug_action) => debug_action.run().await,
     }
 }
 

--- a/twoliter/src/common.rs
+++ b/twoliter/src/common.rs
@@ -12,11 +12,10 @@ pub(crate) async fn exec(cmd: &mut Command) -> Result<()> {
             let output = cmd
                 .output()
                 .await
-                .context(format!("Unable to start command '{:?}'", cmd))?;
+                .context(format!("Unable to start command"))?;
             ensure!(
                 output.status.success(),
-                "Command '{:?}' was unsuccessful, exit code {}:\n{}\n{}",
-                cmd,
+                "Command was unsuccessful, exit code {}:\n{}\n{}",
                 output.status.code().unwrap_or(1),
                 String::from_utf8_lossy(&output.stdout),
                 String::from_utf8_lossy(&output.stderr)
@@ -28,12 +27,11 @@ pub(crate) async fn exec(cmd: &mut Command) -> Result<()> {
             let status = cmd
                 .status()
                 .await
-                .context(format!("Unable to start command '{:?}'", cmd))?;
+                .context(format!("Unable to start command"))?;
 
             ensure!(
                 status.success(),
-                "Command '{:?}' was unsuccessful, exit code {:?}",
-                cmd,
+                "Command was unsuccessful, exit code {}",
                 status.code().unwrap_or(1),
             );
         }

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -4,20 +4,63 @@ use log::debug;
 use std::path::Path;
 use tar::Archive;
 use tempfile::TempDir;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
 
 const TAR_GZ_DATA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/tools.tar.gz"));
+const BOTTLEROCKET_VARIANT: &[u8] =
+    include_bytes!(env!("CARGO_BIN_FILE_BUILDSYS_bottlerocket-variant"));
+const BUILDSYS: &[u8] = include_bytes!(env!("CARGO_BIN_FILE_BUILDSYS"));
+const PUBSYS: &[u8] = include_bytes!(env!("CARGO_BIN_FILE_PUBSYS"));
+const PUBSYS_SETUP: &[u8] = include_bytes!(env!("CARGO_BIN_FILE_PUBSYS_SETUP"));
+const TESTSYS: &[u8] = include_bytes!(env!("CARGO_BIN_FILE_TESTSYS"));
+const TUFTOOL: &[u8] = include_bytes!(env!("CARGO_BIN_FILE_TUFTOOL"));
 
-pub(crate) async fn install_tools() -> Result<TempDir> {
-    let tempdir = TempDir::new().context("Unable to create a tempdir for Twoliter's tools")?;
-    let tools_dir = tempdir.path();
-    debug!("Installing tools to '{}'", tools_dir.display());
+/// Create a `TempDir` object and provide a tools-centric error message if it fails. Make sure you
+/// hang on to the `TempDir` for as long as you need it. It will be deleted when it goes out of
+/// scope.
+pub(crate) fn tools_tempdir() -> Result<TempDir> {
+    TempDir::new().context("Unable to create a tempdir for Twoliter's tools")
+}
+
+/// Install tools into the given `tools_dir`. If you use a `TempDir` object, make sure to pass it by
+/// reference and hold on to it until you no longer need the tools to still be installed (it will
+/// auto delete when it goes out of scope).
+pub(crate) async fn install_tools(tools_dir: impl AsRef<Path>) -> Result<()> {
+    let dir = tools_dir.as_ref();
+    debug!("Installing tools to '{}'", dir.display());
+
+    write_bin("bottlerocket-variant", BOTTLEROCKET_VARIANT, &dir).await?;
+    write_bin("buildsys", BUILDSYS, &dir).await?;
+    write_bin("pubsys", PUBSYS, &dir).await?;
+    write_bin("pubsys-setup", PUBSYS_SETUP, &dir).await?;
+    write_bin("testsys", TESTSYS, &dir).await?;
+    write_bin("tuftool", TUFTOOL, &dir).await?;
 
     // Write out the embedded tools and scripts.
-    unpack_tarball(&tools_dir)
+    unpack_tarball(&dir)
         .await
         .context("Unable to install tools")?;
 
-    Ok(tempdir)
+    Ok(())
+}
+
+async fn write_bin(name: &str, data: &[u8], dir: impl AsRef<Path>) -> Result<()> {
+    let path = dir.as_ref().join(name);
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .read(false)
+        .write(true)
+        .mode(0o755)
+        .open(&path)
+        .await
+        .context(format!("Unable to create file '{}'", path.display()))?;
+    f.write_all(data)
+        .await
+        .context(format!("Unable to write to '{}'", path.display()))?;
+    f.flush()
+        .await
+        .context(format!("Unable to finalize '{}'", path.display()))
 }
 
 async fn unpack_tarball(tools_dir: impl AsRef<Path>) -> Result<()> {
@@ -34,8 +77,25 @@ async fn unpack_tarball(tools_dir: impl AsRef<Path>) -> Result<()> {
 
 #[tokio::test]
 async fn test_install_tools() {
-    let tempdir = install_tools().await.unwrap();
+    let tempdir = tools_tempdir().unwrap();
+    install_tools(&tempdir).await.unwrap();
 
     // Assert that the expected files exist in the tools directory.
+
+    // Check that non-binary files were copied.
+    assert!(tempdir.path().join("Dockerfile").is_file());
     assert!(tempdir.path().join("Makefile.toml").is_file());
+    assert!(tempdir.path().join("docker-go").is_file());
+    assert!(tempdir.path().join("partyplanner").is_file());
+    assert!(tempdir.path().join("rpm2img").is_file());
+    assert!(tempdir.path().join("rpm2kmodkit").is_file());
+    assert!(tempdir.path().join("rpm2migrations").is_file());
+
+    // Check that binaries were copied.
+    assert!(tempdir.path().join("bottlerocket-variant").is_file());
+    assert!(tempdir.path().join("buildsys").is_file());
+    assert!(tempdir.path().join("pubsys").is_file());
+    assert!(tempdir.path().join("pubsys-setup").is_file());
+    assert!(tempdir.path().join("testsys").is_file());
+    assert!(tempdir.path().join("tuftool").is_file());
 }


### PR DESCRIPTION
*Issue #, if available:*

Closes #14 
Closes #9 
Closes #32
Partly Addresses #43 (We install it here, but should probably still eliminate it in favor of a lib)

*Description of changes:*

Embed tools such as `buildsys`, and scripts such as `rpm2img` into the Twoliter binary. Use them when building Bottlerocket

*Testing*

- [x] Build Bottlerocket on an x86_64 host
- [x] Build Bottlerocket on an Arm host

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
