### PR TITLE
alpha-sdk: keep a flat rpm structure

### DIFF
--- a/local/alpha-sdk.Dockerfile
+++ b/local/alpha-sdk.Dockerfile
@@ -4,7 +4,8 @@ ARG HOST_GOARCH
 FROM $SDK
 FROM --platform=linux/${HOST_GOARCH} $SDK
 
-COPY build/rpms/ /twoliter/alpha/build/rpms/
+COPY build/rpms/*.rpm /twoliter/alpha/build/rpms/
+COPY build/rpms/*/*.rpm /twoliter/alpha/build/rpms/
 
 # These may need to be moved to Twoliter, but for now we will access them from the Alpha SDK.
 # They have been moved into the .cargo directory because they are otherwise .dockerignored.


### PR DESCRIPTION
**Issue number:**

Related #209 #210 

**Description of changes:**

For now, twoliter build variant is using the Alpha SDK, which has always had a flat RPM directory structure. Now the build produces a per-package directory structure in build/rpms.

When creating an Alpha SDK we will flatten the RPM directory structure so that twoliter build variant keeps working.


**Testing done:**

Did this

```shell
wrk="$(mktemp -d)"
echo $wrk
cd $wrk

mkdir -p \
  build/rpms/a \
  build/rpms/b \
  build/rpms/c \
  .cargo/sbkeys \
  sources/logdog/conf \
  sources/models/src/variant

touch build/rpms/a/a.rpm \
  build/rpms/b.rpm \
  build/rpms/c1.rpm \
  build/rpms/flat1.rpm \
  build/rpms/c/c1.rpm \
  build/rpms/c/c2.rpm \
  build/rpms/c/c3.rpm \
  .cargo/sbkeys/generate-local-sbkeys \
  .cargo/sbkeys/generate-aws-sbkeys \
  sources/logdog/conf/current \
  sources/models/src/variant \
  touch LICENSE-APACHE \
  touch LICENSE-MIT \
  touch COPYRIGHT

tree -a

docker build \
  --file $REPOS/twoliter/local/alpha-sdk.Dockerfile \
  --build-arg SDK=ubuntu \
  --build-arg HOST_GOARCH=amd64 \
  --tag alpha-sdk-proto:latest \
 .

docker run -it --rm --name deleteme alpha-sdk-proto:latest \
  bash -c 'apt update && apt install tree && tree /twoliter'
```

Before this change:

```
/twoliter
`-- alpha
    |-- build
    |   `-- rpms
    |       |-- a
    |       |   `-- a.rpm
    |       |-- b
    |       |-- b.rpm
    |       |-- c
    |       |   |-- c1.rpm
    |       |   |-- c2.rpm
    |       |   `-- c3.rpm
    |       |-- c1.rpm
    |       `-- flat1.rpm
    |-- licenses
    |   |-- COPYRIGHT
    |   |-- LICENSE-APACHE
    |   `-- LICENSE-MIT
    |-- sbkeys
    |   |-- generate-aws-sbkeys
    |   `-- generate-local-sbkeys
    `-- sources
        |-- logdog
        |   `-- conf
        |       `-- current
        `-- models
            `-- src
                `-- variant
```


After this change

```
/twoliter
`-- alpha
    |-- build
    |   `-- rpms
    |       |-- a.rpm
    |       |-- b.rpm
    |       |-- c1.rpm
    |       |-- c2.rpm
    |       |-- c3.rpm
    |       `-- flat1.rpm
    |-- licenses
    |   |-- COPYRIGHT
    |   |-- LICENSE-APACHE
    |   `-- LICENSE-MIT
    |-- sbkeys
    |   |-- generate-aws-sbkeys
    |   `-- generate-local-sbkeys
    `-- sources
        |-- logdog
        |   `-- conf
        |       `-- current
        `-- models
            `-- src
                `-- variant
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
