### PR TITLE
introduce buildsys_epoch variable to trigger rebuilds

### DIFF
--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -15,8 +15,9 @@ use url::Url;
 /// variable changes. The build type is represented with bit flags so that we can easily list
 /// multiple build types for a single variable. See `[BuildType]` and `[rerun_for_envs]` below to
 /// see how this list is used.
-const REBUILD_VARS: [(&str, u8); 12] = [
+const REBUILD_VARS: [(&str, u8); 13] = [
     ("BUILDSYS_ARCH", PACKAGE | VARIANT),
+    ("BUILDSYS_EPOCH", PACKAGE | VARIANT),
     ("BUILDSYS_NAME", VARIANT),
     ("BUILDSYS_OUTPUT_DIR", VARIANT),
     ("BUILDSYS_PACKAGES_DIR", PACKAGE),

--- a/twoliter/src/common.rs
+++ b/twoliter/src/common.rs
@@ -2,6 +2,12 @@ use anyhow::{ensure, Context, Result};
 use log::{self, debug, LevelFilter};
 use tokio::process::Command;
 
+/// This is passed as an environment variable to Buildsys. Buildsys tells Cargo to watch this
+/// environment variable for changes. So if we have a breaking change to the way Buildsys and/or
+/// Twoliter function, we can increment this so that we know users will rebuild after updating
+/// Twoliter.
+pub(crate) const BUILDSYS_EPOCH: u32 = 1;
+
 /// Run a `tokio::process::Command` and return a `Result` letting us know whether or not it worked.
 /// Pipes stdout/stderr when logging `LevelFilter` is more verbose than `Warn`.
 pub(crate) async fn exec_log(cmd: &mut Command) -> Result<()> {


### PR DESCRIPTION
**Issue number:**

Closes #215

**Description of changes:**

Introduce the `BUILDSYS_EPOCH` variable because users will need to rebuild after the breaking changes in #210

**Testing done:**

- [x] Build Bottlerocket with the `BUILDSYS_EPOCH` variable set to 1
- [x] Build it again without changing the `BUILDSYS_EPOCH` variable, packages were not rebuilt (other than `os` as usual).
- [x] Increment it to 2, build again, we should see all packages being rebuilt.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
