### PR TITLE
makefile: fix bug with testsys loglevel arg

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1573,7 +1573,7 @@ script = [
     '''
     set -eu
     export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-    testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} install
+    testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} install
     '''
 ]
 
@@ -1591,7 +1591,7 @@ script = [
     export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
     # The ami that is selected from `amis.json` is determined by `TESTSYS_REGION` if set; otherwise,
     # it is the first region listed in `Infra.toml` (for aws variants).
-    testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} run ${TESTSYS_TEST} \
+    testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} run ${TESTSYS_TEST} \
       ${testsys_ami_input} \
       ${TESTSYS_AWS_SECRET_NAME:+--secret ${TESTSYS_AWS_SECRET_NAME}} \
       ${@}
@@ -1607,7 +1607,7 @@ script = [
     '''
     set -eu
     export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-    testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} delete --test ${@}
+    testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} delete --test ${@}
     '''
 ]
 
@@ -1617,7 +1617,7 @@ script = [
     '''
     set -eu
     export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-    testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} delete ${@}
+    testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} delete ${@}
     '''
 ]
 
@@ -1627,7 +1627,7 @@ script = [
    '''
    set -eu
    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-   testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} uninstall
+   testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} uninstall
    '''
 ]
 
@@ -1644,7 +1644,7 @@ script = [
    '''
    set -eu
    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-   watch -- testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} status --test ${@}
+   watch -- testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} status --test ${@}
    '''
 ]
 
@@ -1656,7 +1656,7 @@ script = [
    '''
    set -eu
    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-   watch -- testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} status ${@}
+   watch -- testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} status ${@}
    '''
 ]
 
@@ -1667,7 +1667,7 @@ script = [
    '''
    set -eu
    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-   testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} logs --test ${@}
+   testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} logs --test ${@}
    '''
 ]
 
@@ -1677,7 +1677,7 @@ script = [
    '''
    set -eu
    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-   testsys ${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} ${@}
+   testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} ${@}
    '''
 ]
 


### PR DESCRIPTION

*Issue #, if available:*

Fixes #75 

*Description of changes:*

The --log-level argument was being passed incorrectly to testsys. This fixes it.

*Testing:*

In Bottlerocket:

```
cargo make -e TWOLITER_VERSION=97937a81fcce104faaa2b7464936de8261bcd0a4 \
  -e TWOLITER_REPO=https://github.com/webern/twoliter \
  -e TWOLITER_SKIP_VERSION_CHECK=true \
  -e TWOLITER_ALLOW_BINARY_INSTALL=false \
  -e TWOLITER_LOG_LEVEL=trace \
  test --help
```

This was broken before but worked with these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
