### PR TITLE
testsys: Add test type for cluster templating

### DIFF
--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -486,8 +486,14 @@ pub(crate) trait CrdCreator: Sync {
                         &mut self
                             .additional_fields(&test_type.to_string())
                             .into_iter()
-                            // Add the image id in case it is needed for cluster creation
+                            // Add the image id, original test type, and resolved test type in case
+                            // it is needed for cluster creation
                             .chain(Some(("image-id".to_string(), image_id.clone())))
+                            .chain(Some((
+                                "test-flavor".to_string(),
+                                crd_input.test_flavor.clone(),
+                            )))
+                            .chain(Some(("test-type".to_string(), test_type.to_string())))
                             .collect::<BTreeMap<String, String>>(),
                     )?,
                     hardware_csv: &crd_input


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #N/A

**Description of changes:**

Adds 2 additional fields for templating cluster config files. This allows us to provision separate clusters for each test type.

```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: "{{kube-arch}}-{{kube-variant}}-ipv6-{{test-flavor}}"
  version: "{{version}}"
  region: "us-west-2"
kubernetesNetworkConfig:
  ipFamily: IPv6
```

**Testing done:**

TBA

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
