### PR TITLE
alpha: Create `.cargo/sbkeys` if it doesn't exist

### DIFF
--- a/local/alpha-sdk.sh
+++ b/local/alpha-sdk.sh
@@ -149,6 +149,7 @@ do
   # We need the sbkeys scripts in a location that is not .dockerignored but is .gitignored
   rm -rf "${bottlerocket_dir}/build/sbkeys"
   mkdir -p "${bottlerocket_dir}/build/sbkeys"
+  mkdir -p "${bottlerocket_dir}/.cargo/sbkeys"
   cp "${bottlerocket_dir}/sbkeys/generate-aws-sbkeys" "${bottlerocket_dir}/.cargo/sbkeys"
   cp "${bottlerocket_dir}/sbkeys/generate-local-sbkeys" "${bottlerocket_dir}/.cargo/sbkeys"
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #N/A

**Description of changes:**

Before this change running the alpha sdk script on a clean BR repo causes issues.

**Testing done:**

Tested on clean BR repo.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
