### PR TITLE
add image prep functions to imghelper

### DIFF
--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034 # some variables are used through parameter substitution
+
+# shellcheck disable=SC2154  # some variables are defined externally by the environment
+FILENAME_PREFIX="${IMAGE_NAME:?}-${VARIANT:?}-${ARCH:?}-${VERSION_ID:?}-${BUILD_ID:?}"
+SYMLINK_PREFIX="${IMAGE_NAME:?}-${VARIANT:?}-${ARCH:?}"
+
+DATA_IMAGE_SUFFIX="-data"
+BOOT_IMAGE_SUFFIX="-boot"
+VERITY_IMAGE_SUFFIX="-root"
+ROOT_IMAGE_SUFFIX="-root"
+
+OS_IMAGE_NAME="${FILENAME_PREFIX}"
+DATA_IMAGE_NAME="${FILENAME_PREFIX}${DATA_IMAGE_SUFFIX}"
+BOOT_IMAGE_NAME="${FILENAME_PREFIX}${BOOT_IMAGE_SUFFIX}"
+VERITY_IMAGE_NAME="${FILENAME_PREFIX}${VERITY_IMAGE_SUFFIX}"
+ROOT_IMAGE_NAME="${FILENAME_PREFIX}${ROOT_IMAGE_SUFFIX}"
 
 sanity_checks() {
   local output_fmt partition_plan ovf_template uefi_secure_boot
@@ -52,24 +68,52 @@ sanity_checks() {
   fi
 }
 
-# shellcheck disable=SC2034 # variables are used through parameter substitution
+compress_image() {
+  local ext what output_dir input_image image_name
+  ext="${1:?}"
+  what="${2:?}"
+  output_dir="${3:?}"
+  input_image="${what^^}"
+  image_name="${what^^}_NAME"
+
+  case "${ext}" in
+  *lz4)
+    lz4 -9vc "${!input_image}" >"${output_dir}/${!image_name}${ext:+.${ext}}"
+    ;;
+  qcow2)
+    qemu-img convert -f raw -O "${ext}" \
+      "${!input_image}" "${output_dir}/${!image_name}${ext:+.${ext}}"
+    ;;
+  # stream optimization is required for creating Open Virtual Appliances (OVAs)
+  vmdk)
+    qemu-img convert -f raw -O "${ext}" -o subformat=streamOptimized \
+      "${!input_image}" "${output_dir}/${!image_name}${ext:+.${ext}}"
+    ;;
+  *)
+    echo "unexpected extension: ${ext}" >&2
+    exit 1
+    ;;
+  esac
+}
+
 symlink_image() {
-  local ext what target symlink_prefix version_id output_dir symlink_suffix
+  local ext what target output_dir symlink_prefix version_id symlink_suffix
   ext="$1"
   what="${2:?}"
-  symlink_prefix="${3:?}"
-  version_id="${4:?}"
-  output_dir="${5:?}"
+  output_dir="${3:?}"
+
+  symlink_prefix="${SYMLINK_PREFIX}"
+  version_id="${VERSION_ID:?}"
 
   ext="${ext:+.$ext}"
   target="${what^^}_NAME"
 
   case "${what}" in
   os_image) symlink_suffix="" ;;
-  data_image) symlink_suffix="-data" ;;
-  boot_image) symlink_suffix="-boot.ext4.lz4" ;;
-  verity_image) symlink_suffix="-root.verity.lz4" ;;
-  root_image) symlink_suffix="-root.ext4.lz4" ;;
+  data_image) symlink_suffix="${DATA_IMAGE_SUFFIX}" ;;
+  boot_image) symlink_suffix="${BOOT_IMAGE_SUFFIX}" ;;
+  verity_image) symlink_suffix="${VERITY_IMAGE_SUFFIX}" ;;
+  root_image) symlink_suffix="${ROOT_IMAGE_SUFFIX}" ;;
   *)
     echo "unknown image '${what}'" >&2
     exit 1

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -68,6 +68,34 @@ sanity_checks() {
   fi
 }
 
+decompress_image() {
+  local ext what input_dir input_image image_name
+  ext="${1:?}"
+  what="${2:?}"
+  input_dir="${3:?}"
+
+  input_image="${what^^}"
+  image_name="${what^^}_NAME"
+
+  case "${ext}" in
+  *lz4)
+    unlz4 -f "${input_dir}/${!image_name}${ext:+.${ext}}" "${!image_name}.img"
+    ;;
+  qcow2)
+    qemu-img convert -f "${ext}" -O raw \
+      "${input_dir}/${!image_name}${ext:+.${ext}}" "${!image_name}.img"
+    ;;
+  vmdk)
+    qemu-img convert -f "${ext}" -O raw \
+      "${input_dir}/${!image_name}${ext:+.${ext}}" "${!image_name}.img"
+    ;;
+  *)
+    echo "unexpected extension: ${ext}" >&2
+    exit 1
+    ;;
+  esac
+}
+
 compress_image() {
   local ext what output_dir input_image image_name
   ext="${1:?}"

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -1,5 +1,57 @@
 #!/usr/bin/env bash
 
+sanity_checks() {
+  local output_fmt partition_plan ovf_template uefi_secure_boot
+  output_fmt="${1:?}"
+  partition_plan="${2:?}"
+  ovf_template="${3:?}"
+  uefi_secure_boot="${4:?}"
+  case "${output_fmt}" in
+  raw | qcow2 | vmdk) ;;
+  *)
+    echo "unexpected image output format '${output_fmt}'" >&2
+    exit 1
+    ;;
+  esac
+
+  case "${partition_plan}" in
+  split | unified) ;;
+  *)
+    echo "unexpected partition plan '${partition_plan}'" >&2
+    exit 1
+    ;;
+  esac
+
+  # Fail fast if the OVF template doesn't exist, or doesn't match the layout.
+  if [ "${output_fmt}" == "vmdk" ]; then
+    if [ ! -s "${ovf_template}" ]; then
+      echo "required OVF template not found: ${ovf_template}" >&2
+      exit 1
+    fi
+
+    if [ "${partition_plan}" == "split" ]; then
+      if ! grep -Fq '{{DATA_DISK}}' "${ovf_template}"; then
+        echo "Missing data disk in OVF template, which is required for 'split' layout." >&2
+        exit 1
+      fi
+    fi
+
+    if [ "${partition_plan}" == "unified" ]; then
+      if grep -Fq '{{DATA_DISK}}' "${ovf_template}"; then
+        echo "Data disk included in OVF template, which is not supported for 'unified' layout." >&2
+        exit 1
+      fi
+    fi
+
+    if [ "${uefi_secure_boot}" == "yes" ]; then
+      if ! grep -Fq '{{DB_CERT_DER_HEX}}' "${ovf_template}"; then
+        echo "Missing CA certificate field in OVF template, which is required for Secure Boot support." >&2
+        exit 1
+      fi
+    fi
+  fi
+}
+
 # shellcheck disable=SC2034 # variables are used through parameter substitution
 symlink_image() {
   local ext what target symlink_prefix version_id output_dir symlink_suffix

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -39,50 +39,8 @@ done
 # shellcheck source=imghelper
 . "${0%/*}/imghelper"
 
-case "${OUTPUT_FMT}" in
-   raw|qcow2|vmdk) ;;
-   *)
-      echo "unexpected image output format '${OUTPUT_FMT}'" >&2
-      exit 1
-      ;;
-esac
-
-case "${PARTITION_PLAN}" in
-  split|unified) ;;
-  *)
-    echo "unexpected partition plan '${PARTITION_PLAN}'" >&2
-    exit 1
-    ;;
-esac
-
-# Fail fast if the OVF template doesn't exist, or doesn't match the layout.
-if [ "${OUTPUT_FMT}" == "vmdk" ] ; then
-  if [ ! -s "${OVF_TEMPLATE}" ] ; then
-    echo "required OVF template not found: ${OVF_TEMPLATE}" >&2
-    exit 1
-  fi
-
-  if [ "${PARTITION_PLAN}" == "split" ] ; then
-    if ! grep -Fq '{{DATA_DISK}}' "${OVF_TEMPLATE}" ; then
-      echo "Missing data disk in OVF template, which is required for 'split' layout." >&2
-      exit 1
-    fi
-  fi
-
-  if [ "${PARTITION_PLAN}" == "unified" ] ; then
-    if grep -Fq '{{DATA_DISK}}' "${OVF_TEMPLATE}" ; then
-      echo "Incorrect data disk in OVF template, which is not supported for 'unified' layout." >&2
-      exit 1
-    fi
-  fi
-
-  if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
-    if ! grep -Fq '{{DB_CERT_DER_HEX}}' "${OVF_TEMPLATE}" ; then
-      echo "Missing CA certificate field in OVF template, which is required for Secure Boot support." >&2
-      exit 1
-    fi
-  fi
-fi
+sanity_checks \
+  "${OUTPUT_FMT}" "${PARTITION_PLAN}" "${OVF_TEMPLATE}" "${UEFI_SECURE_BOOT}"
 
 # Store output artifacts in a versioned directory.
 OUTPUT_DIR="${OUTPUT_DIR}/${VERSION_ID}-${BUILD_ID}"

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -15,8 +15,6 @@ GRUB_SET_PRIVATE_VAR="no"
 XFS_DATA_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 
-SYMLINK_PREFIX="${IMAGE_NAME}-${VARIANT}-${ARCH}"
-
 for opt in "$@"; do
    optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
    case "${opt}" in
@@ -45,13 +43,6 @@ sanity_checks \
 # Store output artifacts in a versioned directory.
 OUTPUT_DIR="${OUTPUT_DIR}/${VERSION_ID}-${BUILD_ID}"
 mkdir -p "${OUTPUT_DIR}"
-
-FILENAME_PREFIX="${IMAGE_NAME}-${VARIANT}-${ARCH}-${VERSION_ID}-${BUILD_ID}"
-OS_IMAGE_NAME="${FILENAME_PREFIX}"
-DATA_IMAGE_NAME="${FILENAME_PREFIX}-data"
-BOOT_IMAGE_NAME="${FILENAME_PREFIX}-boot.ext4.lz4"
-VERITY_IMAGE_NAME="${FILENAME_PREFIX}-root.verity.lz4"
-ROOT_IMAGE_NAME="${FILENAME_PREFIX}-root.ext4.lz4"
 
 OS_IMAGE="$(mktemp)"
 BOOT_IMAGE="$(mktemp)"
@@ -589,32 +580,26 @@ esac
 sgdisk -v "${OS_IMAGE}"
 [ -s "${DATA_IMAGE}" ] && sgdisk -v "${DATA_IMAGE}"
 if [[ ${OUTPUT_FMT} == "raw" ]]; then
-  lz4 -vc "${OS_IMAGE}" >"${OUTPUT_DIR}/${OS_IMAGE_NAME}.img.lz4"
-  symlink_image "img.lz4" "os_image" \
-    "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
+  compress_image "img.lz4" "os_image" "${OUTPUT_DIR}"
+  symlink_image "img.lz4" "os_image" "${OUTPUT_DIR}"
   if [ -s "${DATA_IMAGE}" ] ; then
-    lz4 -vc "${DATA_IMAGE}" >"${OUTPUT_DIR}/${DATA_IMAGE_NAME}.img.lz4"
-    symlink_image "img.lz4" "data_image" \
-      "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
+    compress_image "img.lz4" "data_image" "${OUTPUT_DIR}"
+    symlink_image "img.lz4" "data_image" "${OUTPUT_DIR}"
   fi
 elif [[ ${OUTPUT_FMT} == "qcow2" ]]; then
-  qemu-img convert -f raw -O qcow2 "${OS_IMAGE}" "${OUTPUT_DIR}/${OS_IMAGE_NAME}.qcow2"
-  symlink_image "qcow2" "os_image" \
-    "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
+  compress_image "qcow2" "os_image" "${OUTPUT_DIR}"
+  symlink_image "qcow2" "os_image" "${OUTPUT_DIR}"
   if [ -s "${DATA_IMAGE}" ] ; then
-    qemu-img convert -f raw -O qcow2 "${DATA_IMAGE}" "${OUTPUT_DIR}/${DATA_IMAGE_NAME}.qcow2"
-    symlink_image "qcow2" "data_image" \
-      "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
+    compress_image "qcow2" "data_image" "${OUTPUT_DIR}"
+    symlink_image "qcow2" "data_image" "${OUTPUT_DIR}"
   fi
 elif [[ ${OUTPUT_FMT} == "vmdk" ]]; then
   # Stream optimization is required for creating an Open Virtual Appliance (OVA)
-  qemu-img convert -f raw -O vmdk -o subformat=streamOptimized "${OS_IMAGE}" "${OUTPUT_DIR}/${OS_IMAGE_NAME}.vmdk"
-  symlink_image "vmdk" "os_image" \
-    "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
+  compress_image "vmdk" "os_image" "${OUTPUT_DIR}"
+  symlink_image "vmdk" "os_image" "${OUTPUT_DIR}"
   if [ -s "${DATA_IMAGE}" ] ; then
-    qemu-img convert -f raw -O vmdk -o subformat=streamOptimized "${DATA_IMAGE}" "${OUTPUT_DIR}/${DATA_IMAGE_NAME}.vmdk"
-    symlink_image "vmdk" "data_image" \
-      "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
+    compress_image "vmdk" "data_image" "${OUTPUT_DIR}"
+    symlink_image "vmdk" "data_image" "${OUTPUT_DIR}"
   fi
 fi
 
@@ -629,20 +614,16 @@ if [ "${OUTPUT_FMT}" == "vmdk" ] ; then
     "${UEFI_SECURE_BOOT}" \
     "${SBKEYS}" \
     "${OUTPUT_DIR}"
-  symlink_image "ova" "os_image" \
-    "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
+  symlink_image "ova" "os_image" "${OUTPUT_DIR}"
 fi
 
-lz4 -9vc "${BOOT_IMAGE}" >"${OUTPUT_DIR}/${BOOT_IMAGE_NAME}"
-lz4 -9vc "${VERITY_IMAGE}" >"${OUTPUT_DIR}/${VERITY_IMAGE_NAME}"
-lz4 -9vc "${ROOT_IMAGE}" >"${OUTPUT_DIR}/${ROOT_IMAGE_NAME}"
+compress_image "ext4.lz4" "boot_image" "${OUTPUT_DIR}"
+compress_image "verity.lz4" "verity_image" "${OUTPUT_DIR}"
+compress_image "ext4.lz4" "root_image" "${OUTPUT_DIR}"
 
-symlink_image "" "boot_image" \
-  "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
-symlink_image "" "verity_image" \
-  "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
-symlink_image "" "root_image" \
-  "${SYMLINK_PREFIX}" "${VERSION_ID}" "${OUTPUT_DIR}"
+symlink_image "ext4.lz4" "boot_image" "${OUTPUT_DIR}"
+symlink_image "verity.lz4" "verity_image" "${OUTPUT_DIR}"
+symlink_image "ext4.lz4" "root_image" "${OUTPUT_DIR}"
 
 find "${OUTPUT_DIR}" -type f -print -exec chown 1000:1000 {} \;
 


### PR DESCRIPTION
**Description of changes:**

Adds or moves functionality around image name generation, compression, and decompression to `imghelper`.

**Testing done:**

- Built `aws-k8s-1.28`
- Repacked `aws-k8s-1.28`
- Build `vmware-k8s-1.28`
- Repacked `vmware-k8s-1.28`



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
