### PR TITLE
buildsys: enable host network for variant builds

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -127,6 +127,8 @@ struct PackageBuildArgs {
 impl PackageBuildArgs {
     fn build_args(&self) -> Vec<String> {
         let mut args = Vec::new();
+        args.push("--network".into());
+        args.push("none".into());
         args.build_arg("PACKAGE", &self.package);
         args.build_arg("REPO", &self.publish_repo);
         args.build_arg("VARIANT", &self.variant);
@@ -163,6 +165,8 @@ struct VariantBuildArgs {
 impl VariantBuildArgs {
     fn build_args(&self) -> Vec<String> {
         let mut args = Vec::new();
+        args.push("--network".into());
+        args.push("host".into());
         args.build_arg(
             "DATA_IMAGE_PUBLISH_SIZE_GIB",
             self.data_image_publish_size_gib.to_string(),


### PR DESCRIPTION
**Issue number:**

Closes #154

**Description of changes:**
This is required to permit Secure Boot signing with AWS KMS keys.


**Testing done:**
Built `aws-dev` and signed it with an "AWS" type sbkeys profile.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
