### PR TITLE
improve backwards compatibility for existing projects

### DIFF
--- a/tools/buildsys/src/manifest/error.rs
+++ b/tools/buildsys/src/manifest/error.rs
@@ -34,9 +34,4 @@ pub(super) enum Error {
         "The cargo package we are building, '{name}', could not be found in the graph"
     ))]
     RootDependencyMissing { name: String },
-
-    #[snafu(display(
-        "Expected to find one of build-package, build-kit, or build-variant in package.metadata."
-    ))]
-    UnknownManifestType {},
 }

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -820,9 +820,20 @@ export BUILDSYS_VARIANT_RUNTIME="${BUILDSYS_VARIANT_RUNTIME:?}"
 export BUILDSYS_VARIANT_FAMILY="${BUILDSYS_VARIANT_FAMILY:?}"
 export BUILDSYS_VARIANT_FLAVOR="${BUILDSYS_VARIANT_FLAVOR}"
 
+# Relocate an existing target directory to the new location, to avoid breaking
+# compatibility on upgrade. On downgrade, the missing directory will trigger a
+# full rebuild, which is good because the new layout of RPM artifacts is not
+# compatible with previous versions.
+if [ -d "${BUILDSYS_ROOT_DIR}/variants/target/${BUILDSYS_ARCH}" ]; then
+  mkdir -p "${BUILDSYS_ROOT_DIR}/target"
+  mv \
+    "${BUILDSYS_ROOT_DIR}/variants/target/${BUILDSYS_ARCH}" \
+    "${BUILDSYS_ROOT_DIR}/target/${BUILDSYS_ARCH}"
+fi
+
 # Save built artifacts for each architecture.  We don't set this everywhere
 # because we build host tools with cargo as well, like buildsys and pubsys.
-export CARGO_TARGET_DIR=${BUILDSYS_ROOT_DIR}/variants/target/${BUILDSYS_ARCH}
+export CARGO_TARGET_DIR="${BUILDSYS_ROOT_DIR}/target/${BUILDSYS_ARCH}"
 
 cargo build \
   ${CARGO_BUILD_ARGS} \
@@ -844,6 +855,17 @@ export BUILDSYS_VARIANT_PLATFORM="${BUILDSYS_VARIANT_PLATFORM:?}"
 export BUILDSYS_VARIANT_RUNTIME="${BUILDSYS_VARIANT_RUNTIME:?}"
 export BUILDSYS_VARIANT_FAMILY="${BUILDSYS_VARIANT_FAMILY:?}"
 export BUILDSYS_VARIANT_FLAVOR="${BUILDSYS_VARIANT_FLAVOR}"
+
+# Relocate an existing target directory to the new location, to avoid breaking
+# compatibility on upgrade. On downgrade, the missing directory will trigger a
+# full rebuild, which is good because the new layout of RPM artifacts is not
+# compatible with previous versions.
+if [ -d "${BUILDSYS_ROOT_DIR}/variants/target/${BUILDSYS_ARCH}" ]; then
+  mkdir -p "${BUILDSYS_ROOT_DIR}/target"
+  mv \
+    "${BUILDSYS_ROOT_DIR}/variants/target/${BUILDSYS_ARCH}" \
+    "${BUILDSYS_ROOT_DIR}/target/${BUILDSYS_ARCH}"
+fi
 
 # Save built artifacts for each architecture.  We don't set this everywhere
 # because we build host tools with cargo as well, like buildsys and pubsys.

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -329,11 +329,10 @@ dependencies = ["setup"]
 script_runner = "bash"
 script = [
 '''
-if [ -f "${BUILDSYS_SOURCES_DIR}/Cargo.toml" ]; then
-  cargo fetch --locked --manifest-path "${BUILDSYS_SOURCES_DIR}/Cargo.toml"
-fi
-
-cargo fetch --locked --manifest-path "${BUILDSYS_ROOT_DIR}/Cargo.toml"
+for ws in sources variants .; do
+  [ -s "${BUILDSYS_ROOT_DIR}/${ws}/Cargo.toml" ] || continue
+  cargo fetch --locked --manifest-path "${BUILDSYS_ROOT_DIR}/${ws}/Cargo.toml"
+done
 
 chmod -R o+r ${CARGO_HOME}
 '''
@@ -744,10 +743,27 @@ dependencies = ["setup"]
 script_runner = "bash"
 script = [
 '''
+OLD_WS_MANIFEST="${BUILDSYS_ROOT_DIR}/variants/Cargo.toml"
+NEW_WS_MANIFEST="${BUILDSYS_ROOT_DIR}/Cargo.toml"
+if [ -s "${OLD_WS_MANIFEST}" ] && [ -s "${NEW_WS_MANIFEST}" ]; then
+  echo "Found two project workspaces: ${OLD_WS_MANIFEST} and ${NEW_WS_MANIFEST}.">&2
+  echo "This configuration is not supported.">&2
+  exit 1
+elif [ -s "${NEW_WS_MANIFEST}" ]; then
+  PROJECT_MANIFEST="${NEW_WS_MANIFEST}"
+elif [ -s "${OLD_WS_MANIFEST}" ]; then
+  echo "Found deprecated project workspace ${OLD_WS_MANIFEST}.">&2
+  echo "Please relocate it to ${NEW_WS_MANIFEST}.">&2
+  PROJECT_MANIFEST="${OLD_WS_MANIFEST}"
+else
+  echo "Could not find project workspace at ${NEW_WS_MANIFEST}. Please create it." >&2
+  exit 1
+fi
+
 rm -f "${BUILDSYS_CARGO_METADATA_PATH}"
 cargo metadata \
   --format-version 1 \
-  --manifest-path "${BUILDSYS_ROOT_DIR}/Cargo.toml" \
+  --manifest-path "${PROJECT_MANIFEST}" \
   --offline \
   --all-features \
   > "${BUILDSYS_CARGO_METADATA_PATH}"
@@ -1573,7 +1589,19 @@ rm -f ${BUILDSYS_TOOLS_DIR}/bin/*
 script_runner = "bash"
 script = [
 '''
-cargo clean --manifest-path "${BUILDSYS_ROOT_DIR}/Cargo.toml"
+# The workspace manifest could be the old one under variants, or the new one at
+# the project root.
+for ws in variants .; do
+  manifest="${BUILDSYS_ROOT_DIR}/${ws}/Cargo.toml"
+  [ -s "${manifest}" ] || continue
+  # The targets directory could be under variants, or at the root, for either of
+  # the possible workspace manifest locations.
+  for td in target variants/target ; do
+    targets="${BUILDSYS_ROOT_DIR}/${td}/${BUILDSYS_ARCH}"
+    [ -d "${targets}" ] || continue
+    CARGO_TARGET_DIR="${targets}" cargo clean --manifest-path "${manifest}"
+  done
+done
 '''
 ]
 

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -770,34 +770,6 @@ cargo metadata \
 '''
 ]
 
-# This task is temporarily necessary due to changes in Twoliter that occurred in June 2024. A new
-# directory structure was introduced for build/rpms. Attempts to do an incremental build when the
-# build output was in the old directory structure would fail, so we needed a way to inform users
-# that they need to run a cargo make clean.
-#
-# Once the changed build/rpms structure has been around long enough (in, say, August 2024), this
-# task can be removed as we can assume that no lingering old incremental builds exist in the wild.
-#
-# TODO - remove this task sometime around, or after, August 2024.
-[tasks.check-rpm-structure]
-script_runner = "bash"
-script = [
-'''
-if [ ! -d "${BUILDSYS_PACKAGES_DIR}" ]; then
-  exit 0
-fi
-
-count=$(find "${BUILDSYS_PACKAGES_DIR}" -maxdepth 1 -name "*.rpm" | wc -l)
-
-if [ "${count}" != "0" ]; then
-    echo "ERROR: You have rpms in a flat structure in ${BUILDSYS_PACKAGES_DIR}"
-    echo "Twoliter and Buildsys have been updated to use a different RPM directory structure"
-    echo "PLEASE RUN: cargo make clean"
-    exit 1
-fi
-'''
-]
-
 # Builds a package including its build-time and runtime dependency packages.
 [tasks.build-package]
 dependencies = ["check-cargo-version", "fetch", "publish-setup", "fetch-licenses", "cargo-metadata"]

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -346,7 +346,7 @@ WORKDIR /root
 USER root
 RUN --mount=target=/host \
     mkdir -p /local/migrations \
-    && find /host/build/rpms/os/ -maxdepth 1 -type f \
+    && find /host/build/rpms/ -maxdepth 2 -type f \
         -name "bottlerocket-migrations-*.rpm" \
         -not -iname '*debuginfo*' \
         -exec cp '{}' '/local/migrations/' ';' \
@@ -373,7 +373,7 @@ WORKDIR /tmp
 RUN --mount=target=/host \
     mkdir -p /local/archives \
     && KERNEL="$(printf "%s\n" ${PACKAGES} | awk '/^kernel-/{print $1}')" \
-    && find /host/build/rpms/${KERNEL}/ -maxdepth 1 -type f \
+    && find /host/build/rpms/ -maxdepth 2 -type f \
         -name "bottlerocket-${KERNEL}-archive-*.rpm" \
         -exec cp '{}' '/local/archives/' ';' \
     && /host/build/tools/rpm2kmodkit \

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -129,8 +129,11 @@ RUN \
 
 USER root
 RUN --mount=target=/host \
+    find /host/build/rpms/ -mindepth 1 -maxdepth 1 -name '*.rpm' -size +0c -print -exec \
+      ln -snft ./rpmbuild/RPMS {} \+ && \
     for pkg in ${PACKAGE_DEPENDENCIES} ; do \
-      ln -s /host/build/rpms/${pkg}/*.rpm ./rpmbuild/RPMS ; \
+      find /host/build/rpms/${pkg}/ -mindepth 1 -maxdepth 1 -name '*.rpm' -size +0c -print -exec \
+        ln -snft ./rpmbuild/RPMS {} \+ ; \
     done && \
     createrepo_c \
         -o ./rpmbuild/RPMS \
@@ -239,10 +242,13 @@ WORKDIR /root
 USER root
 RUN --mount=target=/host \
     mkdir -p ./rpmbuild/RPMS && \
+    find /host/build/rpms/ -mindepth 1 -maxdepth 1 -name '*.rpm' -size +0c -print -exec \
+      ln -snft ./rpmbuild/RPMS {} \+ && \
     for pkg in ${PACKAGE_DEPENDENCIES} ; do \
-      ln -s /host/build/rpms/${pkg}/*.rpm ./rpmbuild/RPMS ; \
+      find /host/build/rpms/${pkg}/ -mindepth 1 -maxdepth 1 -name '*.rpm' -size +0c -print -exec \
+        ln -snft ./rpmbuild/RPMS {} \+ ; \
     done && \
-    ln -s /home/builder/rpmbuild/RPMS/*/*.rpm ./rpmbuild/RPMS && \
+    ln -snf /home/builder/rpmbuild/RPMS/*/*.rpm ./rpmbuild/RPMS && \
     createrepo_c \
         -o ./rpmbuild/RPMS \
         -x '*-debuginfo-*.rpm' \


### PR DESCRIPTION
**Issue number:**

Related: #207

**Description of changes:**
The changes queued up amount to flag day where existing projects have to make structural changes and clean existing build artifacts. This is an annoyance for local development, but could be a bigger headache if past point release branches need to move to a newer version of `twoliter` for any reason.

Try to ease some of the pain in the transition by making a few concessions to backwards compatibility:

1. Use existing RPMs during builds if they exist, but clean them up if the corresponding package is rebuilt so the project converges on the new structure over time.
2. Keep the old target directory that cargo uses to track what's been built, but move it to the new location.
3. Support the workspace manifest in either the old location, under `variants`, or the new location at the project root.
4. Treat manifests with no buildsys-related metadata as "packages" (rather than "variants" or "kits").


**Testing done:**
Built the main project repo with the previous release of `twoliter`, updated to a local build of `twoliter` with these changes, and confirmed that builds and cleanup worked as expected. 

Output showing warnings:
```
[cargo-make] INFO - cargo make 0.36.11
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: default
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: install-twoliter
Found Twoliter v0.1.1 installed.
Skipping installation.
[cargo-make] INFO - Execute Command: "/home/fedora/brdev/tools/twoliter/twoliter" "--log-level=info" "make" "default" "--project-path=/home/fedora/brdev/Twoliter.toml" "--cargo-home=/home/fedora/brdev/.cargo" "--"
[2024-05-29T17:22:16Z WARN  twoliter::project] A Release.toml file was found. Release.toml is deprecated. Please remove it from your project.
[cargo-make][1] INFO - Build File: /home/fedora/brdev/build/tools/Makefile.toml
[cargo-make][1] INFO - Task: default
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: setup
[cargo-make][1] INFO - Running Task: setup-build
[cargo-make][1] INFO - Running Task: fetch-sdk
[cargo-make][1] INFO - Running Task: fetch-sources
[cargo-make][1] INFO - Running Task: fetch-vendored
[cargo-make][1] INFO - Running Task: check-licenses
bans ok, licenses ok, sources ok
[cargo-make][1] INFO - Running Task: fetch-licenses
Skipping fetching licenses
[cargo-make][1] INFO - Running Task: build-sbkeys
[cargo-make][1] INFO - Running Task: publish-setup
17:22:21 [INFO] Found infra config at path: /home/fedora/brdev/Infra.toml
[cargo-make][1] INFO - Running Task: cargo-metadata
Found deprecated project workspace /home/fedora/brdev/variants/Cargo.toml.
Please relocate it to /home/fedora/brdev/Cargo.toml.
[cargo-make][1] INFO - Running Task: build-variant
   Compiling libtirpc v0.1.0 (/home/fedora/brdev/packages/libtirpc)
   Compiling aws-signing-helper v0.1.0 (/home/fedora/brdev/packages/aws-signing-helper)
   Compiling static-pods v0.1.0 (/home/fedora/brdev/packages/static-pods)
   Compiling ecr-credential-provider-1_27 v0.1.0 (/home/fedora/brdev/packages/ecr-credential-provider-1.27)
   Compiling os v0.1.0 (/home/fedora/brdev/packages/os)
warning: netdog@0.1.0: Expected to find one of 'build-package', 'build-kit', or 'build-variant' in package.metadata. Assuming 'build-package'.
warning: netdog@0.1.0: Expected to find one of 'build-package', 'build-kit', or 'build-variant' in package.metadata. Assuming 'build-package'.
   Compiling kmod-6_1-nvidia v0.1.0 (/home/fedora/brdev/packages/kmod-6.1-nvidia)
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
