### PR TITLE
twoliter: adjust project specifications and infra specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,6 +3792,7 @@ dependencies = [
  "non-empty-string",
  "pubsys",
  "pubsys-setup",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/tests/projects/local-kit/Twoliter.toml
+++ b/tests/projects/local-kit/Twoliter.toml
@@ -2,6 +2,9 @@ schema-version = 1
 release-version = "1.0.0"
 
 [sdk]
+name = "bottlerocket-sdk"
+vendor = "bottlerocket"
+version = "0.41.0"
+
+[vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"
-repo = "bottlerocket-sdk"
-tag = "v0.41.0"

--- a/tests/projects/project1/Twoliter.toml
+++ b/tests/projects/project1/Twoliter.toml
@@ -2,6 +2,9 @@ schema-version = 1
 release-version = "1.0.0"
 
 [sdk]
+name = "bottlerocket-sdk"
+vendor = "bottlerocket"
+version = "0.41.0"
+
+[vendor.bottlerocket]
 registry = "twoliter.alpha"
-repo = "bottlerocket-sdk"
-tag = "latest"

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -26,6 +26,9 @@ pub struct InfraConfig {
 
     // Config for VMware specific subcommands
     pub vmware: Option<VmwareConfig>,
+
+    // Config for container registries
+    pub vendor: Option<HashMap<String, Vendor>>,
 }
 
 impl InfraConfig {
@@ -102,6 +105,12 @@ impl InfraConfig {
             })?
             .join("Infra.lock"))
     }
+}
+
+/// Container registry vendor
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
+pub struct Vendor {
+    pub registry: String,
 }
 
 /// S3-specific TUF infrastructure configuration

--- a/tools/pubsys/Infra.toml.example
+++ b/tools/pubsys/Infra.toml.example
@@ -82,3 +82,7 @@ datastore = "WorkloadDatastore" # GOVC_DATASTORE
 network = "sddc-cgw-network-1" # GOVC_NETWORK
 folder = "my_folder" # GOVC_FOLDER
 resource_pool = "/SDDC-Datacenter/host/Cluster/Resources/Compute-ResourcePool" # GOVC_RESOURCE_POOL
+
+# Container vendor specific configuration
+[vendor.bottlerocket]
+registry = "my.vendor/path"

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -21,6 +21,7 @@ futures= "0.3"
 hex = "0.4"
 log = "0.4"
 non-empty-string = { version = "0.2", features = [ "serde" ] }
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/twoliter/src/cargo_make.rs
+++ b/twoliter/src/cargo_make.rs
@@ -140,7 +140,7 @@ impl CargoMake {
 }
 
 fn require_sdk(project: &Project) -> Result<ImageUri> {
-    match project.sdk() {
+    match project.sdk()? {
         Some(s) => Ok(s),
         _ => bail!(
             "When using twoliter make, it is required that the SDK be specified in Twoliter.toml"

--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -64,13 +64,10 @@ impl BuildVariant {
 
         let sdk_container = DockerContainer::new(
             format!("sdk-{}", token),
-            project
-                .sdk()
-                .context(format!(
-                    "No SDK defined in {}",
-                    project.filepath().display(),
-                ))?
-                .uri(),
+            project.sdk()?.context(format!(
+                "No SDK defined in {}",
+                project.filepath().display(),
+            ))?,
         )
         .await?;
         sdk_container

--- a/twoliter/src/lock.rs
+++ b/twoliter/src/lock.rs
@@ -1,0 +1,30 @@
+use crate::schema_version::SchemaVersion;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+/// Represents the structure of a `Twoliter.lock` lock file.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct Lock {
+    /// The version of the Twoliter.toml this was generated from
+    pub schema_version: SchemaVersion<1>,
+    /// The workspace release version
+    pub release_version: String,
+    /// The resolved bottlerocket sdk
+    pub sdk: LockedImage,
+    /// Resolved kit dependencies
+    pub kit: Vec<LockedImage>,
+}
+
+/// Represents a locked dependency on an image
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub(crate) struct LockedImage {
+    /// The name of the dependency
+    pub name: String,
+    /// The version of the dependency
+    pub version: Version,
+    /// The vendor this dependency came from
+    pub vendor: String,
+    /// The resolved image uri of the dependency
+    pub source: String,
+}

--- a/twoliter/src/main.rs
+++ b/twoliter/src/main.rs
@@ -6,13 +6,13 @@ mod cargo_make;
 mod cmd;
 mod common;
 mod docker;
+mod lock;
 mod project;
 mod schema_version;
-mod tools;
-
 /// Test code that should only be compiled when running tests.
 #[cfg(test)]
 mod test;
+mod tools;
 
 /// `anyhow` prints a nicely formatted error message with `Debug`, so we can return a result from
 /// the `main` function.

--- a/twoliter/src/test/data/Twoliter-1.toml
+++ b/twoliter/src/test/data/Twoliter-1.toml
@@ -2,6 +2,14 @@ schema-version = 1
 release-version = "1.0.0"
 
 [sdk]
+name = "my-bottlerocket-sdk"
+version = "1.2.3"
+vendor = "my-vendor"
+
+[vendor.my-vendor]
 registry = "a.com/b"
-repo = "my-bottlerocket-sdk"
-tag = "v1.2.3"
+
+[[kit]]
+name = "my-core-kit"
+version = "1.2.3"
+vendor = "my-vendor"


### PR DESCRIPTION
**Issue number:** 233

Closes #233

**Description of changes:**

* Adds vendor section to Twoliter.toml
* Adds kit section to Twoliter.toml
* Adds validation for vendors
* Adjusts sdk definition to use same dependency shape as kits
* Defines shape of Twoliter.lock


**Testing done:**
Expanded tests to the new shape. Added unit test to verify vendor validation


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
