### PR TITLE
Go modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1f344136bad34df1f83a47f3fd7f2ab85d75cb8a940af4ccf6d482a84ea01b"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +188,22 @@ dependencies = [
  "quote",
  "syn 2.0.37",
 ]
+
+[[package]]
+name = "async-walkdir"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f6338023cbfc0555eccb8e83d3d4dcf1183b51ca9140a03b1dbb8a559193db"
+dependencies = [
+ "async-fs",
+ "futures-lite",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -968,6 +1025,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite",
+ "piper",
+ "tracing",
+]
+
+[[package]]
 name = "bottlerocket-types"
 version = "0.0.10"
 source = "git+https://github.com/bottlerocket-os/bottlerocket-test-system?tag=v0.0.10#9d672c05fb9521ad241ae8ccdd06931116435e05"
@@ -1164,6 +1237,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "configuration-derive"
@@ -1447,6 +1529,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1648,19 @@ name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-lite"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2318,6 +2434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2571,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3909,12 +4042,14 @@ version = "0.0.4"
 dependencies = [
  "anyhow",
  "async-recursion",
+ "async-walkdir",
  "buildsys",
  "bytes",
  "clap",
  "env_logger",
  "filetime",
  "flate2",
+ "futures",
  "hex",
  "log",
  "non-empty-string",

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -12,10 +12,12 @@ exclude = ["/design", "/target", "/dockerfiles", "/scripts"]
 [dependencies]
 anyhow = "1"
 async-recursion = "1"
+async-walkdir = "1"
 clap = { version = "4", features = ["derive", "env", "std"] }
 env_logger = "0.10"
 filetime = "0.2"
 flate2 = "1"
+futures= "0.3"
 hex = "0.4"
 log = "0.4"
 non-empty-string = { version = "0.2", features = [ "serde" ] }

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -96,8 +96,10 @@ BUILDSYS_JOBS = "8"
 CARGO_HOME = "${BUILDSYS_ROOT_DIR}/.cargo"
 # This needs to end with pkg/mod so that we can mount the parent of pkg/mod as GOPATH.
 GO_MOD_CACHE = "${BUILDSYS_ROOT_DIR}/.gomodcache/pkg/mod"
-# Dynamically load a list of go modules from ${BUILDSYS_SOURCE_DIR}
-GO_MODULES = { script = ['find ${BUILDSYS_SOURCES_DIR} -name go.mod -type f -printf "%h\n" | xargs -n1 basename'] }
+# The list of Go modules found in the sources directory. These must be passed, space delimited,
+# if you have Go sourcecode.
+GO_MODULES = ""
+
 DOCKER_BUILDKIT = "1"
 
 # This is the filename suffix for operations that write out AMI information to

--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -110,6 +110,7 @@ impl BuildVariant {
             .env("BUILDSYS_VARIANT", &self.variant)
             .env("BUILDSYS_SBKEYS_DIR", sbkeys_dir.display().to_string())
             .env("BUILDSYS_VERSION_IMAGE", project.release_version())
+            .env("GO_MODULES", project.find_go_modules().await?.join(" "))
             .makefile(makefile_path)
             .project_dir(project.project_dir())
             .exec("build")

--- a/twoliter/src/test/mod.rs
+++ b/twoliter/src/test/mod.rs
@@ -17,3 +17,9 @@ pub(crate) fn data_dir() -> PathBuf {
         .canonicalize()
         .unwrap()
 }
+
+pub(crate) fn projects_dir() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.join("tests").join("projects").canonicalize().unwrap()
+}


### PR DESCRIPTION

**Issue number:**

Closes: N/A

**Description of changes:**

    find go modules with rust code

    Some subtlety in the way GO_MODULES were being found was causing
    Bottlerocket builds to fail. Rather than find these with yet more bash
    code in Makefile.toml, we should find these using Rust code when the
    user is invoking twoliter build variant.

    Meanwhile, for twoliter make, we expect these to be passed in (which is
    what the Bottlerocket build does).

**Testing done:**

- built Bottlerocket
- built test project1 with alpha sdk and twoliter build variant

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
