### PR TITLE
imghelper: fix regression in hmac generation

### DIFF
--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -492,7 +492,7 @@ generate_hmac() {
   vmlinuz="${1:?}"
   openssl sha512 -hmac FIPS-FTW-RHT2009 -hex "${vmlinuz}" |
     awk -v vmlinuz="${vmlinuz}" '{ print $2 "  " vmlinuz }' \
-      >"${vmlinuz%/*}.${vmlinuz##*/}.hmac"
+      >"${vmlinuz%/*}/.${vmlinuz##*/}.hmac"
 }
 
 sign_grubcfg() {


### PR DESCRIPTION
**Description of changes:**

When moving the vmlinuz hmac generation to `imghelper`, a typo was introduced where the `/` was missing between the output directory and the beginning of the filename.

**Testing done:**

- Built/repacked `aws-k8s-1.28` and verified in the output that `/boot/.vmlinuz.hmac` existed.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
