### PR TITLE
Add aws-ecs-1 to Alpha SDK

### DIFF
--- a/local/alpha-sdk.sh
+++ b/local/alpha-sdk.sh
@@ -161,6 +161,11 @@ do
     build-variant
 
   cargo make \
+    -e "BUILDSYS_VARIANT=aws-ecs-1" \
+    -e "BUILDSYS_ARCH=${target_arch}" \
+    build-variant
+
+  cargo make \
     -e "BUILDSYS_VARIANT=${variant}" \
     -e "BUILDSYS_ARCH=${target_arch}" \
     build-variant


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

This adds the `aws-ecs-1` variant to the Alpha SDK

**Testing done:**

I built my own Alpha SDK and confirmed I had access to the binaries in the ECS 1 variant

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
