### PR TITLE
add sdk to project schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082a24a9967533dc5d743c602157637116fc1b52806d694a5a45e6f32567fcdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1905,16 @@ name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "non-empty-string"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb438f1eb418cb32cdf63f67ce050d821354faaea45a0869f707a9eeaccaea7a"
+dependencies = [
+ "delegate",
+ "serde",
+]
 
 [[package]]
 name = "nonzero_ext"
@@ -3526,6 +3547,7 @@ dependencies = [
  "flate2",
  "hex",
  "log",
+ "non-empty-string",
  "pubsys",
  "pubsys-setup",
  "serde",

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -7,6 +7,7 @@ the repository's top-level Dockerfile.
 pub(crate) mod error;
 use error::Result;
 
+use crate::constants::{SDK_VAR, TOOLCHAIN_VAR};
 use duct::cmd;
 use lazy_static::lazy_static;
 use nonzero_ext::nonzero;
@@ -283,8 +284,8 @@ fn build(
     let tag = format!("{}-{}", tag, token);
 
     // Our SDK and toolchain are picked by the external `cargo make` invocation.
-    let sdk = getenv("BUILDSYS_SDK_IMAGE")?;
-    let toolchain = getenv("BUILDSYS_TOOLCHAIN")?;
+    let sdk = getenv(SDK_VAR)?;
+    let toolchain = getenv(TOOLCHAIN_VAR)?;
 
     // Avoid using a cached layer from a previous build.
     let nocache = rand::thread_rng().gen::<u32>();

--- a/tools/buildsys/src/constants.rs
+++ b/tools/buildsys/src/constants.rs
@@ -1,0 +1,2 @@
+pub(crate) const SDK_VAR: &str = "TLPRIVATE_SDK_IMAGE";
+pub(crate) const TOOLCHAIN_VAR: &str = "TLPRIVATE_TOOLCHAIN";

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -18,6 +18,7 @@ when the docker-go script is invoked.
 pub(crate) mod error;
 use error::Result;
 
+use crate::constants::SDK_VAR;
 use buildsys::manifest;
 use duct::cmd;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -111,9 +112,7 @@ impl GoMod {
         );
 
         // Our SDK and toolchain are picked by the external `cargo make` invocation.
-        let sdk = env::var("BUILDSYS_SDK_IMAGE").context(error::EnvironmentSnafu {
-            var: "BUILDSYS_SDK_IMAGE",
-        })?;
+        let sdk = env::var(SDK_VAR).context(error::EnvironmentSnafu { var: SDK_VAR })?;
 
         let args = DockerGoArgs {
             module_path: package_dir,

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -10,6 +10,7 @@ The implementation is closely tied to the top-level Dockerfile.
 */
 mod builder;
 mod cache;
+mod constants;
 mod gomod;
 mod project;
 mod spec;

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = "0.10"
 flate2 = "1"
 hex = "0.4"
 log = "0.4"
+non-empty-string = { version = "0.2", features = [ "serde" ] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 tar = "0.4"

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -31,12 +31,6 @@ BUILDSYS_NAME = "bottlerocket"
 # If you're building a Bottlerocket remix, you'd want to set this to something like
 # "Bottlerocket Remix by ${CORP}" or "${CORP}'s Bottlerocket Remix"
 BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
-# SDK name used for building
-BUILDSYS_SDK_NAME="bottlerocket"
-# SDK version used for building
-BUILDSYS_SDK_VERSION="v0.33.0"
-# Site for fetching the SDK
-BUILDSYS_REGISTRY="public.ecr.aws/bottlerocket"
 
 # These can be overridden with -e to change configuration for pubsys (`cargo
 # make repo`).  In addition, you can set RELEASE_START_TIME to determine when
@@ -142,11 +136,6 @@ TESTSYS_LOG_LEVEL = "info"
 # Certain variables are defined here to allow us to override a component value
 # on the command line.
 
-# Depends on ${BUILDSYS_ARCH}, ${BUILDSYS_REGISTRY}, ${BUILDSYS_SDK_NAME}, and
-# ${BUILDSYS_SDK_VERSION}.
-BUILDSYS_SDK_IMAGE = { script = [ "echo ${BUILDSYS_REGISTRY}/${BUILDSYS_SDK_NAME}-sdk-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
-BUILDSYS_TOOLCHAIN = { script = [ "echo ${BUILDSYS_REGISTRY}/${BUILDSYS_SDK_NAME}-toolchain-${BUILDSYS_ARCH}:${BUILDSYS_SDK_VERSION}" ] }
-
 # Depends on ${BUILDSYS_JOBS}.
 CARGO_MAKE_CARGO_LIMIT_JOBS = "--jobs ${BUILDSYS_JOBS}"
 CARGO_MAKE_CARGO_ARGS = "--offline --locked"
@@ -238,7 +227,17 @@ fi
 '''
 ] }
 
+# These are variables that are not meant to be set by users of `twoliter make`. These are intended
+# to be set only by Twoliter itself when it invokes `cargo make`.
+[env.private]
+# The URIs for the SDK image and the toolchain image must be provided.
+TLPRIVATE_SDK_IMAGE = ""
+TLPRIVATE_TOOLCHAIN = ""
+
+####################################################################################################
+
 [tasks.setup]
+script_runner = "bash"
 script = [
 '''
 # Ensure we use a supported architecture
@@ -253,6 +252,13 @@ esac
 # Ensure the tools directory has been set
 if [ -z "${TWOLITER_TOOLS_DIR}" ];then
    echo "TWOLITER_TOOLS_DIR must be defined and must be non-zero in length."
+   exit 1
+fi
+
+# Ensure TLPRIVATE_SDK_IMAGE and TLPRIVATE_TOOLCHAIN are set
+if [[ -z "${TLPRIVATE_SDK_IMAGE}" || -z "{TLPRIVATE_TOOLCHAIN}" ]];then
+   echo "TLPRIVATE_SDK_IMAGE and TLPRIVATE_TOOLCHAIN must be defined and must be non-zero in length."
+   echo "Are you using Twoliter? It is a bug if Twoliter has invoked cargo make without these."
    exit 1
 fi
 
@@ -290,9 +296,9 @@ dependencies = ["setup-build"]
 script_runner = "bash"
 script = [
 '''
-if ! docker image inspect "${BUILDSYS_SDK_IMAGE}" >/dev/null 2>&1 ; then
-  if ! docker pull "${BUILDSYS_SDK_IMAGE}" ; then
-    echo "failed to pull '${BUILDSYS_SDK_IMAGE}'" >&2
+if ! docker image inspect "${TLPRIVATE_SDK_IMAGE}" >/dev/null 2>&1 ; then
+  if ! docker pull "${TLPRIVATE_SDK_IMAGE}" ; then
+    echo "failed to pull '${TLPRIVATE_SDK_IMAGE}'" >&2
     exit 1
   fi
 fi
@@ -304,7 +310,7 @@ dependencies = ["setup-build"]
 script_runner = "bash"
 script = [
 '''
-if docker image inspect "${BUILDSYS_TOOLCHAIN}-${BUILDSYS_ARCH}" >/dev/null 2>&1 ; then
+if docker image inspect "${TLPRIVATE_TOOLCHAIN}-${BUILDSYS_ARCH}" >/dev/null 2>&1 ; then
   exit 0
 fi
 
@@ -315,14 +321,14 @@ esac
 
 # We want the image with the target's native toolchain, rather than one that matches the
 # host architecture.
-if ! docker pull --platform "${docker_arch}" "${BUILDSYS_TOOLCHAIN}" ; then
-  echo "could not pull '${BUILDSYS_TOOLCHAIN}' for ${docker_arch}" >&2
+if ! docker pull --platform "${docker_arch}" "${TLPRIVATE_TOOLCHAIN}" ; then
+  echo "could not pull '${TLPRIVATE_TOOLCHAIN}' for ${docker_arch}" >&2
   exit 1
 fi
 
 # Apply a tag to distinguish the image from other architectures.
-if ! docker tag "${BUILDSYS_TOOLCHAIN}" "${BUILDSYS_TOOLCHAIN}-${BUILDSYS_ARCH}" ; then
-  echo "could not tag '${BUILDSYS_TOOLCHAIN}-${BUILDSYS_ARCH}'" >&2
+if ! docker tag "${TLPRIVATE_TOOLCHAIN}" "${TLPRIVATE_TOOLCHAIN}-${BUILDSYS_ARCH}" ; then
+  echo "could not tag '${TLPRIVATE_TOOLCHAIN}-${BUILDSYS_ARCH}'" >&2
   exit 1
 fi
 '''
@@ -350,7 +356,7 @@ go_fetch() {
   module="${1:?}"
   ${TWOLITER_TOOLS_DIR}/docker-go \
     --module-path "${BUILDSYS_SOURCES_DIR}/${module}" \
-    --sdk-image ${BUILDSYS_SDK_IMAGE} \
+    --sdk-image ${TLPRIVATE_SDK_IMAGE} \
     --go-mod-cache ${GO_MOD_CACHE} \
     --command "go list -mod=readonly ./... >/dev/null && go mod vendor"
 }
@@ -379,7 +385,7 @@ test_go_module() {
   module="${1:?}"
   ${TWOLITER_TOOLS_DIR}/docker-go \
     --module-path "${BUILDSYS_SOURCES_DIR}/${module}" \
-    --sdk-image ${BUILDSYS_SDK_IMAGE} \
+    --sdk-image ${TLPRIVATE_SDK_IMAGE} \
     --go-mod-cache ${GO_MOD_CACHE} \
     --command "cd cmd/$module; go test -v"
 }
@@ -410,7 +416,7 @@ go_fmt() {
   module="${1:?}"
   ${TWOLITER_TOOLS_DIR}/docker-go \
     --module-path "${BUILDSYS_SOURCES_DIR}/${module}" \
-    --sdk-image ${BUILDSYS_SDK_IMAGE} \
+    --sdk-image ${TLPRIVATE_SDK_IMAGE} \
     --go-mod-cache ${GO_MOD_CACHE} \
     --command "gofmt -l cmd/$module"
 }
@@ -429,7 +435,7 @@ if ! docker run --rm \
    -e CARGO_HOME="/tmp/.cargo" \
    -v "${CARGO_HOME}":/tmp/.cargo \
    -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
-   "${BUILDSYS_SDK_IMAGE}" \
+   "${TLPRIVATE_SDK_IMAGE}" \
    cargo fmt \
   --manifest-path /tmp/sources/Cargo.toml \
   --message-format short \
@@ -466,7 +472,7 @@ if ! docker run --rm \
    -v "${CARGO_HOME}":/tmp/.cargo \
    -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
    -e VARIANT \
-   "${BUILDSYS_SDK_IMAGE}" \
+   "${TLPRIVATE_SDK_IMAGE}" \
    cargo clippy \
   --manifest-path /tmp/sources/Cargo.toml \
   --locked -- -D warnings --no-deps; then
@@ -491,7 +497,7 @@ if ! docker run --rm \
   --user "$(id -u):$(id -g)" \
   --security-opt="label=disable" \
   -v "${BUILDSYS_TOOLS_DIR}":/tmp/tools \
-  "${BUILDSYS_SDK_IMAGE}" \
+  "${TLPRIVATE_SDK_IMAGE}" \
   bash -c \
     'flagged_scripts=0 && \
     cd /tmp/tools && \
@@ -657,7 +663,7 @@ echo "Generating local keys." >&2
 
 mkdir -p "${BUILDSYS_SBKEYS_PROFILE_DIR}"
 ${BUILDSYS_SBKEYS_DIR}/generate-local-sbkeys \
-  --sdk-image "${BUILDSYS_SDK_IMAGE}" \
+  --sdk-image "${TLPRIVATE_SDK_IMAGE}" \
   --output-dir "${BUILDSYS_SBKEYS_PROFILE_DIR}"
 '''
 ]
@@ -714,7 +720,7 @@ docker run --rm \
    --security-opt="label=disable" \
    -v "${BOOT_CONFIG_INPUT}":/tmp/bootconfig-input \
    -v "${boot_config}":/tmp/bootconfig.data \
-   "${BUILDSYS_SDK_IMAGE}" \
+   "${TLPRIVATE_SDK_IMAGE}" \
    bootconfig -a /tmp/bootconfig-input /tmp/bootconfig.data
 
 if [ -e "${boot_config_tmp}" ] ; then
@@ -734,7 +740,7 @@ docker run --rm \
    --user "$(id -u):$(id -g)" \
    --security-opt="label=disable" \
    -v "${BOOT_CONFIG}":/tmp/bootconfig.data \
-   "${BUILDSYS_SDK_IMAGE}" \
+   "${TLPRIVATE_SDK_IMAGE}" \
    bootconfig -l /tmp/bootconfig.data
 '''
 ]
@@ -816,7 +822,7 @@ docker run --rm \
   -e CARGO_HOME="/tmp/.cargo" \
   -v "${CARGO_HOME}":/tmp/.cargo \
   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
-  "${BUILDSYS_SDK_IMAGE}" \
+  "${TLPRIVATE_SDK_IMAGE}" \
   bash -c "${run_cargo_deny}"
 [ "${?}" -eq 0 ] || [ "${BUILDSYS_ALLOW_FAILED_LICENSE_CHECK}" = "true" ]
 '''
@@ -854,7 +860,7 @@ docker run --rm \
   -v "${CARGO_HOME}":/tmp/.cargo \
   -v "${BUILDSYS_ROOT_DIR}/licenses:/tmp/licenses" \
   -v "${BUILDSYS_ROOT_DIR}/Licenses.toml:/tmp/Licenses.toml" \
-  "${BUILDSYS_SDK_IMAGE}" \
+  "${TLPRIVATE_SDK_IMAGE}" \
   bash -c "${run_fetch_licenses}"
 '''
 ]

--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -1,5 +1,5 @@
-use crate::docker;
-use crate::project::{Project, Sdk};
+use crate::project::Project;
+use crate::{docker, project};
 use anyhow::Result;
 use clap::Parser;
 use log::debug;
@@ -44,7 +44,7 @@ impl BuildVariant {
             Some(p) => Project::load(p).await?,
         };
         // TODO - get smart about sdk: https://github.com/bottlerocket-os/twoliter/issues/11
-        let sdk = Sdk::default();
+        let sdk = project::default_sdk();
         let _ = docker::create_twoliter_image_if_not_exists(&sdk.uri(&self.arch)).await?;
         Ok(())
     }

--- a/twoliter/src/docker/image.rs
+++ b/twoliter/src/docker/image.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 /// Represents a docker image URI such as `public.ecr.aws/myregistry/myrepo:v0.1.0`. The registry is
 /// optional as it is when using `docker`. That is, it will be looked for locally first, then at
 /// `dockerhub.io` when the registry is absent.
@@ -71,15 +73,15 @@ impl ImageArchUri {
     /// Create a new `ImageArchUri`.
     pub(crate) fn new<S1, S2, S3>(registry: Option<String>, name: S1, arch: S2, tag: S3) -> Self
     where
-        S1: Into<String>,
-        S2: Into<String>,
-        S3: Into<String>,
+        S1: AsRef<str>,
+        S2: AsRef<str>,
+        S3: AsRef<str>,
     {
         Self {
             registry,
-            name: name.into(),
-            arch: arch.into(),
-            tag: tag.into(),
+            name: name.as_ref().into(),
+            arch: arch.as_ref().into(),
+            tag: tag.as_ref().into(),
         }
     }
 
@@ -90,6 +92,12 @@ impl ImageArchUri {
             None => format!("{}-{}:{}", self.name, self.arch, self.tag),
             Some(registry) => format!("{}/{}-{}:{}", registry, self.name, self.arch, self.tag),
         }
+    }
+}
+
+impl Display for ImageArchUri {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.uri(), f)
     }
 }
 

--- a/twoliter/src/docker/mod.rs
+++ b/twoliter/src/docker/mod.rs
@@ -5,8 +5,3 @@ mod twoliter;
 pub(crate) use self::commands::DockerBuild;
 pub(crate) use self::image::{ImageArchUri, ImageUri};
 pub(crate) use self::twoliter::create_twoliter_image_if_not_exists;
-
-pub(super) const DEFAULT_REGISTRY: &str = "public.ecr.aws/bottlerocket";
-pub(super) const DEFAULT_SDK_NAME: &str = "bottlerocket-sdk";
-// TODO - get this from lock file: https://github.com/bottlerocket-os/twoliter/issues/11
-pub(super) const DEFAULT_SDK_VERSION: &str = "v0.33.0";

--- a/twoliter/src/test/data/Twoliter-1.toml
+++ b/twoliter/src/test/data/Twoliter-1.toml
@@ -3,6 +3,11 @@ project-name = "sample-project"
 project-version = "v1.0.0"
 
 [sdk]
-registry = "example.com/my-repos"
+registry = "a.com/b"
 name = "my-bottlerocket-sdk"
-version = "1.2.3"
+version = "v1.2.3"
+
+[toolchain]
+registry = "c.co/d"
+name = "toolchainz"
+version = "v3.4.5"

--- a/twoliter/src/test/data/Twoliter-invalid-version.toml
+++ b/twoliter/src/test/data/Twoliter-invalid-version.toml
@@ -5,4 +5,9 @@ project-version = "v1.0.0"
 [sdk]
 registry = "example.com/my-repos"
 name = "my-bottlerocket-sdk"
-version = "1.2.3"
+version = "v1.2.3"
+
+[toolchain]
+registry = "example.com/my-repos"
+name = "my-bottlerocket-toolchain"
+version = "v1.2.3"


### PR DESCRIPTION
*Issue #, if available:*

Closes #83

*Description of changes:*

```
Add the ability to specify the desired Bottlerocket SDK in
Twoliter.toml.
```

```
Require the SDK to be specified in Twoliter.toml when using twoliter
make.
```

*Testing*

I used this version of Twoliter without changing anything in Bottlerocket and got the expected error:

```
Error: The environment variable 'BUILDSYS_SDK_NAME' can no longer be used. Specify the SDK in Twoliter.toml
[cargo-make] ERROR - Error while executing command, exit code: 1
```

I then removed these vars from Bottlerocket's Makefile.toml and got the expected error:

```
Error: When using twoliter make, it is required that the SDK be specified in Twoliter.toml
```

I added the SDK to Bottlerocket's Twoliter.toml and the build succeeded and the correct SDK was used:

```
v0.34.1: Pulling from bottlerocket/bottlerocket-sdk-x86_64
```	

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
