### PR TITLE
make upstream-source-fallback a non-positional arg

### DIFF
--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -42,6 +42,7 @@ pub(crate) struct BuildVariant {
 
     /// If sources are not found in the lookaside cache, this flag will cause buildsys to pull them
     /// from the upstream URL found in a package's `Cargo.toml`.
+    #[clap(long = "upstream-source-fallback")]
     upstream_source_fallback: bool,
 }
 


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

make upstream-source-fallback a non-positional arg


Without this change, twoliter fails to run for me.  Maybe a new change in clap?
```sh
$ twoliter build variant help
thread 'main' panicked at /home/ec2-user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.6/src/builder/debug_asserts.rs:747:9:
Argument 'upstream_source_fallback` is positional and it must take a value but action is SetTrue
```

**Testing done:**
`cargo test`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
