### PR TITLE
buildsys: revert removal of force-upstream

### DIFF
--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -63,7 +63,7 @@ impl LookasideCache {
                 }
                 Err(e) => {
                     // next check with upstream, if permitted
-                    if upstream_fallback {
+                    if f.force_upstream.unwrap_or(false) || upstream_fallback {
                         println!("Error fetching from lookaside cache: {}", e);
                         println!("Fetching {:?} from upstream source", url_file_name);
                         Self::fetch_file(&f.url, &tmp, hash)?;

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -566,6 +566,7 @@ pub struct ExternalFile {
     pub path: Option<PathBuf>,
     pub sha512: String,
     pub url: String,
+    pub force_upstream: Option<bool>,
     pub bundle_modules: Option<Vec<BundleModule>>,
     pub bundle_root_path: Option<PathBuf>,
     pub bundle_output_path: Option<PathBuf>,


### PR DESCRIPTION


**Issue number:**

NA

**Description of changes:**

46fe1b8 incorrectly assumed the force-upstream field was unused. Revert the change.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
