### PR TITLE
imghelper: check full output of `pesign -l`

### DIFF
--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -478,7 +478,7 @@ sbsetup_signing_profile() {
 undo_sign() {
   local what
   what="${1:?}"
-  if [[ "$(pesign -i "${what}" -l)" != "No signatures found." ]]; then
+  if [[ ! "$(pesign -i "${what}" -l)" =~ 'No signatures found.' ]]; then
     mv "${what}" "${what}.orig"
     pesign -i "${what}.orig" -o "${what}" -u 0 -r
     rm "${what}.orig"


### PR DESCRIPTION
**Description of changes:**

Rather than assuming listing signatures with `pesign` will only return `"No signatures found."`, check if the output of the command contains that string.

**Testing done:**

Built bottlerocket using an AWS profile for secure boot signing. (thanks, @bcressey!)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
