### PR TITLE
twoliter build kit

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -816,6 +816,40 @@ cargo build \
 '''
 ]
 
+# Builds a kit including its dependency packages.
+[tasks.build-kit]
+dependencies = ["check-cargo-version", "fetch", "publish-setup", "fetch-licenses", "cargo-metadata"]
+script_runner = "bash"
+script = [
+'''
+set -e
+if [ -z "${BUILDSYS_KIT}" ]; then
+    echo "The BUILDSYS_KIT environment variable must be set. For example:"
+    echo "cargo make -e BUILDSYS_KIT=core-kit build-kit"
+    exit 1
+fi
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
+
+# TODO - remove this once package builds no longer require variant variables.
+# Parse the variant into its components and set additional variables.
+eval "$(bottlerocket-variant)"
+export BUILDSYS_VARIANT_PLATFORM="${BUILDSYS_VARIANT_PLATFORM:?}"
+export BUILDSYS_VARIANT_RUNTIME="${BUILDSYS_VARIANT_RUNTIME:?}"
+export BUILDSYS_VARIANT_FAMILY="${BUILDSYS_VARIANT_FAMILY:?}"
+export BUILDSYS_VARIANT_FLAVOR="${BUILDSYS_VARIANT_FLAVOR}"
+
+# Save built artifacts for each architecture.  We don't set this everywhere
+# because we build host tools with cargo as well, like buildsys and pubsys.
+export CARGO_TARGET_DIR=${BUILDSYS_ROOT_DIR}/target/${BUILDSYS_ARCH}
+
+cargo build \
+  ${CARGO_BUILD_ARGS} \
+  ${CARGO_MAKE_CARGO_ARGS} \
+  ${CARGO_MAKE_CARGO_LIMIT_JOBS} \
+  --manifest-path "${BUILDSYS_ROOT_DIR}/kits/${BUILDSYS_KIT}/Cargo.toml"
+'''
+]
+
 [tasks.build-variant]
 dependencies = ["fetch", "build-sbkeys", "publish-setup", "cargo-metadata"]
 script = [


### PR DESCRIPTION
**Issue number:**

Closes #17 
Replaces #248

**Description of changes:**

Adds a subcommand to build a kit.

**Testing done:**

`twoliter build kit extra-3-kit` works in the test project.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
