### PR TITLE
rpm2img: use openssl to generate HMAC

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -461,7 +461,9 @@ if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
 fi
 
 # Generate an HMAC for the kernel after signing.
-sha512hmac "${vmlinuz}" > ".${vmlinuz}.hmac"
+openssl sha512 -hmac FIPS-FTW-RHT2009 -hex "${vmlinuz}" \
+  | awk -v vmlinuz="${vmlinuz}" '{ print $2 "  " vmlinuz }' \
+  > ".${vmlinuz}.hmac"
 
 popd >/dev/null
 


### PR DESCRIPTION
**Issue number:**

Closes #195

**Description of changes:**
The `sha512hmac` tool from libkcapi requires the kernel to be built with CRYPTO_USER support. If this dependency is not satisfied, the signature generation fails with this message:
```
  Error: Netlink error: sendmsg failed
  Error: NETLINK_CRYPTO: cannot obtain cipher information for hmac(sha512)
```

Generate the HMAC with `openssl` instead, which does not require any specific kernel functionality.


**Testing done:**
Verified that the generated HMAC can be validated at runtime with `sha512hmac`:
```
bash-5.2# cd /boot
bash-5.2# sha512hmac -c .vmlinuz.hmac
vmlinuz: OK
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
