### PR TITLE
testsys: update toml to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
  "serde_plain",
  "sha2",
  "snafu",
- "toml 0.8.2",
+ "toml",
  "url",
  "walkdir",
 ]
@@ -2256,7 +2256,7 @@ dependencies = [
  "tinytemplate",
  "tokio",
  "tokio-stream",
- "toml 0.8.2",
+ "toml",
  "tough",
  "tough-kms",
  "tough-ssm",
@@ -2276,7 +2276,7 @@ dependencies = [
  "serde",
  "serde_yaml 0.9.25",
  "snafu",
- "toml 0.8.2",
+ "toml",
  "url",
 ]
 
@@ -3080,7 +3080,7 @@ dependencies = [
  "serde_yaml 0.9.25",
  "snafu",
  "testsys-model",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -3291,15 +3291,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3566,7 +3557,7 @@ dependencies = [
  "tempfile",
  "testsys",
  "tokio",
- "toml 0.8.2",
+ "toml",
  "tuftool",
  "uuid",
 ]
@@ -3640,7 +3631,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "snafu",
- "toml 0.8.2",
+ "toml",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -89,8 +89,6 @@ skip = [
     { name = "socket2", version = "0.4" },
     # multiple deps are using an older version of syn
     { name = "syn", version = "1" },
-    # Testsys is using a feature of TOML 0.5 that has been removed in subsequent versions.
-    { name = "toml", version = "0.5" },
 
     # aws-sdk-rust is using an old version of rustls, hyper-rustls, and tokio-rustls
     { name = "rustls", version = "=0.20" },

--- a/tools/testsys-config/Cargo.toml
+++ b/tools/testsys-config/Cargo.toml
@@ -17,4 +17,4 @@ serde = { version = "1", features = ["derive"] }
 serde_plain = "1"
 serde_yaml = "0.9"
 snafu = "0.7"
-toml = "0.5"
+toml = "0.8"

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -21,7 +21,7 @@ pub struct TestConfig {
     /// High level configuration for TestSys
     pub test: Option<Test>,
 
-    #[serde(flatten, serialize_with = "toml::ser::tables_last")]
+    #[serde(flatten)]
     /// Configuration for testing variants
     pub configs: HashMap<String, GenericConfig>,
 }


### PR DESCRIPTION

*Issue #, if available:*

Closes #51

*Description of changes:*

According to https://github.com/toml-rs/toml/issues/613, the tables_last function is no longer needed. This allows us to update testsys to use toml 0.8

*Testing*

Unit tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
