### PR TITLE
Fix tmp files being created in project directory

### DIFF
--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -57,7 +57,7 @@ impl BuildVariant {
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");
         // A temporary directory in the `build` directory
-        let build_temp_dir = TempDir::new_in(project.project_dir())
+        let build_temp_dir = TempDir::new_in("/tmp")
             .context("Unable to create a tempdir for Twoliter's build")?;
         let packages_dir = build_temp_dir.path().join("sdk_rpms");
         fs::create_dir_all(&packages_dir).await?;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #180

**Description of changes:**

This issue is probably reproducible on every variant (tested on 1) when SIGINT or SIGSTP (or SIGTERM) is called on the build process in a linux host, temp files are not cleared. This is expected behavior as per https://docs.rs/tempfile/latest/tempfile/struct.TempDir.html#resource-leaking as the destructors are never called. The build.rs where these files are created are [here](https://github.com/bottlerocket-os/twoliter/blob/develop/twoliter/src/cmd/build.rs#L60).

Instead we will create these files under /tmp as suggested by @webern . This allows us to keep the current build directory clean.

**Testing done:**

When a `SIGINT` or `SIGSTP` (ctrl+c and ctrl+z) is called, I see the file created in the tmp directory. For example:

```
/tmp/.tmpXYZ
```

When no such interruption is provided, watching a directory, I see a file created, then deleted eventually when it goes out of scope.

```
Every 2.0s: ls -a | grep "^\.tmp"                                                                                             Wed May  8 09:45:02 2024

.tmpi6qmGD
.tmpM1RQq1
```

But eventually it was cleared
```
Every 2.0s: ls -a | grep "^\.tmp"                                                                                             Wed May  8 09:45:02 2024

.tmpM1RQq1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
