### PR TITLE
add FIPS-related functionality

### DIFF
--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -134,6 +134,18 @@ pub(crate) struct BuildVariantArgs {
     #[arg(long, env = "BUILDSYS_VARIANT")]
     pub(crate) variant: String,
 
+    #[arg(long, env = "BUILDSYS_VARIANT_PLATFORM")]
+    pub(crate) variant_platform: String,
+
+    #[arg(long, env = "BUILDSYS_VARIANT_RUNTIME")]
+    pub(crate) variant_runtime: String,
+
+    #[arg(long, env = "BUILDSYS_VARIANT_FAMILY")]
+    pub(crate) variant_family: String,
+
+    #[arg(long, env = "BUILDSYS_VARIANT_FLAVOR")]
+    pub(crate) variant_flavor: String,
+
     #[arg(long, env = "BUILDSYS_VERSION_BUILD")]
     pub(crate) version_build: String,
 

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -160,6 +160,10 @@ struct VariantBuildArgs {
     partition_plan: String,
     pretty_name: String,
     variant: String,
+    variant_family: String,
+    variant_flavor: String,
+    variant_platform: String,
+    variant_runtime: String,
     version_build: String,
     version_image: String,
 }
@@ -183,6 +187,10 @@ impl VariantBuildArgs {
         args.build_arg("PARTITION_PLAN", &self.partition_plan);
         args.build_arg("PRETTY_NAME", &self.pretty_name);
         args.build_arg("VARIANT", &self.variant);
+        args.build_arg("VARIANT_FAMILY", &self.variant_family);
+        args.build_arg("VARIANT_FLAVOR", &self.variant_flavor);
+        args.build_arg("VARIANT_PLATFORM", &self.variant_platform);
+        args.build_arg("VARIANT_RUNTIME", &self.variant_runtime);
         args.build_arg("BUILD_ID", &self.version_build);
         args.build_arg("VERSION_ID", &self.version_image);
 
@@ -194,6 +202,7 @@ impl VariantBuildArgs {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum TargetBuildArgs {
     Package(PackageBuildArgs),
     Variant(VariantBuildArgs),
@@ -334,6 +343,10 @@ impl DockerBuild {
                 .to_string(),
                 pretty_name: args.pretty_name,
                 variant: args.variant,
+                variant_family: args.variant_family,
+                variant_flavor: args.variant_flavor,
+                variant_platform: args.variant_platform,
+                variant_runtime: args.variant_runtime,
                 version_build: args.version_build,
                 version_image: args.version_image,
             }),

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -233,6 +233,15 @@ when the platform supports it.
 uefi-secure-boot = true
 ```
 
+`fips` means that FIPS-certified modules will be used for cryptographic operations. This affects
+the kernel at runtime. It also causes alternate versions of Go and Rust programs that use
+FIPS-compliant ciphers to be included in the image.
+
+```ignore
+[package.metadata.build-variant.image-features]
+fips = true
+```
+
 */
 
 mod error;
@@ -529,6 +538,7 @@ pub enum ImageFeature {
     UnifiedCgroupHierarchy,
     XfsDataPartition,
     UefiSecureBoot,
+    Fips,
 }
 
 impl TryFrom<String> for ImageFeature {
@@ -540,6 +550,7 @@ impl TryFrom<String> for ImageFeature {
             "unified-cgroup-hierarchy" => Ok(ImageFeature::UnifiedCgroupHierarchy),
             "xfs-data-partition" => Ok(ImageFeature::XfsDataPartition),
             "uefi-secure-boot" => Ok(ImageFeature::UefiSecureBoot),
+            "fips" => Ok(ImageFeature::Fips),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -553,6 +564,7 @@ impl fmt::Display for ImageFeature {
             ImageFeature::UnifiedCgroupHierarchy => write!(f, "UNIFIED_CGROUP_HIERARCHY"),
             ImageFeature::XfsDataPartition => write!(f, "XFS_DATA_PARTITION"),
             ImageFeature::UefiSecureBoot => write!(f, "UEFI_SECURE_BOOT"),
+            ImageFeature::Fips => write!(f, "FIPS"),
         }
     }
 }

--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -34,6 +34,7 @@ fn main() {
     paths.copy_file("rpm2img");
     paths.copy_file("rpm2kmodkit");
     paths.copy_file("rpm2migrations");
+    paths.copy_file("metadata.spec");
 
     // Create tarball in memory.
     println!("Starting tarball creation at {:?}", SystemTime::now());

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -75,7 +75,7 @@ RUN \
    && echo "%_cross_variant_platform ${VARIANT_PLATFORM}" >> "${RPM_MACROS}" \
    && echo "%_cross_variant_runtime ${VARIANT_RUNTIME}" >> "${RPM_MACROS}" \
    && echo "%_cross_variant_family ${VARIANT_FAMILY}" >> "${RPM_MACROS}" \
-   && echo "%_cross_variant_flavor ${VARIANT_FAMILY:-none}" >> "${RPM_MACROS}" \
+   && echo "%_cross_variant_flavor ${VARIANT_FLAVOR:-none}" >> "${RPM_MACROS}" \
    && echo "%_cross_repo_root_json %{_builddir}/root.json" >> "${RPM_MACROS}" \
    && echo "%_topdir /home/builder/rpmbuild" >> "${RPM_MACROS}" \
    && echo "%bcond_without $(V=${VARIANT_PLATFORM,,}; echo ${V//-/_})_platform" > "${RPM_BCONDS}" \

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -65,6 +65,7 @@ ARG UEFI_SECURE_BOOT
 ARG SYSTEMD_NETWORKD
 ARG UNIFIED_CGROUP_HIERARCHY
 ARG XFS_DATA_PARTITION
+ARG FIPS
 
 USER builder
 WORKDIR /home/builder
@@ -83,6 +84,7 @@ RUN \
    && echo "%bcond_without $(V=${VARIANT_FAMILY,,}; echo ${V//-/_})_family" >> "${RPM_BCONDS}" \
    && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> "${RPM_BCONDS}" \
    && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${FIPS:+%bcond_without fips\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> "${RPM_BCONDS}" \

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -174,18 +174,35 @@ FROM sdk AS repobuild
 ARG PACKAGES
 ARG ARCH
 ARG NOCACHE
-WORKDIR /root
 
+WORKDIR /home/builder
+USER builder
+
+COPY --chown=builder --from=rpm-macros-and-bconds /home/builder/generated.* .
+
+# Build the metadata RPM for the variant.
+RUN --mount=target=/host \
+   cat "/usr/lib/rpm/platform/${ARCH}-bottlerocket/macros" generated.rpmmacros > .rpmmacros \
+   && cat generated.bconds /host/build/tools/metadata.spec >> rpmbuild/SPECS/metadata.spec \
+   && rpmbuild -ba --clean \
+      --undefine _auto_set_build_flags \
+      --define "_target_cpu ${ARCH}" \
+      rpmbuild/SPECS/metadata.spec \
+   && rpm -qp --provides rpmbuild/RPMS/${ARCH}/bottlerocket-metadata-*.${ARCH}.rpm \
+   && echo ${NOCACHE}
+
+WORKDIR /root
 USER root
 RUN --mount=target=/host \
     mkdir -p /local/rpms ./rpmbuild/RPMS \
     && ln -s /host/build/rpms/*.rpm ./rpmbuild/RPMS \
+    && ln -s /home/builder/rpmbuild/RPMS/*/*.rpm ./rpmbuild/RPMS \
     && createrepo_c \
         -o ./rpmbuild/RPMS \
         -x '*-debuginfo-*.rpm' \
         -x '*-debugsource-*.rpm' \
         --no-database \
-        /host/build/rpms \
+        ./rpmbuild/RPMS \
     && echo '%_dbpath %{_sharedstatedir}/rpm' >> /etc/rpm/macros \
     && dnf -y \
         --disablerepo '*' \
@@ -195,7 +212,7 @@ RUN --mount=target=/host \
         --downloadonly \
         --downloaddir . \
         --forcearch "${ARCH}" \
-        install $(printf "bottlerocket-%s\n" ${PACKAGES}) \
+        install $(printf "bottlerocket-%s\n" metadata ${PACKAGES}) \
     && mv *.rpm /local/rpms \
     && createrepo_c /local/rpms \
     && echo ${NOCACHE}

--- a/twoliter/embedded/Dockerfile
+++ b/twoliter/embedded/Dockerfile
@@ -53,22 +53,50 @@ COPY --chown=1000:1000 --from=sdk /tmp /variantcache
 COPY --chown=1000:1000 Twoliter.toml /variantcache/.${PACKAGE}.${ARCH}.${VARIANT}.${TOKEN}
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
+# Generate the expected RPM macros and bconds.
+FROM sdk as rpm-macros-and-bconds
+ARG VARIANT
+ARG VARIANT_PLATFORM
+ARG VARIANT_RUNTIME
+ARG VARIANT_FAMILY
+ARG VARIANT_FLAVOR
+ARG GRUB_SET_PRIVATE_VAR
+ARG UEFI_SECURE_BOOT
+ARG SYSTEMD_NETWORKD
+ARG UNIFIED_CGROUP_HIERARCHY
+ARG XFS_DATA_PARTITION
+
+USER builder
+WORKDIR /home/builder
+RUN \
+   export RPM_MACROS="generated.rpmmacros" \
+   && export RPM_BCONDS="generated.bconds" \
+   && echo "%_cross_variant ${VARIANT}" > "${RPM_MACROS}" \
+   && echo "%_cross_variant_platform ${VARIANT_PLATFORM}" >> "${RPM_MACROS}" \
+   && echo "%_cross_variant_runtime ${VARIANT_RUNTIME}" >> "${RPM_MACROS}" \
+   && echo "%_cross_variant_family ${VARIANT_FAMILY}" >> "${RPM_MACROS}" \
+   && echo "%_cross_variant_flavor ${VARIANT_FAMILY:-none}" >> "${RPM_MACROS}" \
+   && echo "%_cross_repo_root_json %{_builddir}/root.json" >> "${RPM_MACROS}" \
+   && echo "%_topdir /home/builder/rpmbuild" >> "${RPM_MACROS}" \
+   && echo "%bcond_without $(V=${VARIANT_PLATFORM,,}; echo ${V//-/_})_platform" > "${RPM_BCONDS}" \
+   && echo "%bcond_without $(V=${VARIANT_RUNTIME,,}; echo ${V//-/_})_runtime" >> "${RPM_BCONDS}" \
+   && echo "%bcond_without $(V=${VARIANT_FAMILY,,}; echo ${V//-/_})_family" >> "${RPM_BCONDS}" \
+   && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> "${RPM_BCONDS}" \
+   && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> "${RPM_BCONDS}"
+
+# =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Builds an RPM package from a spec file.
 FROM sdk AS rpmbuild
 ARG PACKAGE
 ARG ARCH
 ARG NOCACHE
 ARG VARIANT
-ARG VARIANT_PLATFORM
-ARG VARIANT_RUNTIME
-ARG VARIANT_FAMILY
-ARG VARIANT_FLAVOR
 ARG REPO
-ARG GRUB_SET_PRIVATE_VAR
-ARG UEFI_SECURE_BOOT
 ARG SYSTEMD_NETWORKD
-ARG UNIFIED_CGROUP_HIERARCHY
-ARG XFS_DATA_PARTITION
 ENV SYSTEMD_NETWORKD=${SYSTEMD_NETWORKD}
 ENV VARIANT=${VARIANT}
 WORKDIR /home/builder
@@ -87,25 +115,13 @@ RUN --mount=target=/host \
   && cp -r /host/licenses ./rpmbuild/BUILD/ \
   || mkdir ./rpmbuild/BUILD/licenses )
 COPY ./packages/${PACKAGE}/ .
+
+COPY --chown=builder --from=rpm-macros-and-bconds /home/builder/generated.* .
+
+# Merge generated bconds with the package spec, and put sources in the right place.
 RUN \
-   cp "/usr/lib/rpm/platform/${ARCH}-bottlerocket/macros" .rpmmacros \
-   && echo "%_cross_variant ${VARIANT}" >> .rpmmacros \
-   && echo "%_cross_variant_platform ${VARIANT_PLATFORM}" >> .rpmmacros \
-   && echo "%_cross_variant_runtime ${VARIANT_RUNTIME}" >> .rpmmacros \
-   && echo "%_cross_variant_family ${VARIANT_FAMILY}" >> .rpmmacros \
-   && echo "%_cross_variant_flavor ${VARIANT_FAMILY:-none}" >> .rpmmacros \
-   && echo "%_cross_repo_root_json %{_builddir}/root.json" >> .rpmmacros \
-   && echo "%_topdir /home/builder/rpmbuild" >> .rpmmacros \
-   && echo "%bcond_without $(V=${VARIANT_PLATFORM,,}; echo ${V//-/_})_platform" > .bconds \
-   && echo "%bcond_without $(V=${VARIANT_RUNTIME,,}; echo ${V//-/_})_runtime" >> .bconds \
-   && echo "%bcond_without $(V=${VARIANT_FAMILY,,}; echo ${V//-/_})_family" >> .bconds \
-   && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> .bconds \
-   && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> .bconds \
-   && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> .bconds \
-   && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> .bconds \
-   && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> .bconds \
-   && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> .bconds \
-   && cat .bconds ${PACKAGE}.spec >> rpmbuild/SPECS/${PACKAGE}.spec \
+   cat "/usr/lib/rpm/platform/${ARCH}-bottlerocket/macros" generated.rpmmacros > .rpmmacros \
+   && cat generated.bconds ${PACKAGE}.spec >> rpmbuild/SPECS/${PACKAGE}.spec \
    && find . -maxdepth 1 -not -path '*/\.*' -type f -exec mv {} rpmbuild/SOURCES/ \; \
    && echo ${NOCACHE}
 

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -44,6 +44,12 @@ Provides: %{_cross_os}image-feature(xfs-data-partition)
 Provides: %{_cross_os}image-feature(no-xfs-data-partition)
 %endif
 
+%if %{with fips}
+Provides: %{_cross_os}image-feature(fips)
+%else
+Provides: %{_cross_os}image-feature(no-fips)
+%endif
+
 %description
 %{summary}.
 

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -1,0 +1,58 @@
+%global cross_generate_attribution %{nil}
+
+Name: %{_cross_os}metadata
+Version: 1.0
+Release: 1%{?dist}
+Summary: Bottlerocket metadata
+
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/twoliter
+
+Provides: %{_cross_os}variant(%{_cross_variant})
+Provides: %{_cross_os}variant-platform(%{_cross_variant_platform})
+Provides: %{_cross_os}variant-runtime(%{_cross_variant_runtime})
+Provides: %{_cross_os}variant-family(%{_cross_variant_family})
+Provides: %{_cross_os}variant-flavor(%{_cross_variant_flavor})
+
+%if %{with grub_set_private_var}
+Provides: %{_cross_os}image-feature(grub-set-private-var)
+%else
+Provides: %{_cross_os}image-feature(no-grub-set-private-var)
+%endif
+
+%if %{with uefi_secure_boot}
+Provides: %{_cross_os}image-feature(uefi-secure-boot)
+%else
+Provides: %{_cross_os}image-feature(no-uefi-secure-boot)
+%endif
+
+%if %{with systemd_networkd}
+Provides: %{_cross_os}image-feature(systemd-networkd)
+%else
+Provides: %{_cross_os}image-feature(no-systemd-networkd)
+%endif
+
+%if %{with unified_cgroup_hierarchy}
+Provides: %{_cross_os}image-feature(unified-cgroup-hierarchy)
+%else
+Provides: %{_cross_os}image-feature(no-unified-cgroup-hierarchy)
+%endif
+
+%if %{with xfs_data_partition}
+Provides: %{_cross_os}image-feature(xfs-data-partition)
+%else
+Provides: %{_cross_os}image-feature(no-xfs-data-partition)
+%endif
+
+%description
+%{summary}.
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -139,6 +139,9 @@ VERITY_HASH_ALGORITHM=sha256
 VERITY_DATA_BLOCK_SIZE=4096
 VERITY_HASH_BLOCK_SIZE=4096
 
+BOOTCONFIG_DIR="$(mktemp -d)"
+BOOTCONFIG_INPUT="${BOOTCONFIG_DIR}/bootconfig.in"
+
 # Bottlerocket has been experimentally shown to boot faster on EBS volumes when striping the root filesystem into 4MiB stripes.
 # We use 4kb ext4 blocks. The stride and stripe should both be $STRIPE_SIZE / $EXT4_BLOCK_SIZE
 ROOT_STRIDE=1024
@@ -589,6 +592,31 @@ if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
   gpg --verify "${BOOT_MOUNT}/grub/grub.cfg.sig"
 fi
 
+# Combine any bootconfig snippets in /boot for later use, then clean up.
+if [ -d "${BOOT_MOUNT}/boot-config.d" ] ; then
+  find "${BOOT_MOUNT}/boot-config.d" -type f -mindepth 1 -maxdepth 1 -print0 \
+    | sort -Vz | xargs -0 cat > "${BOOTCONFIG_INPUT}"
+  rm -rf "${BOOT_MOUNT}/boot-config.d"
+fi
+
+# This should never happen, but if the image isn't using "grub-set-private-var"
+# and we have some bootconfig input to render, then bail out because otherwise
+# the kernel command line may not be configured as expected.
+if [ -s "${BOOTCONFIG_INPUT}" ] && [ "${GRUB_SET_PRIVATE_VAR}" == "no" ] ; then
+cat <<EOF >&2
+Found bootconfig snippets but 'grub-set-private-var' isn't enabled for the variant.
+To fix this, add the following to the variant's Cargo.toml:"
+  [package.metadata.build-variant.image-features]
+  grub-set-private-var = true
+EOF
+exit 1
+fi
+
+# Generate a no-op bootconfig if there weren't any snippets.
+if [ ! -s  "${BOOTCONFIG_INPUT}" ] ; then
+  echo -e "kernel {}\ninit {}" > "${BOOTCONFIG_INPUT}"
+fi
+
 # BOTTLEROCKET-BOOT-A
 mkdir -p "${BOOT_MOUNT}/lost+found"
 chmod -R go-rwx "${BOOT_MOUNT}"
@@ -602,15 +630,9 @@ dd if="${BOOT_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[BOOT-A
 
 # BOTTLEROCKET-PRIVATE
 
-# Generate an empty bootconfig file for the image, so grub doesn't pause and
-# print an error that the file doesn't exist.
-cat <<EOF > "${PRIVATE_MOUNT}/bootconfig.in"
-kernel {}
-init {}
-EOF
+# Generate bootconfig file for the image.
 touch "${PRIVATE_MOUNT}/bootconfig.data"
-bootconfig -a "${PRIVATE_MOUNT}/bootconfig.in" "${PRIVATE_MOUNT}/bootconfig.data"
-rm "${PRIVATE_MOUNT}/bootconfig.in"
+bootconfig -a "${BOOTCONFIG_INPUT}" "${PRIVATE_MOUNT}/bootconfig.data"
 
 # Targeted toward the current API server implementation.
 # Relative to the ext4 defaults, we:

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -111,6 +111,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("rpm2img").is_file());
     assert!(toolsdir.join("rpm2kmodkit").is_file());
     assert!(toolsdir.join("rpm2migrations").is_file());
+    assert!(toolsdir.join("metadata.spec").is_file());
 
     // Check that binaries were copied.
     assert!(toolsdir.join("bottlerocket-variant").is_file());


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**
The overall aim of this series is to expose the variant's image features as (RPM) package-level metadata, so that packages can add sub-packages that affinitize (or anti-affinitize) to those features. This avoids the need to hardcode the exact list of packages required to support a particular feature. In the case of FIPS, a hardcoded list is unworkable, since most Go binaries need to be built to use FIPS and non-FIPS crypto, and different variants install a different set of Go binaries - most obviously, `kubelet` or `ecs-agent`.

I've added support for bootconfig drop-ins as well: any such drop-ins will be collected and used to populate the default bootconfig file, which was previously empty. In combination with the metadata feature, this can be used so that the bootconfig snippet `kernel.fips = 1` is installed if the `fips` image feature is set. We can also use it to eliminate the conditional compilation of systemd, by adding the bootconfig snippet `init.systemd.unified_cgroup_hierarchy = 1` if the `unified-cgroup-hierarchy` feature is set.

I plan to build on the image feature metadata functionality in follow-up changes, for example to support feature flags like `in-place-updates`, `host-containers`, and `kmod-development` that control whether the related packages are installed. These may also involve changes to `rpm2img`, but my hope is to do that sparingly. For example, `in-place-updates` might control whether the image has one or two partition banks, and whether a migrations archive is produced, but otherwise all the functionality would come through the installation of optional packages.

**Testing done:**
My [fips-and-non-fips](https://github.com/bcressey/bottlerocket/commits/fips-and-non-fips/) branch shows how this feature is used to arrange for the correct set of Go binaries to be installed depending on the image feature.

These two commits demonstrate how bootconfig drop-ins will work:
* [systemd: use bootconfig for unified cgroup hierarchy](https://github.com/bcressey/bottlerocket/commit/2af0c7bfb33bc5c7a6ee88ef3bdb8cd28fb509b1)
* [release: add subpackage for fips](https://github.com/bcressey/bottlerocket/commit/d42d8bceae4e380b9052b4f72480537aea325580)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
