### PR TITLE
generate HMAC for kernel on build

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -451,14 +451,19 @@ mkdir -p "${ROOT_MOUNT}/boot/grub"
 # Now that we're done messing with /, move /boot out of it
 mv "${ROOT_MOUNT}/boot"/* "${BOOT_MOUNT}"
 
+pushd "${BOOT_MOUNT}" >/dev/null
+
+vmlinuz="vmlinuz"
 if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
-  pushd "${BOOT_MOUNT}" >/dev/null
-  vmlinuz="vmlinuz"
   pesign -i "${vmlinuz}" -o "${vmlinuz}.signed" -s "${CODE_SIGN_KEY[@]}"
   mv "${vmlinuz}.signed" "${vmlinuz}"
   pesigcheck -i "${vmlinuz}" -n 0 -c "${SBKEYS}/vendor.cer"
-  popd >/dev/null
 fi
+
+# Generate an HMAC for the kernel after signing.
+sha512hmac "${vmlinuz}" > ".${vmlinuz}.hmac"
+
+popd >/dev/null
 
 # Set the Bottlerocket variant, version, and build-id
 SYS_ROOT="${ARCH}-bottlerocket-linux-gnu/sys-root"


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**
Generate a SHA-512 HMAC for the kernel during the image build. This must occur after the Secure Boot signing step.


**Testing done:**
Ran `sha512hmac -c .vmlinuz.hmac` on a VM with FIPS enabled. Check passed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
