### PR TITLE
buildsys: avoid trailing slash for cache lookup

### DIFF
--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -68,11 +68,20 @@ impl LookasideCache {
                 }
             }
 
-            let name = path.display();
+            let name = &path.display().to_string();
             let tmp = PathBuf::from(format!(".{}", name));
 
             // first check the lookaside cache
-            let url = format!("{}/{}/{}/{}", self.lookaside_cache, name, hash, name);
+            let mut url = self.lookaside_cache.clone();
+            url.path_segments_mut()
+                .map_err(|_| {
+                    error::UrlPathSegmentsSnafu {
+                        url: self.lookaside_cache.clone(),
+                    }
+                    .build()
+                })?
+                .extend([name, hash, name]);
+            let url = url.to_string();
             match self.fetch_file(&url, &tmp, hash) {
                 Ok(_) => {
                     fs::rename(&tmp, path)

--- a/tools/buildsys/src/cache/error.rs
+++ b/tools/buildsys/src/cache/error.rs
@@ -50,6 +50,9 @@ pub(crate) enum Error {
 
     #[snafu(display("Failed to delete file '{}': {}", path.display(), source))]
     ExternalFileDelete { path: PathBuf, source: io::Error },
+
+    #[snafu(display("Failed to get path segments from URL '{}'", url))]
+    UrlPathSegments { url: String },
 }
 
 pub(super) type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
**Issue number:**

Closes #158

**Description of changes:**
The lookaside cache URL is now a `Url` and may have a trailing slash when formatted as a string. Appending a second slash could produce an invalid URL. Avoid this by using `Url::join` instead.


**Testing done:**
Built `aws-dev` and was able to retrieve missing blobs.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
