### PR TITLE
switch to fixed directory for twoliter tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3913,6 +3913,7 @@ dependencies = [
  "bytes",
  "clap",
  "env_logger",
+ "filetime",
  "flate2",
  "hex",
  "log",

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1"
 async-recursion = "1"
 clap = { version = "4", features = ["derive", "env", "std"] }
 env_logger = "0.10"
+filetime = "0.2"
 flate2 = "1"
 hex = "0.4"
 log = "0.4"

--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -20,6 +20,7 @@ fn main() {
     let paths = Paths::new();
     println!("cargo:rerun-if-changed={}", paths.data_input_dir.display());
 
+    let _ = fs::remove_dir_all(&paths.prep_dir);
     fs::create_dir_all(&paths.prep_dir).expect(&format!(
         "Unable to create directory '{}'",
         paths.prep_dir.display()

--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -26,6 +26,7 @@ fn main() {
     ));
 
     paths.copy_file("Dockerfile");
+    paths.copy_file("Dockerfile.dockerignore");
     paths.copy_file("Makefile.toml");
     paths.copy_file("docker-go");
     paths.copy_file("partyplanner");

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -125,7 +125,7 @@ RUN --mount=target=/host \
         --repofrompath repo,./rpmbuild/RPMS \
         --enablerepo 'repo' \
         --nogpgcheck \
-	--forcearch "${ARCH}" \
+        --forcearch "${ARCH}" \
         builddep rpmbuild/SPECS/${PACKAGE}.spec
 
 # We use the "nocache" writable space to generate code where necessary, like the variant-
@@ -176,7 +176,7 @@ RUN --mount=target=/host \
         --nogpgcheck \
         --downloadonly \
         --downloaddir . \
-	--forcearch "${ARCH}" \
+        --forcearch "${ARCH}" \
         install $(printf "bottlerocket-%s\n" ${PACKAGES}) \
     && mv *.rpm /local/rpms \
     && createrepo_c /local/rpms \

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -31,7 +31,7 @@ ARG TOKEN
 # We can't create directories via RUN in a scratch container, so take an existing one.
 COPY --chown=1000:1000 --from=sdk /tmp /cache
 # Ensure the ARG variables are used in the layer to prevent reuse by other builds.
-COPY --chown=1000:1000 .dockerignore /cache/.${PACKAGE}.${ARCH}.${TOKEN}
+COPY --chown=1000:1000 .gitignore /cache/.${PACKAGE}.${ARCH}.${TOKEN}
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Some builds need to modify files in the source directory, for example Rust software using
@@ -52,7 +52,7 @@ ARG TOKEN
 # We can't create directories via RUN in a scratch container, so take an existing one.
 COPY --chown=1000:1000 --from=sdk /tmp /variantcache
 # Ensure the ARG variables are used in the layer to prevent reuse by other builds.
-COPY --chown=1000:1000 .dockerignore /variantcache/.${PACKAGE}.${ARCH}.${VARIANT}.${TOKEN}
+COPY --chown=1000:1000 .gitignore /variantcache/.${PACKAGE}.${ARCH}.${VARIANT}.${TOKEN}
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Builds an RPM package from a spec file.

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -13,16 +13,6 @@ ARG ARCH
 ARG GOARCH
 
 FROM ${SDK} as sdk
-USER root
-RUN \
-     --mount=type=secret,id=tools-docker-go,mode=755,target=/tmp/tools/docker-go \
-     --mount=type=secret,id=tools-partyplanner,mode=755,target=/tmp/tools/partyplanner \
-     --mount=type=secret,id=tools-rpm2img,mode=755,target=/tmp/tools/rpm2img \
-     --mount=type=secret,id=tools-rpm2kmodkit,mode=755,target=/tmp/tools/rpm2kmodkit \
-     --mount=type=secret,id=tools-rpm2migrations,mode=755,target=/tmp/tools/rpm2migrations \
-     cp -a /tmp/tools/ /tools/
-USER builder
-
 FROM --platform=linux/${GOARCH} ${TOOLCHAIN}-${ARCH} as toolchain
 
 ############################################################################################
@@ -232,7 +222,7 @@ RUN --mount=target=/host \
     --mount=type=secret,id=aws-access-key-id.env,target=/root/.aws/aws-access-key-id.env \
     --mount=type=secret,id=aws-secret-access-key.env,target=/root/.aws/aws-secret-access-key.env \
     --mount=type=secret,id=aws-session-token.env,target=/root/.aws/aws-session-token.env \
-    /tools/rpm2img \
+    /host/build/tools/rpm2img \
       --package-dir=/local/rpms \
       --output-dir=/local/output \
       --output-fmt="${IMAGE_FORMAT}" \
@@ -265,7 +255,7 @@ RUN --mount=target=/host \
         -name "bottlerocket-migrations-*.rpm" \
         -not -iname '*debuginfo*' \
         -exec cp '{}' '/local/migrations/' ';' \
-    && /tools/rpm2migrations \
+    && /host/build/tools/rpm2migrations \
         --package-dir=/local/migrations \
         --output-dir=/local/output \
     && echo ${NOCACHE}
@@ -291,7 +281,7 @@ RUN --mount=target=/host \
     && find /host/build/rpms/ -maxdepth 1 -type f \
         -name "bottlerocket-${KERNEL}-archive-*.rpm" \
         -exec cp '{}' '/local/archives/' ';' \
-    && /tools/rpm2kmodkit \
+    && /host/build/tools/rpm2kmodkit \
         --archive-dir=/local/archives \
         --toolchain-dir=/local/toolchain \
         --output-dir=/local/output \

--- a/twoliter/embedded/Dockerfile.dockerignore
+++ b/twoliter/embedded/Dockerfile.dockerignore
@@ -1,0 +1,12 @@
+/.git
+/.gomodcache
+/build/*
+!/build/rpms/
+/build/rpms/*
+!/build/rpms/*.rpm
+/build/rpms/*-debuginfo-*.rpm
+/build/rpms/*-debugsource-*.rpm
+!/build/tools/*
+**/target/*
+/sbkeys
+/tests

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1495,6 +1495,7 @@ dependencies = [
   "clean-images",
   "clean-repos",
   "clean-state",
+  "clean-tools",
 ]
 
 [tasks.clean-sources]
@@ -1542,6 +1543,16 @@ script_runner = "bash"
 script = [
 '''
 rm -rf ${BUILDSYS_STATE_DIR}
+'''
+]
+
+[tasks.clean-tools]
+script_runner = "bash"
+script = [
+'''
+if [ -n "${TWOLITER_TOOLS_DIR}" ] ; then
+  rm -rf "${TWOLITER_TOOLS_DIR}"
+fi
 '''
 ]
 


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
I've been experimenting with a tool to forward file descriptors into a build, which requires the ability to run something larger than a shell script during the Docker execution. That hits the limitation of secrets which can't be larger than 500 KiB.

Switching to a fixed install location under `build/tools` avoids this limitation and makes the code a bit more intuitive. It's also relatively easy to see what `twoliter` has installed.

Because the tools need to be passed in the build context, I've also imported the current `.dockerignore` file from the core repo and renamed it to `Dockerfile.dockerignore`, so that [it will be used by the BuildKit backend](https://docs.docker.com/engine/reference/commandline/build/#use-a-dockerignore-file).

**Testing done:**
Built some variants successfully. I also confirmed through various hacks that the `.dockerignore` file was being respected. For example, excluding `/build/rpms/*.rpm` caused the expected build failure.

**Terms of contribution:**
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
