### PR TITLE
withdraw support for license overrides

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -56,10 +56,6 @@ PUBLISH_LOG_LEVEL = "info"
 # tools/pubsys/policies/ssm/README.md for more information.
 PUBLISH_SSM_TEMPLATES_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/ssm/defaults.toml"
 
-# This can be overridden with -e to change the source path
-# for the Licenses.toml file
-BUILDSYS_LICENSES_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Licenses.toml"
-
 # Specifies whether to validate all targets when validating TUF repositories
 REPO_VALIDATE_TARGETS = "true"
 # Specifies the timeframe to look for upcoming repository metadata expirations
@@ -784,7 +780,7 @@ fi
 
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
-dependencies = ["check-cargo-version", "fetch", "publish-setup", "fetch-licenses", "cargo-metadata"]
+dependencies = ["check-cargo-version", "fetch", "publish-setup", "cargo-metadata"]
 script_runner = "bash"
 script = [
 '''
@@ -889,47 +885,9 @@ docker run --rm \
 '''
 ]
 
-[tasks.fetch-licenses]
-dependencies = ["fetch"]
-script = [
-'''
-if [ "${BUILDSYS_UPSTREAM_LICENSE_FETCH}" = "false" ]; then
-  echo "Skipping fetching licenses"
-  exit 0
-fi
-
-# Attempt copy Licenses.toml
-cp "${BUILDSYS_LICENSES_CONFIG_PATH}" "${BUILDSYS_ROOT_DIR}/Licenses.toml" 2>/dev/null \
-  || echo "Skipping copying file from ${BUILDSYS_LICENSES_CONFIG_PATH}"
-
-if [ ! -s "${BUILDSYS_ROOT_DIR}"/Licenses.toml ] ; then
-  echo "Not fetching licenses since 'Licenses.toml' doesn't exist"
-  exit 0
-fi
-
-mkdir -p "${BUILDSYS_ROOT_DIR}"/licenses
-
-run_fetch_licenses="
-bottlerocket-license-tool -l /tmp/Licenses.toml fetch /tmp/licenses
-"
-set +e
-
-docker run --rm \
-  --user "$(id -u):$(id -g)" \
-  --security-opt="label=disable" \
-  -e CARGO_HOME="/tmp/.cargo" \
-  -v "${CARGO_HOME}":/tmp/.cargo \
-  -v "${BUILDSYS_ROOT_DIR}/licenses:/tmp/licenses" \
-  -v "${BUILDSYS_ROOT_DIR}/Licenses.toml:/tmp/Licenses.toml" \
-  "${TLPRIVATE_SDK_IMAGE}" \
-  bash -c "${run_fetch_licenses}"
-'''
-]
-
 [tasks.build]
 dependencies = [
     "check-licenses",
-    "fetch-licenses",
     "build-variant",
 ]
 

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -106,16 +106,6 @@ WORKDIR /home/builder
 
 USER builder
 ENV PACKAGE=${PACKAGE} ARCH=${ARCH}
-# We attempt to copy `Licenses.toml` and `licenses` for the current build, otherwise
-# an empty file and a directory are created so that `bottlerocket-license-tool` will
-# fail with a more descriptive error message.
-RUN --mount=target=/host \
-  ( [ -f /host/Licenses.toml ] \
-  && cp /host/Licenses.toml ./rpmbuild/BUILD/ \
-  || touch ./rpmbuild/BUILD/Licenses.toml ) \
-  && ( [ -d /host/licenses ] \
-  && cp -r /host/licenses ./rpmbuild/BUILD/ \
-  || mkdir ./rpmbuild/BUILD/licenses )
 COPY ./packages/${PACKAGE}/ .
 
 COPY --chown=builder --from=rpm-macros-and-bconds /home/builder/generated.* .


### PR DESCRIPTION
**Issue number:**

Closes #100

**Description of changes:**
Drop support for overriding licenses via `Licenses.toml`. This doesn't work properly in an out-of-tree build world, since the override must be set when the RPM is built if it is shipped in a kit, but may be needed downstream when the RPM is installed.


**Testing done:**
Built `twoliter` with this change and then built Bottlerocket after applying the change from https://github.com/bottlerocket-os/bottlerocket/pull/3991.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
