### PR TITLE
move secure boot setup to imghelper

### DIFF
--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -479,6 +479,31 @@ provide_certs() {
   mcopy -i "${efi_image}" "${SBKEYS}"/db.{crt,cer} ::/EFI/BOOT
 }
 
+sign_vmlinuz() {
+  local vmlinuz
+  vmlinuz="${1:?}"
+
+  undo_sign "${vmlinuz}"
+  do_sign "${vmlinuz}" "${SBKEYS}/vendor.cer" CODE_SIGN_KEY
+}
+
+generate_hmac() {
+  local vmlinuz
+  vmlinuz="${1:?}"
+  openssl sha512 -hmac FIPS-FTW-RHT2009 -hex "${vmlinuz}" |
+    awk -v vmlinuz="${vmlinuz}" '{ print $2 "  " vmlinuz }' \
+      >"${vmlinuz%/*}.${vmlinuz##*/}.hmac"
+}
+
+sign_grubcfg() {
+  local grub_cfg grub_cfg_sig
+  grub_cfg="${1:?}"
+  grub_cfg_sig="${grub_cfg}.sig"
+  [[ -f "${grub_cfg_sig}" ]] && rm "${grub_cfg_sig}"
+  gpg --batch --no-tty --detach-sign "${grub_cfg}"
+  gpg --batch --no-tty --verify "${grub_cfg_sig}" "${grub_cfg}"
+}
+
 generate_ova() {
   local os_vmdk data_vmdk
   os_vmdk="${1:?}"

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -23,6 +23,11 @@ VERITY_HASH_ALGORITHM=sha256
 VERITY_DATA_BLOCK_SIZE=4096
 VERITY_HASH_BLOCK_SIZE=4096
 
+SBKEYS="${HOME}/sbkeys"
+
+# Pre-emptively declare global arrays to be populated later.
+declare -a SHIM_SIGN_KEY CODE_SIGN_KEY
+
 sanity_checks() {
   local output_fmt partition_plan ovf_template uefi_secure_boot
   output_fmt="${1:?}"
@@ -296,6 +301,97 @@ generate_verity_root() {
   )
 }
 
+sbsetup_wrapup() {
+  local sb_key_source
+  sb_key_source="${1:?}"
+
+  # Convert certificates from PEM format (ASCII) to DER (binary). This could be
+  # done when the certificates are created, but the resulting binary files are
+  # not as nice to store in source control.
+  for cert in PK KEK db vendor; do
+    openssl x509 \
+      -inform PEM -in "${SBKEYS}/${cert}.crt" \
+      -outform DER -out "${SBKEYS}/${cert}.cer"
+  done
+
+  # For signing the grub config, we need to embed the GPG public key in binary
+  # form, which is similarly awkward to store in source control.
+  gpg --batch --no-tty --import "${SBKEYS}/config-sign.key"
+  if [[ "${sb_key_source}" == "aws" ]]; then
+    gpg --batch --no-tty --card-status
+  fi
+  gpg --batch --no-tty --export >"${SBKEYS}/config-sign.pubkey"
+  gpg --batch --no-tty --list-keys
+}
+
+sbsetup_aws_profile() {
+  # Set AWS environment variables from build secrets, if present.
+  local var val
+  for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN; do
+    val="${var,,}"
+    val="${HOME}/.aws/${val//_/-}.env"
+    [[ -s "${val}" ]] || continue
+    declare -x "${var}=$(cat "${val}")"
+  done
+  # Verify that AWS credentials are functional.
+  aws sts get-caller-identity
+  # Log all PKCS11 helper activity, to simplify debugging.
+  export AWS_KMS_PKCS11_DEBUG=1
+  SHIM_SIGN_KEY+=(-c shim-sign-key -t shim-sign-key)
+  CODE_SIGN_KEY+=(-c code-sign-key -t code-sign-key)
+
+  local sb_key_source="aws"
+  sbsetup_wrapup "${sb_key_source}"
+}
+
+sbsetup_local_profile() {
+  # Disable the PKCS11 helper.
+  rm /etc/pkcs11/modules/aws-kms-pkcs11.module
+
+  # Generate the PKCS12 archives for import.
+  openssl pkcs12 \
+    -export \
+    -passout pass: \
+    -inkey "${SBKEYS}/shim-sign.key" \
+    -in "${SBKEYS}/shim-sign.crt" \
+    -certfile "${SBKEYS}/db.crt" \
+    -out "${SBKEYS}/shim-sign.p12"
+
+  openssl pkcs12 \
+    -export \
+    -passout pass: \
+    -inkey "${SBKEYS}/code-sign.key" \
+    -in "${SBKEYS}/code-sign.crt" \
+    -certfile "${SBKEYS}/vendor.crt" \
+    -out "${SBKEYS}/code-sign.p12"
+
+  # Import certificates and private key archive.
+  local pedb="/etc/pki/pesign"
+
+  certutil -d "${pedb}" -A -n db -i "${SBKEYS}/db.crt" -t ",,C"
+  certutil -d "${pedb}" -A -n shim-sign-key -i "${SBKEYS}/shim-sign.crt" -t ",,P"
+  pk12util -d "${pedb}" -i "${SBKEYS}/shim-sign.p12" -W ""
+
+  certutil -d "${pedb}" -A -n vendor -i "${SBKEYS}/vendor.crt" -t ",,C"
+  certutil -d "${pedb}" -A -n code-sign-key -i "${SBKEYS}/code-sign.crt" -t ",,P"
+  pk12util -d "${pedb}" -i "${SBKEYS}/code-sign.p12" -W ""
+
+  certutil -d "${pedb}" -L
+  SHIM_SIGN_KEY+=(-c shim-sign-key)
+  CODE_SIGN_KEY+=(-c code-sign-key)
+
+  local sb_key_source="local"
+  sbsetup_wrapup "${sb_key_source}"
+}
+
+sbsetup_signing_profile() {
+  if [[ -s "${HOME}/.config/aws-kms-pkcs11/config.json" ]]; then
+    sbsetup_aws_profile
+  else
+    sbsetup_local_profile
+  fi
+}
+
 generate_ova() {
   local os_vmdk data_vmdk
   os_vmdk="${1:?}"
@@ -305,11 +401,10 @@ generate_ova() {
   os_image_publish_size_gib="${3:?}"
   data_image_publish_size_gib="${4:?}"
 
-  local ovf_template uefi_secure_boot sbkeys output_dir
+  local ovf_template uefi_secure_boot output_dir
   ovf_template="${5:?}"
   uefi_secure_boot="${6:?}"
-  sbkeys="${7:?}"
-  output_dir="${8:?}"
+  output_dir="${7:?}"
 
   local ova_dir
   ova_dir="$(mktemp -d)"
@@ -333,9 +428,9 @@ generate_ova() {
   # PK, KEK, db, and dbx.
   if [[ "${uefi_secure_boot}" == "yes" ]]; then
     local data_disk_bytes kek_cert_der_hex db_cert_der_hex dbx_empty_hash_hex
-    pk_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${sbkeys}/PK.cer")"
-    kek_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${sbkeys}/KEK.cer")"
-    db_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${sbkeys}/db.cer")"
+    pk_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${SBKEYS}/PK.cer")"
+    kek_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${SBKEYS}/KEK.cer")"
+    db_cert_der_hex="$(hexdump -ve '1/1 "%02x"' "${SBKEYS}/db.cer")"
     dbx_empty_hash_hex="$(sha256sum /dev/null | awk '{ print $1 }')"
     sed -i \
       -e "s/{{PK_CERT_DER_HEX}}/${pk_cert_der_hex}/g" \

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -392,6 +392,93 @@ sbsetup_signing_profile() {
   fi
 }
 
+undo_sign() {
+  local what
+  what="${1:?}"
+  if [[ "$(pesign -i "${what}" -l)" != "No signatures found." ]]; then
+    mv "${what}" "${what}.orig"
+    pesign -i "${what}.orig" -o "${what}" -u 0 -r
+    rm "${what}.orig"
+  fi
+}
+
+do_sign() {
+  local what cert
+  local -n sign_key
+  what="${1:?}"
+  cert="${2:?}"
+  sign_key="${3:?}"
+
+  pesign -i "${what}" -o "${what}.signed" -s "${sign_key[@]}"
+  mv "${what}.signed" "${what}"
+  pesign -i "${what}" -l
+  pesigcheck -i "${what}" -n 0 -c "${cert}"
+}
+
+sign_shim() {
+  local shim
+  shim="${1:?}"
+
+  # Convert the vendor certificate to the expected format.
+  cert_table "${SBKEYS}/vendor.cer" "${SBKEYS}/vendor.obj"
+
+  # Replace the embedded vendor certificate, then sign shim with the db key.
+  undo_sign "${shim}"
+  "${ARCH:?}-objdumpcopy" "${shim}" \
+    --update-section ".vendor_cert=${SBKEYS}/vendor.obj"
+  do_sign "${shim}" "${SBKEYS}/db.cer" SHIM_SIGN_KEY
+}
+
+zero_shim() {
+  local shim
+  shim="${1:?}"
+
+  # Generate a zero-sized certificate in the expected format.
+  cert_table /dev/null "${SBKEYS}/vendor.obj"
+
+  # Replace the embedded vendor certificate with the zero-sized one, which
+  # shim will ignore when Secure Boot is disabled.
+  "${ARCH:?}-objdumpcopy" "${shim}" \
+    --update-section ".vendor_cert=${SBKEYS}/vendor.obj"
+}
+
+sign_mokm() {
+  local mokm
+  mokm="${1:?}"
+
+  undo_sign "${mokm}"
+  do_sign "${mokm}" "${SBKEYS}/vendor.cer" CODE_SIGN_KEY
+}
+
+sign_grub() {
+  local grub
+  grub="${1:?}"
+
+  # Remove the original vendor key if necessary, replace the embedded gpg
+  # public key, then sign grub with the vendor key.
+  undo_sign "${grub}"
+  "${ARCH:?}-objdumpcopy" "${grub}" \
+    --file-alignment 4096 \
+    --update-section ".pubkey=${SBKEYS}/config-sign.pubkey"
+  do_sign "${grub}" "${SBKEYS}/vendor.cer" CODE_SIGN_KEY
+}
+
+unembed_grub() {
+  local grub
+  grub="${1:?}"
+
+  # Remove the embedded gpg public key to disable GRUB's signature checks.
+  "${ARCH:?}-objdumpcopy" "${grub}" \
+    --file-alignment 4096 \
+    --remove-section ".pubkey"
+}
+
+provide_certs() {
+  local efi_image
+  efi_image="${1:?}"
+  mcopy -i "${efi_image}" "${SBKEYS}"/db.{crt,cer} ::/EFI/BOOT
+}
+
 generate_ova() {
   local os_vmdk data_vmdk
   os_vmdk="${1:?}"

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -229,21 +229,12 @@ mkdir -p "${ROOT_MOUNT}/boot/grub"
 # Now that we're done messing with /, move /boot out of it
 mv "${ROOT_MOUNT}/boot"/* "${BOOT_MOUNT}"
 
-pushd "${BOOT_MOUNT}" >/dev/null
-
-vmlinuz="vmlinuz"
 if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
-  pesign -i "${vmlinuz}" -o "${vmlinuz}.signed" -s "${CODE_SIGN_KEY[@]}"
-  mv "${vmlinuz}.signed" "${vmlinuz}"
-  pesigcheck -i "${vmlinuz}" -n 0 -c "${SBKEYS}/vendor.cer"
+  sign_vmlinuz "${BOOT_MOUNT}/vmlinuz"
 fi
 
 # Generate an HMAC for the kernel after signing.
-openssl sha512 -hmac FIPS-FTW-RHT2009 -hex "${vmlinuz}" \
-  | awk -v vmlinuz="${vmlinuz}" '{ print $2 "  " vmlinuz }' \
-  > ".${vmlinuz}.hmac"
-
-popd >/dev/null
+generate_hmac "${BOOT_MOUNT}/vmlinuz"
 
 # Set the Bottlerocket variant, version, and build-id
 SYS_ROOT="${ARCH}-bottlerocket-linux-gnu/sys-root"
@@ -336,8 +327,7 @@ menuentry "${PRETTY_NAME} ${VERSION_ID}" --unrestricted {
 EOF
 
 if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
-  gpg --detach-sign "${BOOT_MOUNT}/grub/grub.cfg"
-  gpg --verify "${BOOT_MOUNT}/grub/grub.cfg.sig"
+  sign_grubcfg "${BOOT_MOUNT}/grub/grub.cfg"
 fi
 
 # Combine any bootconfig snippets in /boot for later use, then clean up.

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -59,8 +59,6 @@ DATA_MOUNT="$(mktemp -d)"
 EFI_MOUNT="$(mktemp -d)"
 PRIVATE_MOUNT="$(mktemp -d)"
 
-SBKEYS="${HOME}/sbkeys"
-
 SELINUX_ROOT="/etc/selinux"
 SELINUX_POLICY="fortified"
 SELINUX_FILE_CONTEXTS="${ROOT_MOUNT}/${SELINUX_ROOT}/${SELINUX_POLICY}/contexts/files/file_contexts"
@@ -191,87 +189,6 @@ fi
 # package has placed the image in /boot/efi/EFI/BOOT.
 mv "${ROOT_MOUNT}/boot/efi"/* "${EFI_MOUNT}"
 
-# Do the setup required for `pesign` and `gpg` signing and
-# verification to "just work" later on, regardless of which
-# type of signing profile we have.
-if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
-  declare -a SHIM_SIGN_KEY
-  declare -a CODE_SIGN_KEY
-
-  # For an AWS profile, we expect a config file for the PKCS11
-  # helper. Otherwise, there should be a local key and cert.
-  if [ -s "${HOME}/.config/aws-kms-pkcs11/config.json" ] ; then
-    # Set AWS environment variables from build secrets, if present.
-    for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN ; do
-      val="${var,,}"
-      val="${HOME}/.aws/${val//_/-}.env"
-      [ -s "${val}" ] || continue
-      declare -x "${var}=$(cat "${val}")"
-    done
-    # Verify that AWS credentials are functional.
-    aws sts get-caller-identity
-    # Log all PKCS11 helper activity, to simplify debugging.
-    export AWS_KMS_PKCS11_DEBUG=1
-    SB_KEY_SOURCE="aws"
-    SHIM_SIGN_KEY=(-c shim-sign-key -t shim-sign-key)
-    CODE_SIGN_KEY=(-c code-sign-key -t code-sign-key)
-  else
-    # Disable the PKCS11 helper.
-    rm /etc/pkcs11/modules/aws-kms-pkcs11.module
-
-    # Generate the PKCS12 archives for import.
-    openssl pkcs12 \
-      -export \
-      -passout pass: \
-      -inkey "${SBKEYS}/shim-sign.key" \
-      -in "${SBKEYS}/shim-sign.crt" \
-      -certfile "${SBKEYS}/db.crt" \
-      -out "${SBKEYS}/shim-sign.p12"
-
-    openssl pkcs12 \
-      -export \
-      -passout pass: \
-      -inkey "${SBKEYS}/code-sign.key" \
-      -in "${SBKEYS}/code-sign.crt" \
-      -certfile "${SBKEYS}/vendor.crt" \
-      -out "${SBKEYS}/code-sign.p12"
-
-    # Import certificates and private key archive.
-    PEDB="/etc/pki/pesign"
-
-    certutil -d "${PEDB}" -A -n db -i "${SBKEYS}/db.crt" -t ",,C"
-    certutil -d "${PEDB}" -A -n shim-sign-key -i "${SBKEYS}/shim-sign.crt" -t ",,P"
-    pk12util -d "${PEDB}" -i "${SBKEYS}/shim-sign.p12" -W ""
-
-    certutil -d "${PEDB}" -A -n vendor -i "${SBKEYS}/vendor.crt" -t ",,C"
-    certutil -d "${PEDB}" -A -n code-sign-key -i "${SBKEYS}/code-sign.crt" -t ",,P"
-    pk12util -d "${PEDB}" -i "${SBKEYS}/code-sign.p12" -W ""
-
-    certutil -d "${PEDB}" -L
-    SB_KEY_SOURCE="local"
-    SHIM_SIGN_KEY=(-c shim-sign-key)
-    CODE_SIGN_KEY=(-c code-sign-key)
-  fi
-
-  # Convert certificates from PEM format (ASCII) to DER (binary). This could be
-  # done when the certificates are created, but the resulting binary files are
-  # not as nice to store in source control.
-  for cert in PK KEK db vendor ; do
-    openssl x509 \
-      -inform PEM -in "${SBKEYS}/${cert}.crt" \
-      -outform DER -out "${SBKEYS}/${cert}.cer"
-  done
-
-  # For signing the grub config, we need to embed the GPG public key in binary
-  # form, which is similarly awkward to store in source control.
-  gpg --import "${SBKEYS}/config-sign.key"
-  if [ "${SB_KEY_SOURCE}" == "aws" ] ; then
-    gpg --card-status
-  fi
-  gpg --export > "${SBKEYS}/config-sign.pubkey"
-  gpg --list-keys
-fi
-
 pushd "${EFI_MOUNT}/EFI/BOOT" >/dev/null
 shims=(boot*.efi)
 shim="${shims[0]}"
@@ -280,6 +197,11 @@ grub="${grubs[0]}"
 mokms=(mm*.efi)
 mokm="${mokms[0]}"
 if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
+  # Do the setup required for `pesign` and `gpg` signing and
+  # verification to "just work", regardless of which type of
+  # signing profile we have.
+  sbsetup_signing_profile
+
   # Convert the vendor certificate to the expected format.
   cert_table "${SBKEYS}/vendor.cer" "${SBKEYS}/vendor.obj"
 
@@ -570,7 +492,6 @@ if [ "${OUTPUT_FMT}" == "vmdk" ] ; then
     "${DATA_IMAGE_PUBLISH_SIZE_GIB}" \
     "${OVF_TEMPLATE}" \
     "${UEFI_SECURE_BOOT}" \
-    "${SBKEYS}" \
     "${OUTPUT_DIR}"
   symlink_image "ova" "os_image" "${OUTPUT_DIR}"
 fi

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -202,41 +202,12 @@ if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
   # signing profile we have.
   sbsetup_signing_profile
 
-  # Convert the vendor certificate to the expected format.
-  cert_table "${SBKEYS}/vendor.cer" "${SBKEYS}/vendor.obj"
-
-  # Replace the embedded vendor certificate, then sign shim with the db key.
-  "${ARCH}-objdumpcopy" "${shim}" \
-    --update-section ".vendor_cert=${SBKEYS}/vendor.obj"
-  pesign -i "${shim}" -o "${shim}.signed" -s "${SHIM_SIGN_KEY[@]}"
-  mv "${shim}.signed" "${shim}"
-  pesigcheck -i "${shim}" -n 0 -c "${SBKEYS}/db.cer"
-
-  # Sign the MOK manager as well.
-  pesign -i "${mokm}" -o "${mokm}.signed" -s "${CODE_SIGN_KEY[@]}"
-  mv "${mokm}.signed" "${mokm}"
-  pesigcheck -i "${mokm}" -n 0 -c "${SBKEYS}/vendor.cer"
-
-  # Replace the embedded gpg public key, then sign grub with the vendor key.
-  "${ARCH}-objdumpcopy" "${grub}" \
-    --file-alignment 4096 \
-    --update-section ".pubkey=${SBKEYS}/config-sign.pubkey"
-  pesign -i "${grub}" -o "${grub}.signed" -s "${CODE_SIGN_KEY[@]}"
-  mv "${grub}.signed" "${grub}"
-  pesigcheck -i "${grub}" -n 0 -c "${SBKEYS}/vendor.cer"
+  sign_shim "${shim}"
+  sign_mokm "${mokm}"
+  sign_grub "${grub}"
 else
-  # Generate a zero-sized certificate in the expected format.
-  cert_table /dev/null "${SBKEYS}/vendor.obj"
-
-  # Replace the embedded vendor certificate with the zero-sized one, which shim
-  # will ignore when Secure Boot is disabled.
-  "${ARCH}-objdumpcopy" "${shim}" \
-    --update-section ".vendor_cert=${SBKEYS}/vendor.obj"
-
-   # Remove the embedded gpg public key to disable GRUB's signature checks.
-   "${ARCH}-objdumpcopy" "${grub}" \
-     --file-alignment 4096 \
-     --remove-section ".pubkey"
+  zero_shim "${shim}"
+  unembed_grub "${grub}"
 fi
 popd >/dev/null
 
@@ -248,7 +219,7 @@ mcopy -i "${EFI_IMAGE}" "${EFI_MOUNT}/EFI/BOOT"/*.efi ::/EFI/BOOT
 if [ "${UEFI_SECURE_BOOT}" == "yes" ] ; then
   # Make the signing certificate available on the EFI system partition so it
   # can be imported through the firmware setup UI on bare metal systems.
-  mcopy -i "${EFI_IMAGE}" "${SBKEYS}"/db.{crt,cer} ::/EFI/BOOT
+  provide_certs "${EFI_IMAGE}"
 fi
 dd if="${EFI_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[EFI-A]}"
 


### PR DESCRIPTION
**Description of changes:**

Moves code-blocks related to secure boot to `imghelper`, with some minor adjustments for portability.

**Testing done:**

- Built and smoke tested `aws-k8s-1.28`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
