### PR TITLE
testsys: provide assume agent role to workload crd

### DIFF
--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -143,6 +143,7 @@ pub(crate) fn workload_crd(test_input: TestInput) -> Result<Test> {
         .keep_running(true)
         .kubeconfig_base64_template(cluster_resource_name, "encodedKubeconfig")
         .tests(plugins)
+        .assume_role(test_input.crd_input.config.agent_role.to_owned())
         .set_secrets(Some(test_input.crd_input.config.secrets.to_owned()))
         .set_labels(Some(labels))
         .build(format!(


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
testsys: provide assume agent role to workload crd


**Testing done:**
Launch workload test for `aws-k8s-1.27` and `aws-k8s-1.27-nvidia`
```
cargo make -e TWOLITER_ALLOW_SOURCE_INSTALL=true \
           -e TWOLITER_ALLOW_BINARY_INSTALL=false  \
           -e TWOLITER_REPO="https://github.com/gthao313/twoliter.git" \
           -e TWOLITER_VERSION="v0.0.2" \
           -e TESTSYS_KUBECONFIG=${TESTSYS_KUBECONFIG} \
           -e TESTSYS_TEST=workload \
           -e BUILDSYS_VARIANT=aws-k8s-1.27 \
           -e BUILDSYS_ARCH=x86_64 \
           -e TESTSYS_TEST_CONFIG_PATH=Test.toml \
           test
```

result
```
 NAME                                                          TYPE                   STATE                                    PASSED                   FAILED                   SKIPPED   BUILD ID                   LAST UPDATE
 cluster-ipv4-test                                             Test                   passed                                        1                        0                         0   d533ff69                   2024-03-15T07:39:10Z
 x86-64-aws-k8s-127-nvidia-cluster-ipv4-test                   Test                   passed                                        2                        0                         0   d533ff69                   2024-03-15T07:34:05Z
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
