### PR TITLE
twoliter: skip missing per-package dirs

### DIFF
--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -122,6 +122,7 @@ RUN --mount=target=/host \
     find /host/build/rpms/ -mindepth 1 -maxdepth 1 -name '*.rpm' -size +0c -print -exec \
       ln -snft ./rpmbuild/RPMS {} \+ && \
     for pkg in ${PACKAGE_DEPENDENCIES} ; do \
+      [ -d "/host/build/rpms/${pkg}" ] || continue ; \
       find /host/build/rpms/${pkg}/ -mindepth 1 -maxdepth 1 -name '*.rpm' -size +0c -print -exec \
         ln -snft ./rpmbuild/RPMS {} \+ ; \
     done && \
@@ -235,6 +236,7 @@ RUN --mount=target=/host \
     find /host/build/rpms/ -mindepth 1 -maxdepth 1 -name '*.rpm' -size +0c -print -exec \
       ln -snft ./rpmbuild/RPMS {} \+ && \
     for pkg in ${PACKAGE_DEPENDENCIES} ; do \
+      [ -d "/host/build/rpms/${pkg}" ] || continue ; \
       find /host/build/rpms/${pkg}/ -mindepth 1 -maxdepth 1 -name '*.rpm' -size +0c -print -exec \
         ln -snft ./rpmbuild/RPMS {} \+ ; \
     done && \


### PR DESCRIPTION
**Issue number:**

Closes #264

**Description of changes:**
This fixes backwards compatibility when moving between releases when the twoliter version changes but some of the packages (such as glibc) do not. The cargo metadata for the older builds is still valid, and the RPMs will be present in the top-level output directory, but the per-package subdirectories will not yet exist.


**Testing done:**
Tested a local branch where I'd made changes to `os.spec` and added some packages. First reverted the `twoliter` upgrade as my base commit, then built all my changes. Then dropped the `twoliter` upgrade in a rebase, and verified that everything built again. [Here](https://gist.github.com/bcressey/022ad0a9948334ffe71bcd2b32b14853) is the output of `tree build/rpms` after the second build.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
