### PR TITLE
Unified alpha sdk

### DIFF
--- a/local/alpha-sdk.sh
+++ b/local/alpha-sdk.sh
@@ -49,8 +49,9 @@ Usage:
     --bottlerocket-dir            REQUIRED: The directory of the Bottlerocket checkout that we will
                                   build.
 
-    --variants                    OPTIONAL: The space-delimited of Bottlerocket variant that we will
-                                  build. Defaults to 'aws-dev'.
+    --variants                    OPTIONAL: The space-delimited list of Bottlerocket variants that
+                                  we will build. Defaults to 'aws-dev'. For example:
+                                  "aws-dev aws-ecs-1 aws-ecs-2"
 
     --sdk-version                 OPTIONAL: The version of the Bottlerocket SDK to use when building
                                   packages and to use as the base for the Twoliter alpha-sdk. For

--- a/tests/projects/project1/variants/hello-ootb/Cargo.toml
+++ b/tests/projects/project1/variants/hello-ootb/Cargo.toml
@@ -23,7 +23,6 @@ included-packages = [
     "docker-cli",
     "docker-engine",
     "docker-init",
-    "docker-proxy",
     # tools
     "login",
     "iputils",


### PR DESCRIPTION


**Issue number:**

Closes #192

**Description of changes:**

Change the alpha-sdk.sh script to work with the new unified SDK and to
allow the script user to choose which variants to build serially.

test/projects/project1 included a package that no longer exists.

**Testing done:**

Built an alpha-sdk and used it to build `tests/projects/project1`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
