### PR TITLE
buildsys: use clap for env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ name = "buildsys"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-variant",
+ "clap",
  "duct",
  "hex",
  "lazy_static",

--- a/tools/buildsys/Cargo.toml
+++ b/tools/buildsys/Cargo.toml
@@ -10,6 +10,7 @@ exclude = ["README.md"]
 
 [dependencies]
 bottlerocket-variant = { version = "0.1", path = "../bottlerocket-variant" }
+clap = { version = "4", features = ["derive", "env"] }
 duct = "0.13"
 hex = "0.4"
 lazy_static = "1"

--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -5,6 +5,7 @@ of its input arguments from environment variables.
 
 !*/
 
+use buildsys::manifest::SupportedArch;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use url::Url;
@@ -55,10 +56,10 @@ impl Command {
 #[derive(Debug, Parser)]
 pub(crate) struct Common {
     #[arg(long, env = "BUILDSYS_ARCH")]
-    pub(crate) arch: String,
+    pub(crate) arch: SupportedArch,
 
     #[arg(long, env = "BUILDSYS_OUTPUT_DIR")]
-    pub(crate) output_dir: PathBuf,
+    pub(crate) image_arch_variant_dir: PathBuf,
 
     #[arg(long, env = "BUILDSYS_ROOT_DIR")]
     pub(crate) root_dir: PathBuf,
@@ -80,6 +81,9 @@ pub(crate) struct Common {
 
     #[arg(long, env = "TLPRIVATE_TOOLCHAIN")]
     pub(crate) toolchain: String,
+
+    #[arg(long, env = "TWOLITER_TOOLS_DIR")]
+    pub(crate) tools_dir: PathBuf,
 }
 
 /// Build RPMs from a spec file and sources.
@@ -90,6 +94,21 @@ pub(crate) struct BuildPackageArgs {
 
     #[arg(long, env = "BUILDSYS_VARIANT")]
     pub(crate) variant: String,
+
+    #[arg(long, env = "BUILDSYS_VARIANT_PLATFORM")]
+    pub(crate) variant_platform: String,
+
+    #[arg(long, env = "BUILDSYS_VARIANT_RUNTIME")]
+    pub(crate) variant_runtime: String,
+
+    #[arg(long, env = "BUILDSYS_VARIANT_FAMILY")]
+    pub(crate) variant_family: String,
+
+    #[arg(long, env = "BUILDSYS_VARIANT_FLAVOR")]
+    pub(crate) variant_flavor: String,
+
+    #[arg(long, env = "PUBLISH_REPO")]
+    pub(crate) publish_repo: String,
 
     #[arg(long, env = "BUILDSYS_SOURCES_DIR")]
     pub(crate) sources_dir: PathBuf,

--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -1,0 +1,195 @@
+/*!
+
+These structs provide the CLI interface for buildsys which is called from Cargo.toml and accepts all
+of its input arguments from environment variables.
+
+!*/
+
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+use url::Url;
+
+/// A list of environment variables and the type of build that should be rerun if that environment
+/// variable changes. The build type is represented with bit flags so that we can easily list
+/// multiple build types for a single variable. See `[BuildType]` and `[rerun_for_envs]` below to
+/// see how this list is used.
+const REBUILD_VARS: [(&str, u8); 13] = [
+    ("BUILDSYS_ARCH", PACKAGE | VARIANT),
+    ("BUILDSYS_NAME", VARIANT),
+    ("BUILDSYS_OUTPUT_DIR", VARIANT),
+    ("BUILDSYS_PACKAGES_DIR", PACKAGE),
+    ("BUILDSYS_PRETTY_NAME", VARIANT),
+    ("BUILDSYS_ROOT_DIR", PACKAGE | VARIANT),
+    ("BUILDSYS_STATE_DIR", PACKAGE | VARIANT),
+    ("BUILDSYS_TIMESTAMP", VARIANT),
+    ("BUILDSYS_VARIANT", VARIANT),
+    ("BUILDSYS_VERSION_BUILD", VARIANT),
+    ("BUILDSYS_VERSION_IMAGE", VARIANT),
+    ("TLPRIVATE_SDK_IMAGE", PACKAGE | VARIANT),
+    ("TLPRIVATE_TOOLCHAIN", PACKAGE | VARIANT),
+];
+
+/// A tool for building Bottlerocket images and artifacts.
+#[derive(Debug, Parser)]
+pub(crate) struct Buildsys {
+    #[command(subcommand)]
+    pub(crate) command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum Command {
+    BuildPackage(Box<BuildPackageArgs>),
+    BuildVariant(Box<BuildVariantArgs>),
+}
+
+impl Command {
+    pub(crate) fn build_type(&self) -> BuildType {
+        match self {
+            Command::BuildPackage(_) => BuildType::Package,
+            Command::BuildVariant(_) => BuildType::Variant,
+        }
+    }
+}
+
+/// Arguments common to all subcommands.
+#[derive(Debug, Parser)]
+pub(crate) struct Common {
+    #[arg(long, env = "BUILDSYS_ARCH")]
+    pub(crate) arch: String,
+
+    #[arg(long, env = "BUILDSYS_OUTPUT_DIR")]
+    pub(crate) output_dir: PathBuf,
+
+    #[arg(long, env = "BUILDSYS_ROOT_DIR")]
+    pub(crate) root_dir: PathBuf,
+
+    #[arg(long, env = "BUILDSYS_STATE_DIR")]
+    pub(crate) state_dir: PathBuf,
+
+    #[arg(long, env = "BUILDSYS_TIMESTAMP")]
+    pub(crate) timestamp: String,
+
+    #[arg(long, env = "BUILDSYS_VERSION_FULL")]
+    pub(crate) version_full: String,
+
+    #[arg(long, env = "CARGO_MANIFEST_DIR")]
+    pub(crate) cargo_manifest_dir: PathBuf,
+
+    #[arg(long, env = "TLPRIVATE_SDK_IMAGE")]
+    pub(crate) sdk_image: String,
+
+    #[arg(long, env = "TLPRIVATE_TOOLCHAIN")]
+    pub(crate) toolchain: String,
+}
+
+/// Build RPMs from a spec file and sources.
+#[derive(Debug, Parser)]
+pub(crate) struct BuildPackageArgs {
+    #[arg(long, env = "BUILDSYS_PACKAGES_DIR")]
+    pub(crate) packages_dir: PathBuf,
+
+    #[arg(long, env = "BUILDSYS_VARIANT")]
+    pub(crate) variant: String,
+
+    #[arg(long, env = "BUILDSYS_SOURCES_DIR")]
+    pub(crate) sources_dir: PathBuf,
+
+    #[arg(long, env = "BUILDSYS_LOOKASIDE_CACHE")]
+    pub(crate) lookaside_cache: Url,
+
+    #[arg(long, env = "BUILDSYS_UPSTREAM_SOURCE_FALLBACK")]
+    pub(crate) upstream_source_fallback: String,
+
+    #[arg(long, env = "CARGO_PKG_NAME")]
+    pub(crate) cargo_package_name: String,
+
+    #[command(flatten)]
+    pub(crate) common: Common,
+}
+
+/// Build filesystem and disk images from RPMs.
+#[derive(Debug, Parser)]
+pub(crate) struct BuildVariantArgs {
+    #[arg(long, env = "BUILDSYS_NAME")]
+    pub(crate) name: String,
+
+    #[arg(long, env = "BUILDSYS_PRETTY_NAME")]
+    pub(crate) pretty_name: String,
+
+    #[arg(long, env = "BUILDSYS_VARIANT")]
+    pub(crate) variant: String,
+
+    #[arg(long, env = "BUILDSYS_VERSION_BUILD")]
+    pub(crate) version_build: String,
+
+    #[arg(long, env = "BUILDSYS_VERSION_IMAGE")]
+    pub(crate) version_image: String,
+
+    #[command(flatten)]
+    pub(crate) common: Common,
+}
+
+/// Returns the environment variables that need to be watched for a given `[BuildType]`.
+fn sensitive_env_vars(build_type: BuildType) -> impl Iterator<Item = &'static str> {
+    REBUILD_VARS
+        .into_iter()
+        .filter(move |(_, flags)| build_type.includes(*flags))
+        .map(|(var, _)| var)
+}
+
+/// Emits the cargo directives for a the list of sensitive environment variables for a given
+/// `[BuildType]`.
+pub(crate) fn rerun_for_envs(build_type: BuildType) {
+    for var in sensitive_env_vars(build_type) {
+        println!("cargo:rerun-if-env-changed={}", var)
+    }
+}
+
+/// The thing that buildsys is building.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum BuildType {
+    Package = 0b00000001,
+    Variant = 0b00000010,
+}
+
+impl BuildType {
+    fn includes(&self, flags: u8) -> bool {
+        let this = *self as u8;
+        let and = flags & this;
+        and == this
+    }
+}
+
+const PACKAGE: u8 = BuildType::Package as u8;
+const VARIANT: u8 = BuildType::Variant as u8;
+
+#[test]
+fn build_type_includes_test() {
+    // true
+    assert!(BuildType::Package.includes(PACKAGE | VARIANT));
+    assert!(BuildType::Variant.includes(VARIANT));
+    assert!(BuildType::Variant.includes(VARIANT | PACKAGE));
+
+    // false
+    assert!(!BuildType::Package.includes(VARIANT));
+    assert!(!BuildType::Variant.includes(PACKAGE));
+    assert!(!BuildType::Variant.includes(32));
+    assert!(!BuildType::Variant.includes(0));
+}
+
+#[test]
+fn test_sensitive_env_vars_variant() {
+    let list: Vec<&str> = sensitive_env_vars(BuildType::Variant).collect();
+    assert!(list.contains(&"BUILDSYS_ARCH"));
+    assert!(list.contains(&"BUILDSYS_VARIANT"));
+    assert!(!list.contains(&"BUILDSYS_PACKAGES_DIR"));
+}
+
+#[test]
+fn test_sensitive_env_vars_package() {
+    let list: Vec<&str> = sensitive_env_vars(BuildType::Package).collect();
+    assert!(list.contains(&"BUILDSYS_ARCH"));
+    assert!(list.contains(&"BUILDSYS_PACKAGES_DIR"));
+    assert!(!list.contains(&"BUILDSYS_VARIANT"));
+}

--- a/tools/buildsys/src/constants.rs
+++ b/tools/buildsys/src/constants.rs
@@ -1,2 +1,0 @@
-pub(crate) const SDK_VAR: &str = "TLPRIVATE_SDK_IMAGE";
-pub(crate) const TOOLCHAIN_VAR: &str = "TLPRIVATE_TOOLCHAIN";

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -16,11 +16,10 @@ when the docker-go script is invoked.
  */
 
 pub(crate) mod error;
-use error::Result;
 
-use crate::constants::SDK_VAR;
 use buildsys::manifest;
 use duct::cmd;
+use error::Result;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -76,6 +75,7 @@ impl GoMod {
         root_dir: &Path,
         package_dir: &Path,
         external_file: &manifest::ExternalFile,
+        sdk: &str,
     ) -> Result<()> {
         let url_file_name = extract_file_name(&external_file.url)?;
         let local_file_name = &external_file.path.as_ref().unwrap_or(&url_file_name);
@@ -111,12 +111,9 @@ impl GoMod {
             output_path_arg.to_string_lossy()
         );
 
-        // Our SDK and toolchain are picked by the external `cargo make` invocation.
-        let sdk = env::var(SDK_VAR).context(error::EnvironmentSnafu { var: SDK_VAR })?;
-
         let args = DockerGoArgs {
             module_path: package_dir,
-            sdk_image: sdk,
+            sdk_image: sdk.to_string(),
             go_mod_cache: &root_dir.join(".gomodcache"),
             command: format!("./{}", GO_MOD_DOCKER_SCRIPT_NAME),
         };

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -8,22 +8,22 @@ specified as a command line argument.
 The implementation is closely tied to the top-level Dockerfile.
 
 */
+mod args;
 mod builder;
 mod cache;
-mod constants;
 mod gomod;
 mod project;
 mod spec;
 
+use crate::args::{BuildPackageArgs, BuildVariantArgs, Buildsys, Command};
 use builder::{PackageBuilder, VariantBuilder};
 use buildsys::manifest::{BundleModule, ManifestInfo, SupportedArch};
 use cache::LookasideCache;
+use clap::Parser;
 use gomod::GoMod;
 use project::ProjectInfo;
-use serde::Deserialize;
 use snafu::{ensure, ResultExt};
 use spec::SpecInfo;
-use std::env;
 use std::path::PathBuf;
 use std::process;
 
@@ -83,63 +83,42 @@ mod error {
 
 type Result<T> = std::result::Result<T, error::Error>;
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum Command {
-    BuildPackage,
-    BuildVariant,
-}
-
-fn usage() -> ! {
-    eprintln!(
-        "\
-USAGE:
-    buildsys <SUBCOMMAND>
-
-SUBCOMMANDS:
-    build-package           Build RPMs from a spec file and sources.
-    build-variant           Build filesystem and disk images from RPMs."
-    );
-    process::exit(1)
-}
-
 // Returning a Result from main makes it print a Debug representation of the error, but with Snafu
 // we have nice Display representations of the error, so we wrap "main" (run) and print any error.
 // https://github.com/shepmaster/snafu/issues/110
 fn main() {
-    if let Err(e) = run() {
+    let args = Buildsys::parse();
+    if let Err(e) = run(args) {
         eprintln!("{}", e);
         process::exit(1);
     }
 }
 
-fn run() -> Result<()> {
-    // Not actually redundant for a diverging function.
-    #[allow(clippy::redundant_closure)]
-    let command_str = std::env::args().nth(1).unwrap_or_else(|| usage());
-    let command = serde_plain::from_str::<Command>(&command_str).unwrap_or_else(|_| usage());
-    match command {
-        Command::BuildPackage => build_package()?,
-        Command::BuildVariant => build_variant()?,
+fn run(args: Buildsys) -> Result<()> {
+    args::rerun_for_envs(args.command.build_type());
+    match args.command {
+        Command::BuildPackage(args) => build_package(*args),
+        Command::BuildVariant(args) => build_variant(*args),
     }
-    Ok(())
 }
 
-fn build_package() -> Result<()> {
+fn build_package(args: BuildPackageArgs) -> Result<()> {
     let manifest_file = "Cargo.toml";
     println!("cargo:rerun-if-changed={}", manifest_file);
 
-    let root_dir: PathBuf = getenv("BUILDSYS_ROOT_DIR")?.into();
-    let variant = getenv("BUILDSYS_VARIANT")?;
-    let variant_manifest_path = root_dir.join("variants").join(variant).join(manifest_file);
+    let variant_manifest_path = args
+        .common
+        .root_dir
+        .join("variants")
+        .join(&args.variant)
+        .join(manifest_file);
     let variant_manifest =
         ManifestInfo::new(variant_manifest_path).context(error::ManifestParseSnafu)?;
-    supported_arch(&variant_manifest)?;
+    supported_arch(&variant_manifest, &args.common.arch)?;
     let mut image_features = variant_manifest.image_features();
 
-    let manifest_dir: PathBuf = getenv("CARGO_MANIFEST_DIR")?.into();
-    let manifest =
-        ManifestInfo::new(manifest_dir.join(manifest_file)).context(error::ManifestParseSnafu)?;
+    let manifest = ManifestInfo::new(args.common.cargo_manifest_dir.join(manifest_file))
+        .context(error::ManifestParseSnafu)?;
     let package_features = manifest.package_features();
 
     // For any package feature specified in the package manifest, track the corresponding
@@ -187,7 +166,14 @@ fn build_package() -> Result<()> {
     }
 
     if let Some(files) = manifest.external_files() {
-        LookasideCache::fetch(files).context(error::ExternalFileFetchSnafu)?;
+        let lookaside_cache = LookasideCache::new(
+            &args.common.version_full,
+            args.lookaside_cache.clone(),
+            args.upstream_source_fallback == "true",
+        );
+        lookaside_cache
+            .fetch(files)
+            .context(error::ExternalFileFetchSnafu)?;
         for f in files {
             if f.bundle_modules.is_none() {
                 continue;
@@ -195,20 +181,23 @@ fn build_package() -> Result<()> {
 
             for b in f.bundle_modules.as_ref().unwrap() {
                 match b {
-                    BundleModule::Go => {
-                        GoMod::vendor(&root_dir, &manifest_dir, f).context(error::GoModSnafu)?
-                    }
+                    BundleModule::Go => GoMod::vendor(
+                        &args.common.root_dir,
+                        &args.common.cargo_manifest_dir,
+                        f,
+                        &args.common.sdk_image,
+                    )
+                    .context(error::GoModSnafu)?,
                 }
             }
         }
     }
 
     if let Some(groups) = manifest.source_groups() {
-        let var = "BUILDSYS_SOURCES_DIR";
-        let root: PathBuf = getenv(var)?.into();
-        println!("cargo:rerun-if-env-changed={}", var);
-
-        let dirs = groups.iter().map(|d| root.join(d)).collect::<Vec<_>>();
+        let dirs = groups
+            .iter()
+            .map(|d| args.sources_dir.join(d))
+            .collect::<Vec<_>>();
         let info = ProjectInfo::crawl(&dirs).context(error::ProjectCrawlSnafu)?;
         for f in info.files {
             println!("cargo:rerun-if-changed={}", f.display());
@@ -220,7 +209,7 @@ fn build_package() -> Result<()> {
     let package = if let Some(name_override) = manifest.package_name() {
         name_override.clone()
     } else {
-        getenv("CARGO_PKG_NAME")?
+        args.cargo_package_name.clone()
     };
     let spec = format!("{}.spec", package);
     println!("cargo:rerun-if-changed={}", spec);
@@ -235,20 +224,19 @@ fn build_package() -> Result<()> {
         println!("cargo:rerun-if-changed={}", f.display());
     }
 
-    PackageBuilder::build(&package, image_features).context(error::BuildAttemptSnafu)?;
+    PackageBuilder::build(&args, &package, image_features).context(error::BuildAttemptSnafu)?;
 
     Ok(())
 }
 
-fn build_variant() -> Result<()> {
-    let manifest_dir: PathBuf = getenv("CARGO_MANIFEST_DIR")?.into();
+fn build_variant(args: BuildVariantArgs) -> Result<()> {
     let manifest_file = "Cargo.toml";
     println!("cargo:rerun-if-changed={}", manifest_file);
 
-    let manifest =
-        ManifestInfo::new(manifest_dir.join(manifest_file)).context(error::ManifestParseSnafu)?;
+    let manifest = ManifestInfo::new(args.common.cargo_manifest_dir.join(manifest_file))
+        .context(error::ManifestParseSnafu)?;
 
-    supported_arch(&manifest)?;
+    supported_arch(&manifest, &args.common.arch)?;
 
     if let Some(packages) = manifest.included_packages() {
         let image_format = manifest.image_format();
@@ -256,6 +244,7 @@ fn build_variant() -> Result<()> {
         let kernel_parameters = manifest.kernel_parameters();
         let image_features = manifest.image_features();
         VariantBuilder::build(
+            &args,
             packages,
             image_format,
             image_layout,
@@ -271,16 +260,15 @@ fn build_variant() -> Result<()> {
 }
 
 /// Ensure that the current arch is supported by the current variant
-fn supported_arch(manifest: &ManifestInfo) -> Result<()> {
+fn supported_arch(manifest: &ManifestInfo, arch: &str) -> Result<()> {
     if let Some(supported_arches) = manifest.supported_arches() {
-        let arch = getenv("BUILDSYS_ARCH")?;
         let current_arch: SupportedArch =
-            serde_plain::from_str(&arch).context(error::UnknownArchSnafu { arch: &arch })?;
+            serde_plain::from_str(arch).context(error::UnknownArchSnafu { arch })?;
 
         ensure!(
             supported_arches.contains(&current_arch),
             error::UnsupportedArchSnafu {
-                arch: &arch,
+                arch,
                 supported_arches: supported_arches
                     .iter()
                     .map(|a| a.to_string())
@@ -289,9 +277,4 @@ fn supported_arch(manifest: &ManifestInfo) -> Result<()> {
         )
     }
     Ok(())
-}
-
-/// Retrieve a variable that we expect to be set in the environment.
-fn getenv(var: &str) -> Result<String> {
-    env::var(var).context(error::EnvironmentSnafu { var })
 }

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -237,7 +237,7 @@ uefi-secure-boot = true
 
 mod error;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -501,12 +501,15 @@ pub enum PartitionPlan {
     Unified,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Eq, Hash)]
+#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum SupportedArch {
     X86_64,
     Aarch64,
 }
+
+serde_plain::derive_fromstr_from_deserialize!(SupportedArch);
+serde_plain::derive_display_from_serialize!(SupportedArch);
 
 /// Map a Linux architecture into the corresponding Docker architecture.
 impl SupportedArch {
@@ -518,7 +521,7 @@ impl SupportedArch {
     }
 }
 
-#[derive(Deserialize, Debug, PartialEq, Eq, Hash)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[serde(try_from = "String")]
 pub enum ImageFeature {
     GrubSetPrivateVar,
@@ -570,13 +573,4 @@ pub struct ExternalFile {
     pub bundle_modules: Option<Vec<BundleModule>>,
     pub bundle_root_path: Option<PathBuf>,
     pub bundle_output_path: Option<PathBuf>,
-}
-
-impl fmt::Display for SupportedArch {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            SupportedArch::X86_64 => write!(f, "x86_64"),
-            SupportedArch::Aarch64 => write!(f, "aarch64"),
-        }
-    }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to, refactor before #70 

**Description of changes:**

Required input in the form of environment variables was sprinkled throughout the code. Here we aggregate the inputs into a CLI interface using Clap, while still allowing all to specified via environment variables.

**Testing done:**

- [x] Built an aws-k8s-1.27 image
- [x] Built it again and observed that packages were not rebuilt
- [x] touched a file (binutils.spec) and built it again - observed that binutils was rebuilt but other packages were not
- [x] Built an aws-ecs-2 image, many (but not all) packages were rebuilt due to changed variant
- [x] Built it again and observed that packages were not rebuilt
- [x] touched a file (binutils.spec) and built it again - observed that binutils was rebuilt but other packages were not

Also, during the refactoring process, I captured the output of the docker build command before and after this PR's changes. I found that I was getting the same build args and secrets args before and after (with the exception that SDK, TOOLCHAIN, TOKEN and NOCACHE have been added during build-variant, which seems fine).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
