### PR TITLE
switch to the unified SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.0.7"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -69,12 +69,13 @@ Packages are defined and built using RPM.
 
 These package builds take place in a docker environment using `docker build` commands with the `BuildKit` backend.
 The toolchains used to compile Rust, C, C++ and Go software are distributed in a container image called the [bottlerocket-sdk].
+The SDK contains cross-compiling toolchains for all supported architectures.
+Currently, x86_64 and aarch64 are supported.
 It is in the SDK environment that the package builds take place.
 
 Once all the software for a Bottlerocket image has been built into RPM images, a final image creation step occurs.
 A `docker build` command installs everything into an image file.
 
-The toolchains necessary for each arch (x86_64 and aarch64) are available as separate SDK containers to allow for cross-compilation.
 The build host has the following requirements: sufficient versions of Docker, buildx, Cargo, Cargo Make and a few tools like lz4.
 The root of the Bottlerocket git repo is mounted and artifacts are created in `.cargo` and `build` directories.
 

--- a/local/alpha-sdk.sh
+++ b/local/alpha-sdk.sh
@@ -164,31 +164,29 @@ do
     -e "BUILDSYS_VARIANT=${variant}" \
     -e "BUILDSYS_ARCH=${target_arch}" \
     build-variant
-
-  for host_arch in amd64 arm64
-  do
-    sdk="${sdk_repo}-${target_arch}:${sdk_version}"
-    tag="${alpha_registry}/${alpha_name}-${target_arch}:${alpha_version}-${host_arch}"
-    echo "creating image ${tag}"
-
-    docker build \
-      --tag "${tag}" \
-      --build-arg "SDK=${sdk}" \
-      --build-arg "HOST_GOARCH=${host_arch}" \
-      --build-arg "TARGET_ARCH=${target_arch}" \
-      --file "${script_dir}/alpha-sdk.dockerfile" \
-      "${bottlerocket_dir}"
-    docker push "${tag}"
-  done
-
-  arm_host="${alpha_registry}/${alpha_name}-${target_arch}:${alpha_version}-arm64"
-  amd_host="${alpha_registry}/${alpha_name}-${target_arch}:${alpha_version}-amd64"
-  multiarch="${alpha_registry}/${alpha_name}-${target_arch}:${alpha_version}"
-
-  echo "creating multiarch manifest ${multiarch}"
-  docker manifest rm "${multiarch}" || true
-  docker manifest create "${multiarch}" "${arm_host}" "${amd_host}"
-  echo "pushing multiarch manifest ${multiarch}"
-  docker manifest push "${multiarch}"
-
 done
+
+for host_arch in amd64 arm64
+do
+  sdk="${sdk_repo}:${sdk_version}"
+  tag="${alpha_registry}/${alpha_name}:${alpha_version}-${host_arch}"
+  echo "creating image ${tag}"
+
+  docker build \
+    --tag "${tag}" \
+    --build-arg "SDK=${sdk}" \
+    --build-arg "HOST_GOARCH=${host_arch}" \
+    --file "${script_dir}/alpha-sdk.dockerfile" \
+    "${bottlerocket_dir}"
+  docker push "${tag}"
+done
+
+arm_host="${alpha_registry}/${alpha_name}:${alpha_version}-arm64"
+amd_host="${alpha_registry}/${alpha_name}:${alpha_version}-amd64"
+multiarch="${alpha_registry}/${alpha_name}:${alpha_version}"
+
+echo "creating multiarch manifest ${multiarch}"
+docker manifest rm "${multiarch}" || true
+docker manifest create "${multiarch}" "${arm_host}" "${amd_host}"
+echo "pushing multiarch manifest ${multiarch}"
+docker manifest push "${multiarch}"

--- a/tests/projects/local-kit/Twoliter.toml
+++ b/tests/projects/local-kit/Twoliter.toml
@@ -2,10 +2,5 @@ schema-version = 1
 
 [sdk]
 registry = "twoliter.alpha"
-name = "bottlerocket-sdk"
-version = "latest"
-
-[toolchain]
-registry = "public.ecr.aws/bottlerocket"
-name = "bottlerocket-toolchain"
-version = "v0.34.1"
+repo = "bottlerocket-sdk"
+tag = "latest"

--- a/tests/projects/project1/Twoliter.toml
+++ b/tests/projects/project1/Twoliter.toml
@@ -3,10 +3,5 @@ release-version = "1.0.0"
 
 [sdk]
 registry = "twoliter.alpha"
-name = "bottlerocket-sdk"
-version = "latest"
-
-[toolchain]
-registry = "public.ecr.aws/bottlerocket"
-name = "bottlerocket-toolchain"
-version = "v0.34.1"
+repo = "bottlerocket-sdk"
+tag = "latest"

--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -14,7 +14,7 @@ use url::Url;
 /// variable changes. The build type is represented with bit flags so that we can easily list
 /// multiple build types for a single variable. See `[BuildType]` and `[rerun_for_envs]` below to
 /// see how this list is used.
-const REBUILD_VARS: [(&str, u8); 13] = [
+const REBUILD_VARS: [(&str, u8); 12] = [
     ("BUILDSYS_ARCH", PACKAGE | VARIANT),
     ("BUILDSYS_NAME", VARIANT),
     ("BUILDSYS_OUTPUT_DIR", VARIANT),
@@ -27,7 +27,6 @@ const REBUILD_VARS: [(&str, u8); 13] = [
     ("BUILDSYS_VERSION_BUILD", VARIANT),
     ("BUILDSYS_VERSION_IMAGE", VARIANT),
     ("TLPRIVATE_SDK_IMAGE", PACKAGE | VARIANT),
-    ("TLPRIVATE_TOOLCHAIN", PACKAGE | VARIANT),
 ];
 
 /// A tool for building Bottlerocket images and artifacts.
@@ -78,9 +77,6 @@ pub(crate) struct Common {
 
     #[arg(long, env = "TLPRIVATE_SDK_IMAGE")]
     pub(crate) sdk_image: String,
-
-    #[arg(long, env = "TLPRIVATE_TOOLCHAIN")]
-    pub(crate) toolchain: String,
 
     #[arg(long, env = "TWOLITER_TOOLS_DIR")]
     pub(crate) tools_dir: PathBuf,

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -88,13 +88,12 @@ static DOCKER_BUILD_MAX_ATTEMPTS: NonZeroU16 = nonzero!(10u16);
 struct CommonBuildArgs {
     arch: SupportedArch,
     sdk: String,
-    toolchain: String,
     nocache: String,
     token: String,
 }
 
 impl CommonBuildArgs {
-    fn new(root: impl AsRef<Path>, sdk: String, toolchain: String, arch: SupportedArch) -> Self {
+    fn new(root: impl AsRef<Path>, sdk: String, arch: SupportedArch) -> Self {
         let mut d = Sha512::new();
         d.update(root.as_ref().display().to_string());
         let digest = hex::encode(d.finalize());
@@ -106,7 +105,6 @@ impl CommonBuildArgs {
         Self {
             arch,
             sdk,
-            toolchain,
             nocache,
             token,
         }
@@ -256,7 +254,6 @@ impl DockerBuild {
             common_build_args: CommonBuildArgs::new(
                 &args.common.root_dir,
                 args.common.sdk_image,
-                args.common.toolchain,
                 args.common.arch,
             ),
             target_build_args: TargetBuildArgs::Package(PackageBuildArgs {
@@ -305,7 +302,6 @@ impl DockerBuild {
             common_build_args: CommonBuildArgs::new(
                 &args.common.root_dir,
                 args.common.sdk_image,
-                args.common.toolchain,
                 args.common.arch,
             ),
             target_build_args: TargetBuildArgs::Variant(VariantBuildArgs {
@@ -428,7 +424,6 @@ impl DockerBuild {
         args.build_arg("ARCH", self.common_build_args.arch.to_string());
         args.build_arg("GOARCH", self.common_build_args.arch.goarch());
         args.build_arg("SDK", &self.common_build_args.sdk);
-        args.build_arg("TOOLCHAIN", &self.common_build_args.toolchain);
         args.build_arg("NOCACHE", &self.common_build_args.nocache);
         // Avoid using a cached layer from a concurrent build in another checkout.
         args.build_arg("TOKEN", &self.common_build_args.token);

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.0.7"
+version = "0.1.0"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -8,12 +8,10 @@
 # filesystem at /host.
 
 ARG SDK
-ARG TOOLCHAIN
 ARG ARCH
 ARG GOARCH
 
 FROM ${SDK} as sdk
-FROM --platform=linux/${GOARCH} ${TOOLCHAIN}-${ARCH} as toolchain
 
 ############################################################################################
 # Section 1: The following build stages are used to build rpm.spec packages
@@ -89,8 +87,9 @@ RUN --mount=target=/host \
   && cp -r /host/licenses ./rpmbuild/BUILD/ \
   || mkdir ./rpmbuild/BUILD/licenses )
 COPY ./packages/${PACKAGE}/ .
-RUN rpmdev-setuptree \
-   && echo "%_cross_variant ${VARIANT}" > .rpmmacros \
+RUN \
+   cp "/usr/lib/rpm/platform/${ARCH}-bottlerocket/macros" .rpmmacros \
+   && echo "%_cross_variant ${VARIANT}" >> .rpmmacros \
    && echo "%_cross_variant_platform ${VARIANT_PLATFORM}" >> .rpmmacros \
    && echo "%_cross_variant_runtime ${VARIANT_RUNTIME}" >> .rpmmacros \
    && echo "%_cross_variant_family ${VARIANT_FAMILY}" >> .rpmmacros \
@@ -127,6 +126,9 @@ RUN --mount=target=/host \
         --nogpgcheck \
         --forcearch "${ARCH}" \
         builddep rpmbuild/SPECS/${PACKAGE}.spec
+
+# Ensure that the target binutils that `find-debuginfo.sh` uses are present in $PATH.
+ENV PATH="/usr/${ARCH}-bottlerocket-linux-gnu/debuginfo/bin:${PATH}"
 
 # We use the "nocache" writable space to generate code where necessary, like the variant-
 # specific models.
@@ -272,7 +274,6 @@ ARG VARIANT
 ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 
 USER root
-COPY --from=toolchain /toolchain /local/toolchain
 
 WORKDIR /tmp
 RUN --mount=target=/host \
@@ -283,7 +284,7 @@ RUN --mount=target=/host \
         -exec cp '{}' '/local/archives/' ';' \
     && /host/build/tools/rpm2kmodkit \
         --archive-dir=/local/archives \
-        --toolchain-dir=/local/toolchain \
+        --toolchain-dir=/toolchain \
         --output-dir=/local/output \
     && echo ${NOCACHE}
 

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -236,9 +236,8 @@ fi
 # These are variables that are not meant to be set by users of `twoliter make`. These are intended
 # to be set only by Twoliter itself when it invokes `cargo make`.
 [env.private]
-# The URIs for the SDK image and the toolchain image must be provided.
+# The URI for the SDK image must be provided.
 TLPRIVATE_SDK_IMAGE = ""
-TLPRIVATE_TOOLCHAIN = ""
 
 ####################################################################################################
 
@@ -261,10 +260,10 @@ if [ -z "${TWOLITER_TOOLS_DIR}" ];then
    exit 1
 fi
 
-# Ensure TLPRIVATE_SDK_IMAGE and TLPRIVATE_TOOLCHAIN are set
-if [[ -z "${TLPRIVATE_SDK_IMAGE}" || -z "{TLPRIVATE_TOOLCHAIN}" ]];then
-   echo "TLPRIVATE_SDK_IMAGE and TLPRIVATE_TOOLCHAIN must be defined and must be non-zero in length."
-   echo "Are you using Twoliter? It is a bug if Twoliter has invoked cargo make without these."
+# Ensure TLPRIVATE_SDK_IMAGE is set
+if [ -z "${TLPRIVATE_SDK_IMAGE}" ];then
+   echo "TLPRIVATE_SDK_IMAGE must be defined and must be non-zero in length."
+   echo "Are you using Twoliter? It is a bug if Twoliter has invoked cargo make without this."
    exit 1
 fi
 
@@ -299,7 +298,6 @@ done
 [tasks.fetch]
 dependencies = [
   "fetch-sdk",
-  "fetch-toolchain",
   "fetch-sources",
   "fetch-vendored",
 ]
@@ -314,35 +312,6 @@ if ! docker image inspect "${TLPRIVATE_SDK_IMAGE}" >/dev/null 2>&1 ; then
     echo "failed to pull '${TLPRIVATE_SDK_IMAGE}'" >&2
     exit 1
   fi
-fi
-'''
-]
-
-[tasks.fetch-toolchain]
-dependencies = ["setup-build"]
-script_runner = "bash"
-script = [
-'''
-if docker image inspect "${TLPRIVATE_TOOLCHAIN}-${BUILDSYS_ARCH}" >/dev/null 2>&1 ; then
-  exit 0
-fi
-
-case "${BUILDSYS_ARCH}" in
-  x86_64) docker_arch="amd64" ;;
-  aarch64) docker_arch="arm64" ;;
-esac
-
-# We want the image with the target's native toolchain, rather than one that matches the
-# host architecture.
-if ! docker pull --platform "${docker_arch}" "${TLPRIVATE_TOOLCHAIN}" ; then
-  echo "could not pull '${TLPRIVATE_TOOLCHAIN}' for ${docker_arch}" >&2
-  exit 1
-fi
-
-# Apply a tag to distinguish the image from other architectures.
-if ! docker tag "${TLPRIVATE_TOOLCHAIN}" "${TLPRIVATE_TOOLCHAIN}-${BUILDSYS_ARCH}" ; then
-  echo "could not tag '${TLPRIVATE_TOOLCHAIN}-${BUILDSYS_ARCH}'" >&2
-  exit 1
 fi
 '''
 ]

--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -62,11 +62,10 @@ impl BuildVariant {
         let sdk_container = DockerContainer::new(
             format!("sdk-{}", token),
             project
-                .sdk(&self.arch)
+                .sdk()
                 .context(format!(
-                    "No SDK defined in {} for {}",
+                    "No SDK defined in {}",
                     project.filepath().display(),
-                    &self.arch
                 ))?
                 .uri(),
         )
@@ -123,7 +122,7 @@ impl BuildVariant {
         }
 
         // Hold the result of the cargo make call so we can clean up the project directory first.
-        let res = CargoMake::new(&project, &self.arch)?
+        let res = CargoMake::new(&project)?
             .env("TWOLITER_TOOLS_DIR", toolsdir.display().to_string())
             .env("BUILDSYS_ARCH", &self.arch)
             .env("BUILDSYS_VARIANT", &self.variant)

--- a/twoliter/src/cmd/make.rs
+++ b/twoliter/src/cmd/make.rs
@@ -39,7 +39,7 @@ impl Make {
         let toolsdir = project.project_dir().join("build/tools");
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");
-        CargoMake::new(&project, &self.arch)?
+        CargoMake::new(&project)?
             .env("CARGO_HOME", self.cargo_home.display().to_string())
             .env("TWOLITER_TOOLS_DIR", toolsdir.display().to_string())
             .env("BUILDSYS_VERSION_IMAGE", project.release_version())

--- a/twoliter/src/docker/image.rs
+++ b/twoliter/src/docker/image.rs
@@ -1,17 +1,17 @@
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 /// Represents a docker image URI such as `public.ecr.aws/myregistry/myrepo:v0.1.0`. The registry is
 /// optional as it is when using `docker`. That is, it will be looked for locally first, then at
 /// `dockerhub.io` when the registry is absent.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[allow(unused)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 pub(crate) struct ImageUri {
     /// e.g. public.ecr.aws/bottlerocket
-    registry: Option<String>,
+    pub(crate) registry: Option<String>,
     /// e.g. my-repo
-    repo: String,
+    pub(crate) repo: String,
     /// e.g. v0.31.0
-    tag: String,
+    pub(crate) tag: String,
 }
 
 impl ImageUri {
@@ -19,23 +19,34 @@ impl ImageUri {
     #[allow(unused)]
     pub(crate) fn new<S1, S2>(registry: Option<String>, repo: S1, tag: S2) -> Self
     where
-        S1: Into<String>,
-        S2: Into<String>,
+        S1: AsRef<str>,
+        S2: AsRef<str>,
     {
         Self {
             registry,
-            repo: repo.into(),
-            tag: tag.into(),
+            repo: repo.as_ref().into(),
+            tag: tag.as_ref().into(),
         }
     }
 
     /// Returns the `ImageUri` for use with docker, e.g. `public.ecr.aws/myregistry/myrepo:v0.1.0`
-    #[allow(unused)]
     pub(crate) fn uri(&self) -> String {
         match &self.registry {
             None => format!("{}:{}", self.repo, self.tag),
             Some(registry) => format!("{}/{}:{}", registry, self.repo, self.tag),
         }
+    }
+}
+
+impl Display for ImageUri {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.uri(), f)
+    }
+}
+
+impl From<ImageUri> for String {
+    fn from(value: ImageUri) -> Self {
+        value.to_string()
     }
 }
 
@@ -52,81 +63,5 @@ fn image_uri_with_registry() {
     let uri = ImageUri::new(Some("example.com/a/b/c".to_string()), "foo", "v1.2.3");
     let formatted = uri.uri();
     let expected = "example.com/a/b/c/foo:v1.2.3";
-    assert_eq!(expected, formatted);
-}
-
-/// Represents a container URI that is specialized for a target compilation architecture. For
-/// example: `public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.1.0`. The registry is
-/// optional as it is when using `docker`. That is, it will be looked for locally first, then at
-/// `dockerhub.io` when the registry is absent. The `name` is automatically suffixed with the target
-/// architecture when creating a docker image URI.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub(crate) struct ImageArchUri {
-    /// e.g. public.ecr.aws/bottlerocket
-    registry: Option<String>,
-    /// e.g. bottlerocket-sdk
-    name: String,
-    /// e.g. x86_64
-    arch: String,
-    /// e.g. v0.31.0
-    tag: String,
-}
-
-impl ImageArchUri {
-    /// Create a new `ImageArchUri`.
-    pub(crate) fn new<S1, S2, S3>(registry: Option<String>, name: S1, arch: S2, tag: S3) -> Self
-    where
-        S1: AsRef<str>,
-        S2: AsRef<str>,
-        S3: AsRef<str>,
-    {
-        Self {
-            registry,
-            name: name.as_ref().into(),
-            arch: arch.as_ref().into(),
-            tag: tag.as_ref().into(),
-        }
-    }
-
-    /// Returns the `ImageArchUri` for use with docker, e.g.
-    /// `public.ecr.aws/bottlerocket/bottlerocket-sdk-x86_64:v0.1.0`
-    pub(crate) fn uri(&self) -> String {
-        match &self.registry {
-            None => format!("{}-{}:{}", self.name, self.arch, self.tag),
-            Some(registry) => format!("{}/{}-{}:{}", registry, self.name, self.arch, self.tag),
-        }
-    }
-}
-
-impl Display for ImageArchUri {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.uri(), f)
-    }
-}
-
-impl From<ImageArchUri> for String {
-    fn from(value: ImageArchUri) -> Self {
-        value.to_string()
-    }
-}
-
-#[test]
-fn image_arch_uri_no_registry() {
-    let uri = ImageArchUri::new(None, "my-sdk", "i386", "v0.33.1");
-    let formatted = uri.uri();
-    let expected = "my-sdk-i386:v0.33.1";
-    assert_eq!(expected, formatted);
-}
-
-#[test]
-fn image_arch_uri_with_registry() {
-    let uri = ImageArchUri::new(
-        Some("example.com/a/b/c".to_string()),
-        "my-sdk",
-        "i386",
-        "v0.33.1",
-    );
-    let formatted = uri.uri();
-    let expected = "example.com/a/b/c/my-sdk-i386:v0.33.1";
     assert_eq!(expected, formatted);
 }

--- a/twoliter/src/docker/mod.rs
+++ b/twoliter/src/docker/mod.rs
@@ -3,5 +3,4 @@ mod container;
 mod image;
 
 pub(crate) use self::container::DockerContainer;
-#[allow(unused_imports)]
-pub(crate) use self::image::{ImageArchUri, ImageUri};
+pub(crate) use self::image::ImageUri;

--- a/twoliter/src/test/cargo_make.rs
+++ b/twoliter/src/test/cargo_make.rs
@@ -4,7 +4,7 @@ use crate::{cargo_make::CargoMake, project::Project, test::data_dir};
 async fn test_cargo_make() {
     let path = data_dir().join("Twoliter-1.toml");
     let project = Project::load(path).await.unwrap();
-    let cargo_make = CargoMake::new(&project, "arch")
+    let cargo_make = CargoMake::new(&project)
         .unwrap()
         .makefile(data_dir().join("Makefile.toml"));
     cargo_make.exec("verify-twoliter-env").await.unwrap();

--- a/twoliter/src/test/data/Makefile.toml
+++ b/twoliter/src/test/data/Makefile.toml
@@ -8,10 +8,6 @@ script = ['''
         echo "TLPRIVATE_SDK_IMAGE is not set"
         exit 1
     fi
-    if ! [[ -v TLPRIVATE_TOOLCHAIN ]]; then
-        echo "TLPRIVATE_TOOLCHAIN is not set"
-        exit 1
-    fi
 ''']
 
 [tasks.verify-env-set-with-arg]

--- a/twoliter/src/test/data/Twoliter-1.toml
+++ b/twoliter/src/test/data/Twoliter-1.toml
@@ -3,10 +3,5 @@ release-version = "1.0.0"
 
 [sdk]
 registry = "a.com/b"
-name = "my-bottlerocket-sdk"
-version = "v1.2.3"
-
-[toolchain]
-registry = "c.co/d"
-name = "toolchainz"
-version = "v3.4.5"
+repo = "my-bottlerocket-sdk"
+tag = "v1.2.3"

--- a/twoliter/src/test/data/Twoliter-invalid-version.toml
+++ b/twoliter/src/test/data/Twoliter-invalid-version.toml
@@ -3,10 +3,5 @@ release-version = "1.0.0"
 
 [sdk]
 registry = "example.com/my-repos"
-name = "my-bottlerocket-sdk"
-version = "v1.2.3"
-
-[toolchain]
-registry = "example.com/my-repos"
-name = "my-bottlerocket-toolchain"
-version = "v1.2.3"
+repo = "my-bottlerocket-sdk"
+tag = "v1.2.3"


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/156

**Description of changes:**
Adapt `Dockerfile` and `Makefile.toml` to the breaking changes in the unified SDK - merge the right architecture's macros prior to building RPMs, and add a subset of the target's binutils to `$PATH` so that `find-debuginfo.sh` works.

Update `twoliter` to remove the need to suffix the SDK image with the target's architecture, and to get rid of the toolchain image entirely.

Fix the alpha SDK script to generate two images rather than the previous four.

**Testing done:**
Used the updated `twoliter` to build Bottlerocket images with this `Twoliter.toml`:
```
schema-version = 1
release-version = "1.19.3"

[sdk]
registry = "public.ecr.aws/c2b5m1s5"
repo = "thar-be-a-beta-sdk"
tag = "v0.40.0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
