### PR TITLE
alpha-sdk-script: delete manifest before creating

### DIFF
--- a/local/alpha-sdk.sh
+++ b/local/alpha-sdk.sh
@@ -179,6 +179,7 @@ do
   multiarch="${alpha_registry}/${alpha_name}-${target_arch}:${alpha_version}"
 
   echo "creating multiarch manifest ${multiarch}"
+  docker manifest rm "${multiarch}" || true
   docker manifest create "${multiarch}" "${arm_host}" "${amd_host}"
   echo "pushing multiarch manifest ${multiarch}"
   docker manifest push "${multiarch}"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Super-annoying to get an error when you've tried and failed and a manifest is already there.

**Testing done:**

It fixed the annoying failure.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
