### PR TITLE
twoliter: centralize toolsdir creation

### DIFF
--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -50,9 +50,6 @@ impl BuildVariant {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let token = project.token();
         let toolsdir = project.project_dir().join("build/tools");
-        // Ignore errors because we want to proceed even if the directory does not exist.
-        let _ = fs::remove_dir_all(&toolsdir).await;
-        fs::create_dir_all(&toolsdir).await?;
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");
         // A temporary directory in the `build` directory

--- a/twoliter/src/cmd/debug.rs
+++ b/twoliter/src/cmd/debug.rs
@@ -1,4 +1,3 @@
-use crate::common::fs;
 use crate::tools::install_tools;
 use anyhow::Result;
 use clap::Parser;
@@ -49,7 +48,6 @@ impl CheckToolArgs {
             .install_dir
             .clone()
             .unwrap_or_else(|| env::temp_dir().join(unique_name()));
-        fs::create_dir_all(&dir).await?;
         install_tools(&dir).await?;
         println!("{}", dir.display());
         Ok(())

--- a/twoliter/src/cmd/make.rs
+++ b/twoliter/src/cmd/make.rs
@@ -1,5 +1,4 @@
 use crate::cargo_make::CargoMake;
-use crate::common::fs;
 use crate::project::{self};
 use crate::tools::install_tools;
 use anyhow::Result;
@@ -35,7 +34,6 @@ impl Make {
     pub(super) async fn run(&self) -> Result<()> {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let toolsdir = project.project_dir().join("build/tools");
-        let _ = fs::remove_dir_all(&toolsdir).await;
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");
         CargoMake::new(&project, &self.arch)?


### PR DESCRIPTION

**Issue number:**

N/A

**Description of changes:**

Delete and re-create the tools dir inside of the install_tools function instead of requiring the caller to do it. This will lead to fewer bugs.


**Testing done:**

Used it, it works.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
