### PR TITLE
twoliter: remove fetch-licenses from build kit

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -813,7 +813,7 @@ cargo build \
 
 # Builds a kit including its dependency packages.
 [tasks.build-kit]
-dependencies = ["check-cargo-version", "fetch", "publish-setup", "fetch-licenses", "cargo-metadata"]
+dependencies = ["check-cargo-version", "fetch", "publish-setup", "cargo-metadata"]
 script_runner = "bash"
 script = [
 '''


### PR DESCRIPTION



**Issue number:**

Fixes #249 and #241

**Description of changes:**

This is a fix for a mistake that occurred due to rapid development! The fetch-licenses Makefile.toml task no longer exists.


**Testing done:**

It fixed the `twoliter build kit` command!

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
