### PR TITLE
enable lookaside cache arguments

### DIFF
--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -44,7 +44,7 @@ impl LookasideCache {
                 match Self::verify_file(path, hash) {
                     Ok(_) => continue,
                     Err(e) => {
-                        eprintln!("{}", e);
+                        println!("{}", e);
                         fs::remove_file(path).context(error::ExternalFileDeleteSnafu { path })?;
                     }
                 }
@@ -62,7 +62,7 @@ impl LookasideCache {
                     continue;
                 }
                 Err(e) => {
-                    eprintln!("{}", e);
+                    println!("{}", e);
                 }
             }
 

--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -63,7 +63,7 @@ impl LookasideCache {
                 }
                 Err(e) => {
                     // next check with upstream, if permitted
-                    if f.force_upstream.unwrap_or(false) || upstream_fallback {
+                    if upstream_fallback {
                         println!("Error fetching from lookaside cache: {}", e);
                         println!("Fetching {:?} from upstream source", url_file_name);
                         Self::fetch_file(&f.url, &tmp, hash)?;

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -191,7 +191,7 @@ fn docker_go(dg_args: &DockerGoArgs) -> Result<()> {
         var: "TWOLITER_TOOLS_DIR",
     })?;
     let program = PathBuf::from(twoliter_tools_dir).join("docker-go");
-    eprintln!("program: {}", program.to_string_lossy());
+    println!("program: {}", program.to_string_lossy());
     let output = cmd(program, args)
         .stderr_to_stdout()
         .stdout_capture()

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -566,7 +566,6 @@ pub struct ExternalFile {
     pub path: Option<PathBuf>,
     pub sha512: String,
     pub url: String,
-    pub force_upstream: Option<bool>,
     pub bundle_modules: Option<Vec<BundleModule>>,
     pub bundle_root_path: Option<PathBuf>,
     pub bundle_output_path: Option<PathBuf>,

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -76,6 +76,10 @@ VMWARE_IMPORT_SPEC_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/support/vmware/impo
 # Infra.toml for VMware commands; it's a comma-separated list like
 # "datacenter1,datacenter2"
 
+
+# The URL to use for a cache of sourcecode to bypass using upstream sources.
+BUILDSYS_LOOKASIDE_CACHE = "https://cache.bottlerocket.aws"
+
 # Disallow pulling directly Upstream URLs when lookaside cache results in MISSes as a fallback.
 # To use the upstream source as fallback, override this on the command line and set it to 'true'
 BUILDSYS_UPSTREAM_SOURCE_FALLBACK = "false"

--- a/twoliter/src/cargo_make.rs
+++ b/twoliter/src/cargo_make.rs
@@ -94,6 +94,19 @@ impl CargoMake {
         self
     }
 
+    /// Add multiple env variables as `(key, value)` tuples.
+    pub(crate) fn envs<S1, S2>(mut self, key_value_pairs: impl Iterator<Item = (S1, S2)>) -> Self
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+    {
+        for (key, value) in key_value_pairs {
+            self.args
+                .push(format!("-e={}={}", key.into(), value.into()));
+        }
+        self
+    }
+
     /// Execute the `cargo make` task
     pub(crate) async fn exec<S>(&self, task: S) -> Result<()>
     where


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #136 
Closes #135 

**Description of changes:**


    twoliter: accept lookaside cache arguments

    Allow the user to change the lookaside cache URL and upstream sources
    fallback in the twoliter build variant command.

    buildsys: get lookaside cache from the environment

    Out-of-tree builders will want their own lookaside cache for sources.
    This makes it possible to specify the location of the lookaside cache
    instead of hard-coding it in buildsys.


**Testing done:**

- [x] Built `tests/projects/project1` with `twoliter build variant`. This does not test lookaside cache logic, but checks for regression.

Built Bottlerocket

- [x] `cargo make` succeeds
- [x] `BUILDSYS_LOOKASIDE_CACHE=https:://example.com cargo make` fails as expected
- [x] `BUILDSYS_LOOKASIDE_CACHE=https:://example.com BUILDSYS_UPSTREAM_SOURCE_FALLBACK=true` succeeds


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
