### PR TITLE
allow cmd exec quiet

### DIFF
--- a/twoliter/src/cmd/make.rs
+++ b/twoliter/src/cmd/make.rs
@@ -1,4 +1,4 @@
-use crate::common::exec;
+use crate::common::exec_log;
 use crate::docker::ImageArchUri;
 use crate::project;
 use crate::project::Project;
@@ -87,7 +87,7 @@ impl Make {
             args.push(cargo_make_arg.clone());
         }
 
-        exec(Command::new("cargo").args(args)).await
+        exec_log(Command::new("cargo").args(args)).await
     }
 }
 

--- a/twoliter/src/common.rs
+++ b/twoliter/src/common.rs
@@ -3,38 +3,45 @@ use log::{self, debug, LevelFilter};
 use tokio::process::Command;
 
 /// Run a `tokio::process::Command` and return a `Result` letting us know whether or not it worked.
-pub(crate) async fn exec(cmd: &mut Command) -> Result<()> {
+/// Pipes stdout/stderr when logging `LevelFilter` is more verbose than `Warn`.
+pub(crate) async fn exec_log(cmd: &mut Command) -> Result<()> {
+    let quiet = matches!(
+        log::max_level(),
+        LevelFilter::Off | LevelFilter::Error | LevelFilter::Warn
+    );
+    exec(cmd, quiet).await
+}
+
+/// Run a `tokio::process::Command` and return a `Result` letting us know whether or not it worked.
+/// `quiet` determines whether or not the command output will be piped to `stdout/stderr`. When
+/// `quiet=true`, no output will be shown.
+pub(crate) async fn exec(cmd: &mut Command, quiet: bool) -> Result<()> {
     debug!("Running: {:?}", cmd);
-
-    match log::max_level() {
+    if quiet {
         // For quiet levels of logging we capture stdout and stderr
-        LevelFilter::Off | LevelFilter::Error | LevelFilter::Warn => {
-            let output = cmd
-                .output()
-                .await
-                .context(format!("Unable to start command"))?;
-            ensure!(
-                output.status.success(),
-                "Command was unsuccessful, exit code {}:\n{}\n{}",
-                output.status.code().unwrap_or(1),
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-
+        let output = cmd
+            .output()
+            .await
+            .context(format!("Unable to start command"))?;
+        ensure!(
+            output.status.success(),
+            "Command was unsuccessful, exit code {}:\n{}\n{}",
+            output.status.code().unwrap_or(1),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    } else {
         // For less quiet log levels we stream to stdout and stderr.
-        LevelFilter::Info | LevelFilter::Debug | LevelFilter::Trace => {
-            let status = cmd
-                .status()
-                .await
-                .context(format!("Unable to start command"))?;
+        let status = cmd
+            .status()
+            .await
+            .context(format!("Unable to start command"))?;
 
-            ensure!(
-                status.success(),
-                "Command was unsuccessful, exit code {}",
-                status.code().unwrap_or(1),
-            );
-        }
+        ensure!(
+            status.success(),
+            "Command was unsuccessful, exit code {}",
+            status.code().unwrap_or(1),
+        );
     }
     Ok(())
 }

--- a/twoliter/src/docker/commands.rs
+++ b/twoliter/src/docker/commands.rs
@@ -1,4 +1,4 @@
-use crate::common::exec;
+use crate::common::exec_log;
 use crate::docker::ImageUri;
 use anyhow::Result;
 use std::collections::HashMap;
@@ -84,7 +84,7 @@ impl DockerBuild {
                 .map(|(k, v)| format!("--build-arg={}={}", k, v)),
         );
         args.push(self.context_dir.display().to_string());
-        exec(
+        exec_log(
             Command::new("docker")
                 .args(args)
                 .env("DOCKER_BUILDKIT", "1"),


### PR DESCRIPTION


*Issue #, if available:*

N/A

*Description of changes:*

Make it possible in Twoliter to exec an external command quietly. Previously this looked at the log level filter to determine whether or not to send the command output to stdout/stderr. Now there is a form of the exec command that allows you to specify whether or not to send the output to stdout/stderr.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
