### PR TITLE
alpha-sdk: include all packages

### DIFF
--- a/local/alpha-sdk.sh
+++ b/local/alpha-sdk.sh
@@ -153,6 +153,13 @@ do
   cp "${bottlerocket_dir}/sbkeys/generate-aws-sbkeys" "${bottlerocket_dir}/.cargo/sbkeys"
   cp "${bottlerocket_dir}/sbkeys/generate-local-sbkeys" "${bottlerocket_dir}/.cargo/sbkeys"
 
+  # First we build aws-dev to make all of (or at least more of) the upstream packages available in
+  # the event ${variant} does not include them.
+  cargo make \
+    -e "BUILDSYS_VARIANT=aws-dev" \
+    -e "BUILDSYS_ARCH=${target_arch}" \
+    build-variant
+
   cargo make \
     -e "BUILDSYS_VARIANT=${variant}" \
     -e "BUILDSYS_ARCH=${target_arch}" \


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

In order to get all available packages into the Alpha SDK, we should build aws-dev first, before building the desired variant. That way packages like bash or iputils will be available even if the upstream variant does not use them.

**Testing done:**

I have used it and was able to install bash on an OOTB project where the upstream variant did not include it.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
