### PR TITLE
makefile.toml: add cargo-metadata dep to repack-variant

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -854,7 +854,7 @@ ln -snf "${BUILDSYS_VERSION_FULL}" "${BUILDSYS_OUTPUT_DIR}/latest"
 ]
 
 [tasks.repack-variant]
-dependencies = ["fetch-sdk", "build-sbkeys", "publish-setup"]
+dependencies = ["fetch-sdk", "build-sbkeys", "publish-setup", "cargo-metadata"]
 script = [
 '''
 export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"


### PR DESCRIPTION
**Description of changes:**

Add `cargo-metadata` to the list of dependencies for the `repack-variant` task.

**Testing done:**

Fetched and repacked a variant on a fresh bottlerocket repository.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
