### PR TITLE
update twoliter and buildsys to put RPMs into per-package sub-directories

### DIFF
--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -122,9 +122,6 @@ pub(crate) struct BuildPackageArgs {
     #[arg(long, env = "BUILDSYS_UPSTREAM_SOURCE_FALLBACK")]
     pub(crate) upstream_source_fallback: String,
 
-    #[arg(long, env = "CARGO_PKG_NAME")]
-    pub(crate) cargo_package_name: String,
-
     #[command(flatten)]
     pub(crate) common: Common,
 }

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -302,12 +302,7 @@ impl DockerBuild {
         manifest: &Manifest,
         image_features: HashSet<ImageFeature>,
     ) -> Result<Self> {
-        let package = if let Some(name_override) = manifest.info().package_name() {
-            name_override.clone()
-        } else {
-            args.cargo_package_name
-        };
-
+        let package = manifest.info().package_name();
         Ok(Self {
             dockerfile: args.common.tools_dir.join("build.Dockerfile"),
             context: args.common.root_dir.clone(),
@@ -323,7 +318,7 @@ impl DockerBuild {
             root_dir: args.common.root_dir.clone(),
             artifacts_dir: args.packages_dir,
             state_dir: args.common.state_dir,
-            artifact_name: package.clone(),
+            artifact_name: package.to_string(),
             common_build_args: CommonBuildArgs::new(
                 &args.common.root_dir,
                 args.common.sdk_image,
@@ -332,7 +327,7 @@ impl DockerBuild {
             ),
             target_build_args: TargetBuildArgs::Package(PackageBuildArgs {
                 image_features,
-                package,
+                package: package.to_string(),
                 package_dependencies: manifest.package_dependencies().context(error::GraphSnafu)?,
                 kit_dependencies: manifest.kit_dependencies().context(error::GraphSnafu)?,
                 publish_repo: args.publish_repo,

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -303,6 +303,8 @@ impl DockerBuild {
         image_features: HashSet<ImageFeature>,
     ) -> Result<Self> {
         let package = manifest.info().package_name();
+        let per_package_dir = format!("{}/{}", args.packages_dir.display(), package).into();
+
         Ok(Self {
             dockerfile: args.common.tools_dir.join("build.Dockerfile"),
             context: args.common.root_dir.clone(),
@@ -316,7 +318,7 @@ impl DockerBuild {
                 &args.common.root_dir,
             ),
             root_dir: args.common.root_dir.clone(),
-            artifacts_dir: args.packages_dir,
+            artifacts_dir: per_package_dir,
             state_dir: args.common.state_dir,
             artifact_name: package.to_string(),
             common_build_args: CommonBuildArgs::new(

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -203,11 +203,7 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
 
     // Package developer can override name of package if desired, e.g. to name package with
     // characters invalid in Cargo crate names
-    let package = if let Some(name_override) = manifest.info().package_name() {
-        name_override.clone()
-    } else {
-        args.cargo_package_name.clone()
-    };
+    let package = manifest.info().package_name();
     let spec = format!("{}.spec", package);
     println!("cargo:rerun-if-changed={}", spec);
 

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -397,9 +397,13 @@ impl ManifestInfo {
         self.build_package().and_then(|b| b.external_files.as_ref())
     }
 
-    /// Convenience method to return the package name override, if any.
-    pub fn package_name(&self) -> Option<&String> {
-        self.build_package().and_then(|b| b.package_name.as_ref())
+    /// Convenience method to return the package name. If the manifest has an override in the
+    /// `package.metadata.build-package.package-name` key, it is returned, otherwise the Cargo
+    /// manifest name is returned from `package.name`.
+    pub fn package_name(&self) -> &str {
+        self.build_package()
+            .and_then(|b| b.package_name.as_deref())
+            .unwrap_or_else(|| self.manifest_name())
     }
 
     /// Convenience method to find whether the package is sensitive to variant changes.

--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -36,6 +36,7 @@ fn main() {
     paths.copy_file("repack.Dockerfile");
     paths.copy_file("repack.Dockerfile.dockerignore");
     paths.copy_file("rpm2img");
+    paths.copy_file("rpm2kit");
     paths.copy_file("rpm2kmodkit");
     paths.copy_file("rpm2migrations");
     paths.copy_file("metadata.spec");

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -750,6 +750,34 @@ cargo metadata \
 '''
 ]
 
+# This task is temporarily necessary due to changes in Twoliter that occurred in June 2024. A new
+# directory structure was introduced for build/rpms. Attempts to do an incremental build when the
+# build output was in the old directory structure would fail, so we needed a way to inform users
+# that they need to run a cargo make clean.
+#
+# Once the changed build/rpms structure has been around long enough (in, say, August 2024), this
+# task can be removed as we can assume that no lingering old incremental builds exist in the wild.
+#
+# TODO - remove this task sometime around, or after, August 2024.
+[tasks.check-rpm-structure]
+script_runner = "bash"
+script = [
+'''
+if [ ! -d "${BUILDSYS_PACKAGES_DIR}" ]; then
+  exit 0
+fi
+
+count=$(find "${BUILDSYS_PACKAGES_DIR}" -maxdepth 1 -name "*.rpm" | wc -l)
+
+if [ "${count}" != "0" ]; then
+    echo "ERROR: You have rpms in a flat structure in ${BUILDSYS_PACKAGES_DIR}"
+    echo "Twoliter and Buildsys have been updated to use a different RPM directory structure"
+    echo "PLEASE RUN: cargo make clean"
+    exit 1
+fi
+'''
+]
+
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
 dependencies = ["check-cargo-version", "fetch", "publish-setup", "fetch-licenses", "cargo-metadata"]

--- a/twoliter/embedded/build.Dockerfile.dockerignore
+++ b/twoliter/embedded/build.Dockerfile.dockerignore
@@ -6,6 +6,10 @@
 !/build/rpms/*.rpm
 /build/rpms/*-debuginfo-*.rpm
 /build/rpms/*-debugsource-*.rpm
+!/build/rpms/*/*.rpm
+/build/rpms/*/*-debuginfo-*.rpm
+/build/rpms/*/*-debugsource-*.rpm
+!/build/kits/
 !/build/tools/*
 **/target/*
 /sbkeys

--- a/twoliter/embedded/rpm2kit
+++ b/twoliter/embedded/rpm2kit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Create a kit from RPM package inputs.
+set -eu -o pipefail
+
+declare -a PACKAGES
+
+for opt in "$@"; do
+   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
+   case "${opt}" in
+      --packages-dir=*) PACKAGES_DIR="${optarg}" ;;
+      --package=*) PACKAGES+=("${optarg}") ;;
+      --output-dir=*) OUTPUT_DIR="${optarg}" ;;
+   esac
+done
+
+KIT_DIR="${OUTPUT_DIR}/${ARCH}"
+rm -rf "${KIT_DIR}"
+
+mkdir -p "${KIT_DIR}/Packages"
+for pkg in ${PACKAGES} ; do
+  find "${PACKAGES_DIR}/${pkg}" \
+    -mindepth 1 \
+    -maxdepth 1 \
+    ! -name '*-debuginfo-*' \
+    ! -name '*-debugsource-*' \
+    -size +0c \
+    -exec install -p -m 0644 -t "${KIT_DIR}/Packages" {} \+
+done
+
+createrepo_c "${KIT_DIR}"
+dnf --disablerepo '*' --repofrompath "kit,file:///${KIT_DIR}" repoquery --all

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -115,6 +115,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("repack.Dockerfile").is_file());
     assert!(toolsdir.join("repack.Dockerfile.dockerignore").is_file());
     assert!(toolsdir.join("rpm2img").is_file());
+    assert!(toolsdir.join("rpm2kit").is_file());
     assert!(toolsdir.join("rpm2kmodkit").is_file());
     assert!(toolsdir.join("rpm2migrations").is_file());
 


### PR DESCRIPTION
**Issue number:**

Related #185
Related #73
Builds on #198

**Description of changes:**

In order to construct kits containing the correct RPMs, we need to stop using a flat `build/rpms` structure. Instead we need to put each RPM into a sub-directory. Then we can use the package-name to find the right RPMs to build repos with the correct RPMs on-the-fly when building packages, kits and variants.

**Testing done:**

- [x] Build a Bottlerocket Variant
- [x] unit tests are passing
- [x] Built a Bottlerocket variant from develop (flat RPM structure) then tried to do an incremental build without the `twoliter: error if old rpm structure is discovered` commit. Buildsys failed as expected with `No matching package to install: 'bottlerocket-glibc-devel'`
- [x] Tried again with `twoliter: error if old rpm structure is discovered` , got the helpful message: `PLEASE RUN: cargo make clean`
- [x] Tried again after a `cargo make clean` and the build succeeded

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
