### PR TITLE
twoliter: fix make command trailing varargs

### DIFF
--- a/twoliter/src/cmd/make.rs
+++ b/twoliter/src/cmd/make.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 /// Run a cargo make command in Twoliter's build environment. Known Makefile.toml environment
 /// variables will be passed-through to the cargo make invocation.
 #[derive(Debug, Parser)]
+#[clap(trailing_var_arg = true)]
 pub(crate) struct Make {
     /// Path to the project file. Will search for Twoliter.toml when absent.
     #[clap(long)]
@@ -19,15 +20,17 @@ pub(crate) struct Make {
     #[clap(long)]
     cargo_home: PathBuf,
 
+    /// This can be passed by environment variable. We require it as part of the command arguments
+    /// because we need it to pull the right SDK target architecture.
+    #[clap(long, env = "BUILDSYS_ARCH")]
+    arch: String,
+
     /// Cargo make task. E.g. the word "build" if we want to execute `cargo make build`.
     makefile_task: String,
 
     /// Uninspected arguments to be passed to cargo make after the target name. For example, --foo
     /// in the following command : cargo make test --foo.
     additional_args: Vec<String>,
-
-    #[clap(env = "BUILDSYS_ARCH")]
-    arch: String,
 }
 
 impl Make {
@@ -45,4 +48,99 @@ impl Make {
             .exec_with_args(&self.makefile_task, self.additional_args.clone())
             .await
     }
+}
+
+#[test]
+fn test_trailing_args_1() {
+    let args = Make::try_parse_from(&[
+        "make",
+        "--cargo-home",
+        "/tmp/foo",
+        "--arch",
+        "x86_64",
+        "testsys",
+        "--",
+        "add",
+        "secret",
+        "map",
+        "--name",
+        "foo",
+        "something=bar",
+        "something-else=baz",
+    ])
+    .unwrap();
+
+    assert_eq!(args.makefile_task, "testsys");
+    assert_eq!(args.additional_args[0], "add");
+    assert_eq!(args.additional_args[1], "secret");
+    assert_eq!(args.additional_args[2], "map");
+    assert_eq!(args.additional_args[3], "--name");
+    assert_eq!(args.additional_args[4], "foo");
+    assert_eq!(args.additional_args[5], "something=bar");
+    assert_eq!(args.additional_args[6], "something-else=baz");
+}
+
+#[test]
+fn test_trailing_args_2() {
+    let args = Make::try_parse_from(&[
+        "make",
+        "--cargo-home",
+        "/tmp/foo",
+        "--arch",
+        "x86_64",
+        "testsys",
+        "add",
+        "secret",
+        "map",
+        "--name",
+        "foo",
+        "something=bar",
+        "something-else=baz",
+    ])
+    .unwrap();
+
+    assert_eq!(args.makefile_task, "testsys");
+    assert_eq!(args.additional_args[0], "add");
+    assert_eq!(args.additional_args[1], "secret");
+    assert_eq!(args.additional_args[2], "map");
+    assert_eq!(args.additional_args[3], "--name");
+    assert_eq!(args.additional_args[4], "foo");
+    assert_eq!(args.additional_args[5], "something=bar");
+    assert_eq!(args.additional_args[6], "something-else=baz");
+}
+
+#[test]
+fn test_trailing_args_3() {
+    let args = Make::try_parse_from(&[
+        "make",
+        "--cargo-home",
+        "/tmp/foo",
+        "--arch",
+        "x86_64",
+        "testsys",
+        "--",
+        "add",
+        "secret",
+        "map",
+        "--",
+        "--name",
+        "foo",
+        "something=bar",
+        "something-else=baz",
+        "--",
+    ])
+    .unwrap();
+
+    assert_eq!(args.makefile_task, "testsys");
+    assert_eq!(args.additional_args[0], "add");
+    assert_eq!(args.additional_args[1], "secret");
+    assert_eq!(args.additional_args[2], "map");
+    // The first instance of `--`, between `testsys` and `add`, is not passed through to the
+    // varargs. After that, instances of `--` are passed through the varargs.
+    assert_eq!(args.additional_args[3], "--");
+    assert_eq!(args.additional_args[4], "--name");
+    assert_eq!(args.additional_args[5], "foo");
+    assert_eq!(args.additional_args[6], "something=bar");
+    assert_eq!(args.additional_args[7], "something-else=baz");
+    assert_eq!(args.additional_args[8], "--");
 }


### PR DESCRIPTION



**Issue number:**

Closes #139

**Description of changes:**

Fixes issue #139. Clap was not configured correctly such that trailing arguments intended to be passed along to the cargo make invocation were not handled correctly. This commit fixes it and adds regression tests in case we change the command arguments or Clap changes behavior.


**Testing done:**

- [x] Use it with Bottlerocket's Makefile.toml

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
