### PR TITLE
buildsys build-kit

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -369,6 +369,15 @@ impl ManifestInfo {
             .unwrap_or_else(|| self.manifest_name())
     }
 
+    /// Convenience method to return the kit name. If the manifest has an override in the
+    /// `package.metadata.build-kit.kit-name` key, it is returned, otherwise the Cargo manifest name
+    /// is returned from `package.name`.
+    pub fn kit_name(&self) -> &str {
+        self.build_kit()
+            .and_then(|b| b.kit_name.as_deref())
+            .unwrap_or_else(|| self.manifest_name())
+    }
+
     /// Convenience method to find whether the package is sensitive to variant changes.
     pub fn variant_sensitive(&self) -> Option<&VariantSensitivity> {
         self.build_package()
@@ -542,7 +551,7 @@ pub struct BuildPackage {
 #[serde(rename_all = "kebab-case")]
 #[allow(dead_code)]
 pub struct BuildKit {
-    pub included_packages: Option<Vec<String>>,
+    pub kit_name: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -11,6 +11,7 @@ BUILDSYS_ARCH = { script = ['echo "${BUILDSYS_ARCH:-$(uname -m)}"'] }
 BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 BUILDSYS_BUILD_DIR = "${BUILDSYS_ROOT_DIR}/build"
 BUILDSYS_PACKAGES_DIR = "${BUILDSYS_BUILD_DIR}/rpms"
+BUILDSYS_KITS_DIR = "${BUILDSYS_BUILD_DIR}/kits"
 BUILDSYS_STATE_DIR = "${BUILDSYS_BUILD_DIR}/state"
 BUILDSYS_IMAGES_DIR = "${BUILDSYS_BUILD_DIR}/images"
 BUILDSYS_TOOLS_DIR = "${BUILDSYS_ROOT_DIR}/tools"
@@ -280,6 +281,7 @@ fi
 mkdir -p ${BUILDSYS_BUILD_DIR}
 mkdir -p ${BUILDSYS_OUTPUT_DIR}
 mkdir -p ${BUILDSYS_PACKAGES_DIR}
+mkdir -p ${BUILDSYS_KITS_DIR}
 mkdir -p ${BUILDSYS_STATE_DIR}
 mkdir -p ${BUILDSYS_METADATA_DIR}
 mkdir -p ${GO_MOD_CACHE}
@@ -1531,11 +1533,13 @@ extend = "_upload-ova-base"
 dependencies = [
   "clean-sources",
   "clean-packages",
+  "clean-kits",
   "clean-images",
   "clean-repos",
   "clean-state",
   "clean-tools",
   "clean-metadata",
+  "clean-workspace",
 ]
 
 [tasks.clean-sources]
@@ -1551,12 +1555,27 @@ rm -f ${BUILDSYS_TOOLS_DIR}/bin/*
 '''
 ]
 
+[tasks.clean-workspace]
+script_runner = "bash"
+script = [
+'''
+cargo clean --manifest-path "${BUILDSYS_ROOT_DIR}/Cargo.toml"
+'''
+]
+
 [tasks.clean-packages]
 script_runner = "bash"
 script = [
 '''
 rm -rf ${BUILDSYS_PACKAGES_DIR}
-cargo clean --manifest-path "${BUILDSYS_ROOT_DIR}/Cargo.toml"
+'''
+]
+
+[tasks.clean-kits]
+script_runner = "bash"
+script = [
+'''
+rm -rf ${BUILDSYS_KITS_DIR}
 '''
 ]
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #70 
Closes #73
Follows #226 

**Description of changes:**

Add a `build-kit` command that can create a local kit!

**Testing done:**

- [x] Build the test project kits, it worked!
- [x] Build Bottlerocket, it's not broken!

Kit test: (note `build-variant` fails because the test project does not have a kernel)

```
   Compiling pkg-a-1_27 v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/packages/pkg-a-1.27)
   Compiling core-kit v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/kits/core-kit)
   Compiling pkg-c v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/packages/pkg-c)
   Compiling pkg-b v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/packages/pkg-b)
   Compiling pkg-d v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/packages/pkg-d)
   Compiling pkg-f v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/packages/pkg-f)
   Compiling pkg-g v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/packages/pkg-g)
   Compiling extra-1-kit v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/kits/extra-1-kit)
   Compiling extra-2-kit v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/kits/extra-2-kit)
   Compiling pkg-e v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/packages/pkg-e)
   Compiling extra-3-kit v0.1.0 (/home/somebody/repos/twoliter/tests/projects/local-kit/kits/extra-3-kit)
```

```
$ tree rpms kits
rpms
├── pkg-a-1.27
│   └── bottlerocket-pkg-a-0.0-0.x86_64.rpm
├── pkg-b
│   └── bottlerocket-pkg-b-0.0-0.x86_64.rpm
├── pkg-c
│   └── bottlerocket-pkg-c-0.0-0.x86_64.rpm
├── pkg-d
│   └── bottlerocket-pkg-d-0.0-0.x86_64.rpm
├── pkg-e
│   └── bottlerocket-pkg-e-0.0-0.x86_64.rpm
├── pkg-f
│   └── bottlerocket-pkg-f-0.0-0.x86_64.rpm
└── pkg-g
    └── bottlerocket-pkg-g-0.0-0.x86_64.rpm
kits
├── core-kit
│   └── x86_64
│       ├── Packages
│       │   └── bottlerocket-pkg-a-0.0-0.x86_64.rpm
│       └── repodata
│           ├── 1dc260ef8cb9d32636f49827fe04aaf7bac406c21f8d8cdaf1d7766089ebec90-filelists.xml.zst
│           ├── b1d71027e5090bb17bce76a9358bc5549cd3e2710022f5c94c45012882dc61c1-primary.xml.zst
│           ├── e6ad51b865bac427c57e6cc98fe6047c2165831834d252d6476faebbb0d2c6b5-other.xml.zst
│           └── repomd.xml
├── extra-1-kit
│   └── x86_64
│       ├── Packages
│       │   ├── bottlerocket-pkg-b-0.0-0.x86_64.rpm
│       │   └── bottlerocket-pkg-d-0.0-0.x86_64.rpm
│       └── repodata
│           ├── 27986a40a542036143227d3c95bd0d482cbcf5bdfa4c8a2c17319261a81133f3-filelists.xml.zst
│           ├── 2e9747b211b81b6d923b97b925eed64678fa0eb3abee546eba56a5916c2ecdaa-primary.xml.zst
│           ├── 4e63bbf66f02a170e5fdb959693d76074370b0725228b6c4ebcd3ebe780fd89b-other.xml.zst
│           └── repomd.xml
├── extra-2-kit
│   └── x86_64
│       ├── Packages
│       │   └── bottlerocket-pkg-c-0.0-0.x86_64.rpm
│       └── repodata
│           ├── 07f3159e9651db8be604dbb4eadf808789d7b831b1350899d0aed191ef46ddcd-other.xml.zst
│           ├── 6c649dcc73afbff1e2c1982e64e1acc224b123726de816c3435982703354dada-primary.xml.zst
│           ├── 9e3b96057582abd3c874a100efab6491ebd42cfa2c28c14ef5b7afe7d72595e1-filelists.xml.zst
│           └── repomd.xml
└── extra-3-kit
    └── x86_64
        ├── Packages
        │   ├── bottlerocket-pkg-e-0.0-0.x86_64.rpm
        │   ├── bottlerocket-pkg-f-0.0-0.x86_64.rpm
        │   └── bottlerocket-pkg-g-0.0-0.x86_64.rpm
        └── repodata
            ├── 230dd1c616e0f9a38df7664e1be7436190fdb143a7cabb9924a6b9593cd75421-other.xml.zst
            ├── 4ae4927f963e446f083b43590b33199a7aa54d1083152d9466b5e5fba566bbde-primary.xml.zst
            ├── ce0523598374330d2ee6a6fb9ac142ffa0ca1ed58eb92c3a83dc4562cb61d5c8-filelists.xml.zst
            └── repomd.xml
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
