### PR TITLE
pubsys: switch to TLPRIVATE_SDK_IMAGE

### DIFF
--- a/tools/pubsys/src/vmware/govc.rs
+++ b/tools/pubsys/src/vmware/govc.rs
@@ -99,8 +99,8 @@ impl Govc {
 /// to run in the container.
 // The arguments are `&[&str]` in an attempt to be as flexible as possible for the caller
 fn docker_run(docker_env: &[&str], mount: Option<&[&str]>, command: &[&str]) -> Result<Output> {
-    let sdk = env::var("BUILDSYS_SDK_IMAGE").context(error::EnvironmentSnafu {
-        var: "BUILDSYS_SDK_IMAGE",
+    let sdk = env::var("TLPRIVATE_SDK_IMAGE").context(error::EnvironmentSnafu {
+        var: "TLPRIVATE_SDK_IMAGE",
     })?;
     trace!("SDK image: {}", sdk);
 


### PR DESCRIPTION
**Issue number:**

Closes #121

**Description of changes:**
`BUILDSYS_SDK_IMAGE` is no longer set in the environment, so we need to find the SDK using the new variable in order to run `govc`.


**Testing done:**
Ran `cargo make && cargo make upload-ova` for `vmware-dev`.

```
[cargo-make] INFO - Execute Command: "/home/fedora/brdev/tools/twoliter/twoliter" "--log-level=info" "make" "upload-ova" "--project-path=/home/fedora/brdev/Twoliter.toml" "--cargo-home=/home/fedora/brdev/.cargo" "--"
[2024-02-21T23:37:09Z WARN  twoliter::project] A Release.toml file was found. Release.toml is deprecated. Please remove it from your project.
[cargo-make][1] INFO - Build File: /home/fedora/brdev/build/tools/Makefile.toml
[cargo-make][1] INFO - Task: upload-ova
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: setup
[cargo-make][1] INFO - Running Task: setup-build
[cargo-make][1] INFO - Running Task: fetch-sources
[cargo-make][1] INFO - Running Task: upload-ova
23:37:10 [INFO] Uploading to datacenters: vmc-a
23:37:10 [INFO] Uploading OVA to datacenter 'vmc-a' with name 'bottlerocket-vmware-dev-x86_64-v1.19.1-257e33fec'
[cargo-make][1] INFO - Build Done in 12.43 seconds.
[cargo-make] INFO - Build Done in 12.71 seconds.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
