### PR TITLE
twoliter: fetch instead of fetch-sdk for builds

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -752,7 +752,7 @@ cargo metadata \
 
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
-dependencies = ["check-cargo-version", "fetch-sdk", "publish-setup", "fetch-licenses", "cargo-metadata"]
+dependencies = ["check-cargo-version", "fetch", "publish-setup", "fetch-licenses", "cargo-metadata"]
 script_runner = "bash"
 script = [
 '''
@@ -785,7 +785,7 @@ cargo build \
 ]
 
 [tasks.build-variant]
-dependencies = ["fetch-sdk", "build-sbkeys", "publish-setup", "cargo-metadata"]
+dependencies = ["fetch", "build-sbkeys", "publish-setup", "cargo-metadata"]
 script = [
 '''
 export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"


### PR DESCRIPTION

**Issue number:**

Fixes #214 

**Description of changes:**

We accidentally removed "fetch" from the Makefile.toml dependency graph when building a variant. This change restores it.

Get `fetch` back into the dependency graph for `build-variant` and `build-package`.

**Testing done:**

- [x] Before this fix I would get an error during `go mod vendor` and could see that `fetch-vendored` was not running.
- [x] After this fix, Bottlerocket builds.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
