### PR TITLE
buildsys: fix image features

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -114,7 +114,12 @@ impl CommonBuildArgs {
 }
 
 struct PackageBuildArgs {
-    image_features: Option<HashSet<ImageFeature>>,
+    /// The package might need to know what the `image_features` are going to be for the variant
+    /// it is going to be used in downstream. This is because certain packages will be built
+    /// differently based on certain image features such as cgroupsv1 vs cgroupsv2. During a
+    /// package build, these are determined by looking at the variant's Cargo.toml file based on
+    /// what was found in `BUILDSYS_VARIANT`.
+    image_features: HashSet<ImageFeature>,
     package: String,
     publish_repo: String,
     variant: String,
@@ -134,11 +139,10 @@ impl PackageBuildArgs {
         args.build_arg("VARIANT_FLAVOR", &self.variant_flavor);
         args.build_arg("VARIANT_PLATFORM", &self.variant_platform);
         args.build_arg("VARIANT_RUNTIME", &self.variant_runtime);
-        if let Some(image_features) = &self.image_features {
-            for image_feature in image_features.iter() {
-                args.build_arg(format!("{}", image_feature), "1");
-            }
+        for image_feature in &self.image_features {
+            args.build_arg(format!("{}", image_feature), "1");
         }
+
         args
     }
 }
@@ -218,7 +222,11 @@ pub(crate) struct DockerBuild {
 
 impl DockerBuild {
     /// Create a new `DockerBuild` that can build a package.
-    pub(crate) fn new_package(args: BuildPackageArgs, manifest: &ManifestInfo) -> Result<Self> {
+    pub(crate) fn new_package(
+        args: BuildPackageArgs,
+        manifest: &ManifestInfo,
+        image_features: HashSet<ImageFeature>,
+    ) -> Result<Self> {
         let package = if let Some(name_override) = manifest.package_name() {
             name_override.clone()
         } else {
@@ -248,9 +256,7 @@ impl DockerBuild {
                 args.common.arch,
             ),
             target_build_args: TargetBuildArgs::Package(PackageBuildArgs {
-                image_features: manifest
-                    .image_features()
-                    .map(|set| set.iter().map(|&x| x.to_owned()).collect()),
+                image_features,
                 package,
                 publish_repo: args.publish_repo,
                 variant: args.variant,
@@ -301,12 +307,7 @@ impl DockerBuild {
             target_build_args: TargetBuildArgs::Variant(VariantBuildArgs {
                 data_image_publish_size_gib,
                 data_image_size_gib: data_image_size_gib.to_string(),
-                image_features: manifest
-                    .image_features()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .copied()
-                    .collect(),
+                image_features: manifest.image_features().unwrap_or_default(),
                 image_format: match manifest.image_format() {
                     Some(ImageFormat::Raw) | None => "raw",
                     Some(ImageFormat::Qcow2) => "qcow2",

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -325,11 +325,11 @@ impl ManifestInfo {
     }
 
     /// Convenience method to return the enabled image features for this variant.
-    pub fn image_features(&self) -> Option<HashSet<&ImageFeature>> {
+    pub fn image_features(&self) -> Option<HashSet<ImageFeature>> {
         self.build_variant().and_then(|b| {
             b.image_features
                 .as_ref()
-                .map(|m| m.iter().filter(|(_k, v)| **v).map(|(k, _v)| k).collect())
+                .map(|m| m.iter().filter(|(_k, v)| **v).map(|(k, _v)| *k).collect())
         })
     }
 

--- a/tools/pubsys/src/aws/ami/register.rs
+++ b/tools/pubsys/src/aws/ami/register.rs
@@ -129,7 +129,7 @@ async fn _register_image(
         .image_features()
         .iter()
         .flatten()
-        .any(|f| **f == ImageFeature::UefiSecureBoot);
+        .any(|f| *f == ImageFeature::UefiSecureBoot);
 
     let (boot_mode, uefi_data) = if uefi_secure_boot_enabled {
         (Some("uefi-preferred".into()), Some(uefi_data))


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #153 

**Description of changes:**

This commt fixes a couple of regressions introduced in 92bc3bb. Most notably, the wrong set of image_features was being used to set package build args. In this commit we correctly use the image features found in the downstream variants Cargo.toml.

Also fixes an oversight where an error constructing the Builder object would have resulted in a panic.

**Testing done:**

- @bcressey built an `aws-dev` image and observed that the problem was fixed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
