### PR TITLE
buildsys: remove variant sensitivity

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -80,43 +80,6 @@ naming.
 package-name = "better.name"
 ```
 
-`variant-sensitive` lets you specify whether the package should be rebuilt when
-building a new variant, and defaults to false; set it to true if a package is
-using the variant to affect its build process.
-
-```ignore
-[package.metadata.build-package]
-variant-sensitive = true
-```
-
-Some packages might only be sensitive to certain components of the variant
-tuple, such as the platform, runtime, or family. The `variant-sensitive` field
-can also take a string to indicate the source of the sensitivity.
-
-```ignore
-[package.metadata.build-package]
-# sensitive to platform, like "metal" or "aws"
-variant-sensitive = "platform"
-
-# sensitive to runtime, like "k8s" or "ecs"
-variant-sensitive = "runtime"
-
-# sensitive to family, like "metal-k8s" or "aws-ecs"
-variant-sensitive = "family"
-```
-
-`package-features` is a list of image features that the package tracks. This is
-useful when the way the package is built changes based on whether a particular
-image feature is enabled for the current variant, rather than when the variant
-tuple changes.
-
-```ignore
-[package.metadata.build-package]
-package-features = [
-    "grub-set-private-var",
-]
-```
-
 `releases-url` is ignored by buildsys, but can be used by packager maintainers
 to indicate a good URL for checking whether the software has had a new release.
 ```ignore


### PR DESCRIPTION
**Issue number:**

Closes #193
Blocks #70

**Description of changes:**

```
buildsys: remove variant sensitivity documentation

buildsys: deprecate build-package variant sensitivity

    Packages can no longer depend on knowing what variant they are being
    built for, so we raise an error if they declare variant-sensitivity or
    package-features in their Cargo.toml.

    Bottlerocket is not quite ready for this, though. So we place this
    change behind a feature flag variable:
    BUILDSYS_DEPRECATED_FEATURE_VARIANT_SENSITIVITY

buildsys: build-package refactor variant sensitivity

    Move the variant sensitivity logic of build-package into a function that
    can soon be deleted.
```

**Testing done:**

- [x] Built and ran an aws-ecs-2 variant
- [x] Without cleaning: Built and ran an aws-k8s-1.27 variant, and verified that apiclient could get the kubernetes.cluster-name value (which does not exist on aws-ecs-2 and proves conditional compilation of the model took place)
- [x] Build all Bottlerocket variants using Bottlerocket CI.
  - [x] For this I used the following Bottlerocket diff. Note that `os` is the only package relying on `variant-sensitive`! https://github.com/bottlerocket-os/bottlerocket/compare/3243428cde2040f75ef871bbd742bc7ee00d6776...webern:be9d22dd6950fee46683ab5d2e0f1cb30e0f38ed
  - [x] Here is the Bottlerocket actions run in which all variants were built https://github.com/bottlerocket-os/bottlerocket/actions/runs/9135774525

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
