### PR TITLE
testsys: change clustersharedSg to clusterSg in templated var

### DIFF
--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -307,7 +307,7 @@ pub(crate) async fn ec2_karpenter_crd<'a>(
         .region_template(cluster_name, "region")
         .subnet_ids_template(cluster_name, "publicSubnetIds")
         .endpoint_template(cluster_name, "endpoint")
-        .cluster_sg_template(cluster_name, "clustersharedSg")
+        .cluster_sg_template(cluster_name, "clusterSg")
         .device_mappings(device_mappings)
         .assume_role(bottlerocket_input.crd_input.config.agent_role.clone())
         .depends_on(cluster_name)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In the EC2 karpenter instance resource config, instead of using the cluster shared SG, which is now obsolete, use cluster SG.

*Testing:*
```

[cargo-make] INFO - Execute Command: "/home/fedora/bottlerocket/tools/twoliter/twoliter" "--log-level=info" "make" "test" "--project-path=/home/fedora/bottlerocket/Twoliter.toml" "--cargo-home=/home/fedora/bottlerocket/.cargo" "--"
[cargo-make][1] INFO - Build File: /tmp/.tmpSRwG0d/Makefile.toml
[cargo-make][1] INFO - Task: test
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: test
[2023-09-19T20:33:58Z INFO  testsys::run] Successfully added 'bottlerocket'
[2023-09-19T20:33:58Z INFO  testsys::run] Successfully added 'bottlerocket-karpenter-vugp'
[2023-09-19T20:33:58Z INFO  testsys::run] Successfully added 'bottlerocket-karpenter'
[cargo-make][1] INFO - Build Done in 1.67 seconds.
[cargo-make] INFO - Build Done in 905.67 seconds.

...
$ cli  --kubeconfig testsys.kubeconfig status 
 NAME                    TYPE      STATE       PASSED   FAILED   SKIPPED 
 bottlerocket-karpente   Test      passed           5        0      7206 
 bottlerocket            Resourc   completed 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
