### PR TITLE
add cargo deny to makefile check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,4 +22,5 @@ jobs:
       labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
+      - run: cargo install cargo-deny
       - run: make build

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 	cargo test --release --locked
 
 .PHONY: check
-check: fmt clippy test
+check: fmt clippy deny test
 
 .PHONY: build
 build: check

--- a/deny.toml
+++ b/deny.toml
@@ -69,22 +69,33 @@ skip = [
     { name = "base64" },
     # several dependencies are using an old version of bitflags
     { name = "bitflags", version = "=1.3" },
+    # tuftool is using an older version of clap
+    { name = "clap", version = "3" },
+    { name = "clap_derive", version = "3" },
+    { name = "clap_lex", version = "0.2" },
     # several dependencies are using an old version of serde_yaml
     { name = "serde_yaml", version = "=0.8" },
     # aws-sdk-rust is using an old version of fastrand
     { name = "fastrand", version = "=1.9" },
+    # multiple deps are using an older version of hashbrown
+    { name = "hashbrown", version = "=0.12" },
     # tuftool is using an old clap (v3) which is using old hermit-abi
     { name = "hermit-abi", version = "0.1" },
+    # multiple deps are using an older version of indexmap
+    { name = "indexmap", version = "1" },
+    # kube-client uses an old version of redox_syscall
+    { name = "redox_syscall", version = "=0.2" },
+    # hyper and tokio are using different versions of socket2
+    { name = "socket2", version = "0.4" },
+    # multiple deps are using an older version of syn
+    { name = "syn", version = "1" },
+    # Testsys is using a feature of TOML 0.5 that has been removed in subsequent versions.
+    { name = "toml", version = "0.5" },
+
     # aws-sdk-rust is using an old version of rustls, hyper-rustls, and tokio-rustls
     { name = "rustls", version = "=0.20" },
     { name = "hyper-rustls", version = "=0.23" },
     { name = "tokio-rustls", version = "=0.23" },
-    # hyper and tokio are using different versions of socket2
-    { name = "socket2", version = "0.4" },
-    # Testsys is using a feature of TOML 0.5 that has been removed in subsequent versions.
-    { name = "toml", version = "0.5" },
-    # kube-client uses an old version of redox_syscall
-    { name = "redox_syscall", version = "=0.2" },
 ]
 
 skip-tree = [
@@ -93,8 +104,6 @@ skip-tree = [
     # dependency tree because windows-sys has many sub-crates
     # that differ in major version.
     { name = "windows-sys" },
-    # tuftool uses an old version of clap and other dependencies
-    { name = "generate-readme", version = "0.1.0" }
 ]
 
 [sources]


### PR DESCRIPTION
Forgot cargo deny in the makefile check target. Fixed here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
