### PR TITLE
cleanup warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,9 +861,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/tools/buildsys/src/builder/error.rs
+++ b/tools/buildsys/src/builder/error.rs
@@ -74,12 +74,6 @@ pub(crate) enum Error {
         prefix: PathBuf,
         source: std::path::StripPrefixError,
     },
-
-    #[snafu(display("Unsupported architecture '{}'", arch))]
-    UnsupportedArch {
-        arch: String,
-        source: serde_plain::Error,
-    },
 }
 
 pub(super) type Result<T> = std::result::Result<T, Error>;

--- a/tools/buildsys/src/cache/error.rs
+++ b/tools/buildsys/src/cache/error.rs
@@ -6,12 +6,6 @@ use std::path::PathBuf;
 #[snafu(visibility(pub(super)))]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Error {
-    #[snafu(display("Missing environment variable '{}'", var))]
-    Environment {
-        var: String,
-        source: std::env::VarError,
-    },
-
     #[snafu(display("Bad file name '{}'", path.display()))]
     ExternalFileName { path: PathBuf },
 

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -61,18 +61,6 @@ mod error {
             source: crate::builder::error::Error,
         },
 
-        #[snafu(display("Missing environment variable '{}'", var))]
-        Environment {
-            var: String,
-            source: std::env::VarError,
-        },
-
-        #[snafu(display("Unknown architecture: '{}'", arch))]
-        UnknownArch {
-            arch: String,
-            source: serde_plain::Error,
-        },
-
         #[snafu(display(
             "Unsupported architecture {}, this variant supports {}",
             arch,

--- a/tools/buildsys/src/manifest/error.rs
+++ b/tools/buildsys/src/manifest/error.rs
@@ -18,9 +18,6 @@ pub(super) enum Error {
     #[snafu(display("Failed to create dependency graph from '{}': {}", path.display(), source))]
     GraphBuild { path: PathBuf, source: guppy::Error },
 
-    #[snafu(display("Invalid image size {}; must be between 1 and 1024", value))]
-    InvalidImageSize { value: i32 },
-
     #[snafu(display("Failed to read manifest file '{}': {}", path.display(), source))]
     ManifestFileRead { path: PathBuf, source: io::Error },
 

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -501,7 +501,6 @@ mod error {
     use crate::aws::{ami, publish_ami};
     use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::modify_image_attribute::ModifyImageAttributeError;
-    use aws_sdk_ec2::types::LaunchPermission;
     use aws_sdk_sts::operation::get_caller_identity::GetCallerIdentityError;
     use snafu::Snafu;
     use std::path::PathBuf;
@@ -527,12 +526,6 @@ mod error {
             image_id: String,
             region: String,
             source: super::launch_permissions::Error,
-        },
-
-        #[snafu(display("Failed to create file '{}': {}", path.display(), source))]
-        FileCreate {
-            path: PathBuf,
-            source: std::io::Error,
         },
 
         #[snafu(display("Error getting AMI ID for {} {} in {}: {}", arch, name, region, source))]
@@ -586,9 +579,6 @@ mod error {
             region: String,
             source: public::Error,
         },
-
-        #[snafu(display("Invalid launch permission: {:?}", launch_permission))]
-        InvalidLaunchPermission { launch_permission: LaunchPermission },
 
         #[snafu(display("Infra.toml is missing {}", missing))]
         MissingConfig { missing: String },

--- a/tools/pubsys/src/aws/promote_ssm/mod.rs
+++ b/tools/pubsys/src/aws/promote_ssm/mod.rs
@@ -355,11 +355,6 @@ mod error {
             path: PathBuf,
         },
 
-        #[snafu(display("Failed to parse rendered SSM parameters to JSON: {}", source))]
-        ParseRenderedSsmParameters {
-            source: serde_json::Error,
-        },
-
         #[snafu(display("Failed to write rendered SSM parameters to {}: {}", path.display(), source))]
         WriteRenderedSsmParameters {
             path: PathBuf,

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -569,7 +569,7 @@ mod error {
     use crate::aws::ami;
     use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::{
-        describe_images::DescribeImagesError, modify_image_attribute::ModifyImageAttributeError,
+        describe_images::DescribeImagesError,
         modify_snapshot_attribute::ModifySnapshotAttributeError,
     };
     use snafu::Snafu;
@@ -653,18 +653,6 @@ mod error {
         },
 
         #[snafu(display(
-            "Failed to modify permissions of {} in {}: {}",
-            image_id,
-            region,
-            source
-        ))]
-        ModifyImageAttributes {
-            image_id: String,
-            region: String,
-            source: SdkError<ModifyImageAttributeError>,
-        },
-
-        #[snafu(display(
             "Failed to modify permissions of {} of {} snapshots",
             error_count, error_count + success_count,
         ))]
@@ -714,7 +702,6 @@ mod error {
                 | Error::MissingInResponse { .. }
                 | Error::MissingRegion { .. }
                 | Error::ModifyImageAttribute { .. }
-                | Error::ModifyImageAttributes { .. }
                 | Error::ModifySnapshotAttributes { .. }
                 | Error::MultipleImages { .. }
                 | Error::Serialize { .. }

--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -459,11 +459,6 @@ mod error {
             source: crate::aws::ami::public::Error,
         },
 
-        #[snafu(display("Failed to create EC2 client for region {}", region))]
-        CreateEc2Client {
-            region: String,
-        },
-
         #[snafu(display("Failed to deserialize input from '{}': {}", path.display(), source))]
         Deserialize {
             path: PathBuf,

--- a/tools/pubsys/src/aws/validate_ssm/mod.rs
+++ b/tools/pubsys/src/aws/validate_ssm/mod.rs
@@ -256,7 +256,6 @@ pub(crate) async fn run(args: &Args, validate_ssm_args: &ValidateSsmArgs) -> Res
 }
 
 pub(crate) mod error {
-    use crate::aws::ssm::ssm;
     use snafu::Snafu;
     use std::path::PathBuf;
 
@@ -266,15 +265,6 @@ pub(crate) mod error {
         #[snafu(display("Error reading config: {}", source))]
         Config { source: pubsys_config::Error },
 
-        #[snafu(display("Failed to fetch parameters from SSM: {}", source))]
-        FetchSsm { source: ssm::error::Error },
-
-        #[snafu(display("Infra.toml is missing {}", missing))]
-        MissingConfig { missing: String },
-
-        #[snafu(display("Failed to validate SSM parameters: {}", missing))]
-        ValidateSsm { missing: String },
-
         #[snafu(display("Failed to parse expected parameters file: {}", source))]
         ParseExpectedParameterFile { source: serde_json::Error },
 
@@ -283,9 +273,6 @@ pub(crate) mod error {
             source: std::io::Error,
             path: PathBuf,
         },
-
-        #[snafu(display("Invalid validation status filter: {}", filter))]
-        InvalidStatusFilter { filter: String },
 
         #[snafu(display("Failed to serialize validation results to json: {}", source))]
         SerializeValidationResults { source: serde_json::Error },

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -16,7 +16,6 @@ use pubsys_config::{
 };
 use semver::Version;
 use snafu::{ensure, OptionExt, ResultExt};
-use std::convert::TryInto;
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -769,9 +769,6 @@ mod error {
         #[snafu(display("Repo exists at '{}' - remove it and try again", path.display()))]
         RepoExists { path: PathBuf },
 
-        #[snafu(display("Could not fetch repo at '{}': {}", url, msg))]
-        RepoFetch { url: Url, msg: String },
-
         #[snafu(display(
             "Failed to load repo from metadata URL '{}': {}",
             metadata_base_url,
@@ -782,9 +779,6 @@ mod error {
             #[snafu(source(from(tough::error::Error, Box::new)))]
             source: Box<tough::error::Error>,
         },
-
-        #[snafu(display("Requested repository does not exist: '{}'", url))]
-        RepoNotFound { url: Url },
 
         #[snafu(display("Failed to sign repository: {}", source))]
         RepoSign {

--- a/tools/pubsys/src/repo/refresh_repo/mod.rs
+++ b/tools/pubsys/src/repo/refresh_repo/mod.rs
@@ -200,7 +200,6 @@ pub(crate) async fn run(args: &Args, refresh_repo_args: &RefreshRepoArgs) -> Res
 
 mod error {
     use snafu::Snafu;
-    use url::Url;
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
@@ -210,9 +209,6 @@ mod error {
             #[snafu(source(from(crate::repo::Error, Box::new)))]
             source: Box<crate::repo::Error>,
         },
-
-        #[snafu(display("Failed to refresh & re-sign metadata for: {:#?}", list_of_urls))]
-        RepoRefresh { list_of_urls: Vec<Url> },
     }
 }
 pub(crate) use error::Error;

--- a/tools/pubsys/src/repo/validate_repo/mod.rs
+++ b/tools/pubsys/src/repo/validate_repo/mod.rs
@@ -148,29 +148,17 @@ mod error {
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
     pub(crate) enum Error {
-        #[snafu(display("Error running async code: {}", source))]
-        Async { source: std::io::Error },
-
-        #[snafu(display("Invalid percentage specified: {} is greater than 100", percentage))]
-        InvalidPercentage { percentage: u8 },
-
         #[snafu(context(false), display("{}", source))]
         Repo {
             #[snafu(source(from(crate::repo::Error, Box::new)))]
             source: Box<crate::repo::Error>,
         },
 
-        #[snafu(display("Error parallelizing download tasks: {}", source))]
-        Semaphore { source: tokio::sync::AcquireError },
-
         #[snafu(display("Error reading bytes from stream: {}", source))]
         Stream { source: tough::error::Error },
 
         #[snafu(display("Failed to download and write target '{}': {}", target, source))]
         TargetDownload { target: String, source: io::Error },
-
-        #[snafu(display("Failed to complete download task: {}", source))]
-        Join { source: tokio::task::JoinError },
 
         #[snafu(display("Missing target: {}", target))]
         TargetMissing { target: String },

--- a/tools/pubsys/src/vmware/upload_ova/mod.rs
+++ b/tools/pubsys/src/vmware/upload_ova/mod.rs
@@ -206,12 +206,6 @@ mod error {
             source: pubsys_config::vmware::Error,
         },
 
-        #[snafu(display("Missing environment variable '{}'", var))]
-        Environment {
-            var: String,
-            source: std::env::VarError,
-        },
-
         #[snafu(display("Failed to {} '{}': {}", action, path.display(), source))]
         File {
             action: String,

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -512,7 +512,7 @@ pub(crate) trait CrdCreator: Sync {
                 .bottlerocket_crd(BottlerocketInput {
                     cluster_crd_name: &cluster_crd_name,
                     image_id: image_id.clone(),
-                    test_type,
+                    _test_type: test_type,
                     crd_input,
                 })
                 .await?;
@@ -723,7 +723,7 @@ pub struct BottlerocketInput<'a> {
     pub cluster_crd_name: &'a Option<String>,
     /// The image id that should be used by this CRD
     pub image_id: String,
-    pub test_type: &'a KnownTestType,
+    pub _test_type: &'a KnownTestType,
     pub crd_input: &'a CrdInput<'a>,
 }
 

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -49,12 +49,6 @@ pub enum Error {
         source: Box<handlebars::TemplateError>,
     },
 
-    #[snafu(display("Unable to create map from {}: {}", what, source))]
-    IntoMap {
-        what: String,
-        source: testsys_model::Error,
-    },
-
     #[snafu(display("{}", what))]
     Invalid { what: String },
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

The nightly compiler seems to have gained the ability to show us which Snafu error variants are unused.

This PR cleans up warnings from a deprecated function, unused Snafu variants, and a couple of other things that seems to generate warnings depending on how you build.

**Testing done:**

It compiles and unit tests pass.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
