### PR TITLE
twoliter make: take go modules from environment

### DIFF
--- a/twoliter/src/cargo_make.rs
+++ b/twoliter/src/cargo_make.rs
@@ -160,7 +160,7 @@ fn build_system_env_vars() -> Result<Vec<String>> {
 
 /// A list of environment variables that don't conform to naming conventions but need to be passed
 /// through to the `cargo make` invocation.
-const ENV_VARS: [&str; 12] = [
+const ENV_VARS: [&str; 13] = [
     "ALLOW_MISSING_KEY",
     "AMI_DATA_FILE_SUFFIX",
     "CARGO_MAKE_CARGO_ARGS",
@@ -168,6 +168,7 @@ const ENV_VARS: [&str; 12] = [
     "CARGO_MAKE_DEFAULT_TESTSYS_KUBECONFIG_PATH",
     "CARGO_MAKE_TESTSYS_ARGS",
     "CARGO_MAKE_TESTSYS_KUBECONFIG_ARG",
+    "GO_MODULES",
     "MARK_OVA_AS_TEMPLATE",
     "RELEASE_START_TIME",
     "SSM_DATA_FILE_SUFFIX",
@@ -214,6 +215,7 @@ fn test_is_build_system_env() {
     assert!(is_build_system_env("TESTSYS_!"));
     assert!(is_build_system_env("BOOT_CONFIG!"));
     assert!(is_build_system_env("BOOT_CONFIG_INPUT"));
+    assert!(is_build_system_env("GO_MODULES"));
     assert!(is_build_system_env("AWS_REGION"));
     assert!(!is_build_system_env("PATH"));
     assert!(!is_build_system_env("HOME"));


### PR DESCRIPTION

**Issue number:**

NA

**Description of changes:**

In #130 1410d5b we started requiring GO_MODULES to come from the environment when using twoliter make. This appeared to work because go mod vendor had been cached when testing. But in fact, we were not taking the environment variable at all! So this commit fixes it.

**Testing done:**

- [x] `cargo make clean` followed by `cargo build` in Bottlerocket

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
