### PR TITLE
rpm2img: regenerate kernel module info if possible

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -240,6 +240,20 @@ INVENTORY_DATA="$(jq --arg PKG_PREFIX "bottlerocket-" \
 INVENTORY_DATA="$(jq --slurp 'sort_by(.Name)' <<< "${INVENTORY_DATA}" | jq '{"Content": .}')"
 printf "%s\n" "${INVENTORY_DATA}" > "${ROOT_MOUNT}/usr/share/bottlerocket/application-inventory.json"
 
+# Regenerate module dependencies, if possible.
+KMOD_DIR="${ROOT_MOUNT}/lib/modules"
+for kver in "$(find "${KMOD_DIR}" -mindepth 1 -maxdepth 1 -type d -printf '%P\n')" ; do
+  system_map="${KMOD_DIR}/${kver}/System.map"
+  [ -s "${system_map}" ] || continue
+  depmod_out="$(mktemp)"
+  depmod -a -e -b "${ROOT_MOUNT}" -F "${system_map}" "${kver}" >"${depmod_out}" 2>&1
+  if grep -E '(WARNING|ERROR|FATAL)' "${depmod_out}" ; then
+    echo "Failed to run depmod" >&2
+    exit 1
+  fi
+  rm -f "${system_map}"
+done
+
 # install licenses
 mksquashfs \
   "${ROOT_MOUNT}"/usr/share/licenses \


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/pull/3932

**Description of changes:**
With conditional compilation being eliminated, it is no longer always the case that all of the modules built by the kernel package will be installed on all variants. For example, some network device drivers may be built as modules and only installed on bare metal variants, if the corresponding hardware is not expected to show up in virtualized environments.

This requires some care in packaging so that any module dependencies that are not provided by the kernel will be provided by other modules that are also installed. By regenerating module info at image build time, it's guaranteed to be present and correct, or otherwise the build will fail.


**Testing done:**
While testing the related pull request, I verified that modules in the new `modules-metal` package were not present in the regenerated modinfo.

I also verified that removing a dependency of a module resulted in a build failure. (`depmod` does not have an option to exit non-zero after emitting a warning, which is why `rpm2img` captures the output and inspects it with `grep`.)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
