### PR TITLE
pubsys-setup: fix add-key bug

### DIFF
--- a/tools/pubsys-setup/src/main.rs
+++ b/tools/pubsys-setup/src/main.rs
@@ -125,7 +125,7 @@ fn run() -> Result<()> {
 
             let key_url = if let Some(key_url) = maybe_key_url {
                 // If the user has a key, add it to each role.
-                tuftool!("root add-key '{}' '{}' --role root --role snapshot --role targets --role timestamp",
+                tuftool!("root add-key '{}' --key '{}' --role root --role snapshot --role targets --role timestamp",
                          temp_root_role_path, key_url);
                 key_url
             } else {


### PR DESCRIPTION

**Issue number:**

Closes #150 

**Description of changes:**

Add the --key argument to the tuftool add-key invocation as is now required.

**Testing done:**

I ran `cargo make publish-setup` and it failed with Twoliter `v0.0.6`.
Ran it with this fix and it worked.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
