### PR TITLE
update twoliter and buildsys to put RPMs into per-package sub-directories

### DIFF
--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -119,9 +119,6 @@ pub(crate) struct BuildPackageArgs {
     #[arg(long, env = "BUILDSYS_UPSTREAM_SOURCE_FALLBACK")]
     pub(crate) upstream_source_fallback: String,
 
-    #[arg(long, env = "CARGO_PKG_NAME")]
-    pub(crate) cargo_package_name: String,
-
     #[command(flatten)]
     pub(crate) common: Common,
 }

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -247,12 +247,7 @@ impl DockerBuild {
         manifest: &Manifest,
         image_features: HashSet<ImageFeature>,
     ) -> Result<Self> {
-        let package = if let Some(name_override) = manifest.info().package_name() {
-            name_override.clone()
-        } else {
-            args.cargo_package_name
-        };
-
+        let package = manifest.info().package_name();
         Ok(Self {
             dockerfile: args.common.tools_dir.join("Dockerfile"),
             context: args.common.root_dir.clone(),
@@ -268,7 +263,7 @@ impl DockerBuild {
             root_dir: args.common.root_dir.clone(),
             artifacts_dir: args.packages_dir,
             state_dir: args.common.state_dir,
-            artifact_name: package.clone(),
+            artifact_name: package.to_string(),
             common_build_args: CommonBuildArgs::new(
                 &args.common.root_dir,
                 args.common.sdk_image,
@@ -276,7 +271,7 @@ impl DockerBuild {
             ),
             target_build_args: TargetBuildArgs::Package(PackageBuildArgs {
                 image_features,
-                package,
+                package: package.to_string(),
                 package_dependencies: manifest.package_dependencies().context(error::GraphSnafu)?,
                 kit_dependencies: manifest.kit_dependencies().context(error::GraphSnafu)?,
                 publish_repo: args.publish_repo,

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -248,6 +248,13 @@ impl DockerBuild {
         image_features: HashSet<ImageFeature>,
     ) -> Result<Self> {
         let package = manifest.info().package_name();
+        let per_package_dir = format!(
+            "{}/{}",
+            args.packages_dir.display(),
+            manifest.info().manifest_name()
+        )
+        .into();
+
         Ok(Self {
             dockerfile: args.common.tools_dir.join("Dockerfile"),
             context: args.common.root_dir.clone(),
@@ -261,7 +268,7 @@ impl DockerBuild {
                 &args.common.root_dir,
             ),
             root_dir: args.common.root_dir.clone(),
-            artifacts_dir: args.packages_dir,
+            artifacts_dir: per_package_dir,
             state_dir: args.common.state_dir,
             artifact_name: package.to_string(),
             common_build_args: CommonBuildArgs::new(

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -214,11 +214,7 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
 
     // Package developer can override name of package if desired, e.g. to name package with
     // characters invalid in Cargo crate names
-    let package = if let Some(name_override) = manifest.info().package_name() {
-        name_override.clone()
-    } else {
-        args.cargo_package_name.clone()
-    };
+    let package = manifest.info().package_name();
     let spec = format!("{}.spec", package);
     println!("cargo:rerun-if-changed={}", spec);
 

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -397,9 +397,13 @@ impl ManifestInfo {
         self.build_package().and_then(|b| b.external_files.as_ref())
     }
 
-    /// Convenience method to return the package name override, if any.
-    pub fn package_name(&self) -> Option<&String> {
-        self.build_package().and_then(|b| b.package_name.as_ref())
+    /// Convenience method to return the package name. If the manifest has an override in the
+    /// `package.metadata.build-package.package-name` key, it is returned, otherwise the Cargo
+    /// manifest name is returned from `package.name`.
+    pub fn package_name(&self) -> &str {
+        self.build_package()
+            .and_then(|b| b.package_name.as_ref().map(|s| s.as_str()))
+            .unwrap_or_else(|| self.manifest_name())
     }
 
     /// Convenience method to find whether the package is sensitive to variant changes.

--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -32,6 +32,7 @@ fn main() {
     paths.copy_file("docker-go");
     paths.copy_file("partyplanner");
     paths.copy_file("rpm2img");
+    paths.copy_file("rpm2kit");
     paths.copy_file("rpm2kmodkit");
     paths.copy_file("rpm2migrations");
     paths.copy_file("metadata.spec");

--- a/twoliter/embedded/Dockerfile.dockerignore
+++ b/twoliter/embedded/Dockerfile.dockerignore
@@ -3,9 +3,10 @@
 /build/*
 !/build/rpms/
 /build/rpms/*
-!/build/rpms/*.rpm
-/build/rpms/*-debuginfo-*.rpm
-/build/rpms/*-debugsource-*.rpm
+!/build/rpms/*/*.rpm
+/build/rpms/*/*-debuginfo-*.rpm
+/build/rpms/*/*-debugsource-*.rpm
+!/build/kits/
 !/build/tools/*
 **/target/*
 /sbkeys

--- a/twoliter/embedded/rpm2kit
+++ b/twoliter/embedded/rpm2kit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Create a kit from RPM package inputs.
+set -eu -o pipefail
+
+declare -a PACKAGES
+
+for opt in "$@"; do
+   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
+   case "${opt}" in
+      --packages-dir=*) PACKAGES_DIR="${optarg}" ;;
+      --package=*) PACKAGES+=("${optarg}") ;;
+      --output-dir=*) OUTPUT_DIR="${optarg}" ;;
+   esac
+done
+
+# HACK: because we're not passing KIT from buildsys
+export KIT="${VARIANT}"
+
+# FIXME: should this be a versioned directory?
+# - needs to change whenever the kit changes?
+# - needs to be predictable for publishing to work?
+# - needs to avoid ambiguity if we have other local builds of the same kit?
+KIT_DIR="${OUTPUT_DIR}/${ARCH}"
+
+mkdir -p "${KIT_DIR}/Packages"
+for pkg in ${PACKAGES} ; do
+  find "${PACKAGES_DIR}/${pkg}" \
+    -mindepth 1 \
+    -maxdepth 1 \
+    ! -name '*-debuginfo-*' \
+    ! -name '*-debugsource-*' \
+    -size +0c \
+    -exec install -p -m 0644 -t "${KIT_DIR}/Packages" {} \+
+done
+
+createrepo_c "${KIT_DIR}"
+dnf --disablerepo '*' --repofrompath "kit,file:///${KIT_DIR}" repoquery --all

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -109,6 +109,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("docker-go").is_file());
     assert!(toolsdir.join("partyplanner").is_file());
     assert!(toolsdir.join("rpm2img").is_file());
+    assert!(toolsdir.join("rpm2kit").is_file());
     assert!(toolsdir.join("rpm2kmodkit").is_file());
     assert!(toolsdir.join("rpm2migrations").is_file());
     assert!(toolsdir.join("metadata.spec").is_file());


### PR DESCRIPTION
**Issue number:**

Related #185
Related #73
Builds on #198

**Description of changes:**

In order to construct kits containing the correct RPMs, we need to stop using a flat `build/rpms` structure. Instead we need to put each RPM into a sub-directory. Then we can use the package-name to find the right RPMs to build repos with the correct RPMs on-the-fly when building packages, kits and variants.

**Testing done:**

- [ ] Build a Bottlerocket Variant
- [ ] Manifest unit tests are passing

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
