### PR TITLE
twoliter: use grub-bios-setup from SDK

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -219,14 +219,14 @@ rm -rf "${ROOT_MOUNT}"/var/lib "${ROOT_MOUNT}"/usr/share/licenses/*
 if [[ "${ARCH}" == "x86_64" ]]; then
   # MBR and BIOS-BOOT
   echo "(hd0) ${OS_IMAGE}" >"${ROOT_MOUNT}/boot/grub/device.map"
-  "${ROOT_MOUNT}/sbin/grub-bios-setup" \
+  grub-bios-setup \
     --directory="${ROOT_MOUNT}/boot/grub" \
     --device-map="${ROOT_MOUNT}/boot/grub/device.map" \
     --root="hd0" \
     --skip-fs-probe \
     "${OS_IMAGE}"
 
-  rm -vf "${ROOT_MOUNT}"/boot/grub/* "${ROOT_MOUNT}"/sbin/grub*
+  rm -vf "${ROOT_MOUNT}"/boot/grub/*
 fi
 
 # We also need an EFI partition, formatted FAT32 with the


### PR DESCRIPTION
**Issue number:**

Closes #225

**Description of changes:**
Rely on `grub-bios-setup` from the SDK. Depends on https://github.com/bottlerocket-os/bottlerocket-sdk/pull/183.


**Testing done:**
Applied this change and switched to a custom SDK. Verified that I could build an x86_64 image and boot on a system using BIOS firmware.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
