### PR TITLE
add tests for kit builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,17 +4,9 @@ on:
   pull_request:
     branches:
       - "*"
-    paths-ignore:
-      - "**.md"
-      - "**.plantuml"
-      - "**.svg"
   # triggers when a PR is merged
   push:
     branches: [develop]
-    paths-ignore:
-      - "**.md"
-      - "**.plantuml"
-      - "**.svg"
 jobs:
   build:
     runs-on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -1116,6 +1132,12 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -2384,6 +2406,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,6 +3329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "testsys"
 version = "0.1.0"
 dependencies = [
@@ -3778,6 +3833,7 @@ name = "twoliter"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-recursion",
  "async-walkdir",
  "buildsys",
@@ -3933,6 +3989,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ fmt:
 
 .PHONY: test
 test:
-	cargo test --release --locked
+	cargo test --locked
 
 .PHONY: check
 check: fmt clippy deny test

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ We welcome ideas and requirements in the form of issues and comments!
 
 This section includes information for maintainers about testing and releasing Twoliter.
 
-## Testing
+## Unit Tests and Integration Tests
+
+If you run `cargo test` you will get the default features which includes the feature `integ-tests`.
+These will be quite slow as some of them do complete builds.
+If you don't have time for that, run `cargo test --no-default-features` to run only the fast tests.
+
+## Testing the Binary in a Project
 
 In general, if you have changes to Twoliter and want to try them out in a Twoliter project, it is as simple as building the Twoliter binary and using it in your project.
 Different projects will have different ways of making sure the correct Twoliter binary is being used.

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -38,7 +38,14 @@ pubsys-setup = { version = "0.1.0", artifact = [ "bin:pubsys-setup" ], path = ".
 testsys = { version = "0.1.0", artifact = [ "bin:testsys" ], path = "../tools/testsys" }
 tuftool = { version = "0.10", artifact = [ "bin:tuftool" ] }
 
+[dev-dependencies]
+assert_cmd = "2"
+
 [build-dependencies]
 bytes = "1"
 flate2 = "1"
 tar = "0.4"
+
+[features]
+default = ["integ-tests"]
+integ-tests = []

--- a/twoliter/src/test/build_kit.rs
+++ b/twoliter/src/test/build_kit.rs
@@ -1,0 +1,125 @@
+use crate::test::copy_project_to_temp_dir;
+use assert_cmd::Command;
+use std::path::Path;
+
+const PROJECT: &str = "local-kit";
+
+fn expect_kit(project_dir: &Path, name: &str, arch: &str, packages: &[&str]) {
+    let build = project_dir.join("build");
+    let kit_output_dir = build.join("kits").join(name).join(arch).join("Packages");
+    assert!(
+        kit_output_dir.is_dir(),
+        "Expected to find output dir for {} at {}",
+        name,
+        kit_output_dir.display()
+    );
+
+    for package in packages {
+        let rpm = kit_output_dir.join(&format!("bottlerocket-{package}-0.0-0.{arch}.rpm"));
+        assert!(
+            rpm.is_file(),
+            "Expected to find RPM for {}, for {} at {}",
+            package,
+            name,
+            rpm.display()
+        );
+    }
+}
+
+#[tokio::test]
+async fn build_core_kit() {
+    let kit_name = "core-kit";
+    let arch = "aarch64";
+    let temp_dir = copy_project_to_temp_dir(PROJECT);
+    let project_dir = temp_dir.path();
+    let mut cmd = Command::cargo_bin("twoliter").unwrap();
+    let assert = cmd
+        .arg("build")
+        .arg("kit")
+        .arg(kit_name)
+        .arg("--project-path")
+        .arg(&project_dir.join("Twoliter.toml").display().to_string())
+        .arg("--arch")
+        .arg(arch)
+        .assert();
+
+    assert.success();
+
+    expect_kit(&project_dir, "core-kit", arch, &["pkg-a"]);
+}
+
+#[tokio::test]
+async fn build_extra_1_kit() {
+    let kit_name = "extra-1-kit";
+    let arch = "x86_64";
+    let temp_dir = copy_project_to_temp_dir(PROJECT);
+    let project_dir = temp_dir.path();
+    let mut cmd = Command::cargo_bin("twoliter").unwrap();
+    let assert = cmd
+        .arg("build")
+        .arg("kit")
+        .arg(kit_name)
+        .arg("--project-path")
+        .arg(&project_dir.join("Twoliter.toml").display().to_string())
+        .arg("--arch")
+        .arg(arch)
+        .assert();
+
+    assert.success();
+
+    expect_kit(&project_dir, "core-kit", arch, &["pkg-a"]);
+    expect_kit(&project_dir, "extra-1-kit", arch, &["pkg-b", "pkg-d"]);
+}
+
+#[tokio::test]
+async fn build_extra_2_kit() {
+    let kit_name = "extra-2-kit";
+    let arch = "aarch64";
+    let temp_dir = copy_project_to_temp_dir(PROJECT);
+    let project_dir = temp_dir.path();
+    let mut cmd = Command::cargo_bin("twoliter").unwrap();
+    let assert = cmd
+        .arg("build")
+        .arg("kit")
+        .arg(kit_name)
+        .arg("--project-path")
+        .arg(&project_dir.join("Twoliter.toml").display().to_string())
+        .arg("--arch")
+        .arg(arch)
+        .assert();
+
+    assert.success();
+
+    expect_kit(&project_dir, "core-kit", arch, &["pkg-a"]);
+    expect_kit(&project_dir, "extra-2-kit", arch, &["pkg-c"]);
+}
+
+#[tokio::test]
+async fn build_extra_3_kit() {
+    let kit_name = "extra-3-kit";
+    let arch = "x86_64";
+    let temp_dir = copy_project_to_temp_dir(PROJECT);
+    let project_dir = temp_dir.path();
+    let mut cmd = Command::cargo_bin("twoliter").unwrap();
+    let assert = cmd
+        .arg("build")
+        .arg("kit")
+        .arg(kit_name)
+        .arg("--project-path")
+        .arg(&project_dir.join("Twoliter.toml").display().to_string())
+        .arg("--arch")
+        .arg(arch)
+        .assert();
+
+    assert.success();
+
+    expect_kit(&project_dir, "core-kit", arch, &["pkg-a"]);
+    expect_kit(&project_dir, "extra-1-kit", arch, &["pkg-b", "pkg-d"]);
+    expect_kit(&project_dir, "extra-2-kit", arch, &["pkg-c"]);
+    expect_kit(
+        &project_dir,
+        "extra-3-kit",
+        arch,
+        &["pkg-e", "pkg-f", "pkg-g"],
+    );
+}

--- a/twoliter/src/test/mod.rs
+++ b/twoliter/src/test/mod.rs
@@ -4,9 +4,17 @@ This directory and module are for tests, test data, and re-usable test code. Thi
 be compiled for `cfg(test)`, which is accomplished at its declaration in `main.rs`.
 
 !*/
+
+#![allow(unused)]
+
+#[cfg(feature = "integ-tests")]
+mod build_kit;
+#[cfg(feature = "integ-tests")]
 mod cargo_make;
 
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
 /// Return the canonical path to the directory where we store test data.
 pub(crate) fn data_dir() -> PathBuf {
@@ -22,4 +30,37 @@ pub(crate) fn projects_dir() -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.pop();
     path.join("tests").join("projects").canonicalize().unwrap()
+}
+
+pub(crate) fn project_dir(name: &str) -> PathBuf {
+    let path = projects_dir().join(name);
+    path.canonicalize()
+        .expect(&format!("Unable to canonicalize '{}'", path.display()))
+}
+
+fn copy_project_to_temp_dir(project: &str) -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    let src = project_dir(project);
+    let dst = temp_dir.path();
+    copy_most_dirs_recursively(&src, dst);
+    temp_dir
+}
+
+/// Copy dirs recursively except for some of the larger "ignoreable" dirs that may exist in the
+/// user's checkout.
+fn copy_most_dirs_recursively(src: &Path, dst: &Path) {
+    for entry in fs::read_dir(src).unwrap() {
+        fs::create_dir_all(&dst).unwrap();
+        let entry = entry.unwrap();
+        let file_type = entry.file_type().unwrap();
+        if file_type.is_dir() {
+            let name = entry.file_name().to_str().unwrap().to_string();
+            if matches!(name.as_ref(), "target" | "build" | ".gomodcache" | ".cargo") {
+                continue;
+            }
+            copy_most_dirs_recursively(&entry.path(), &dst.join(entry.file_name()));
+        } else {
+            fs::copy(entry.path(), dst.join(entry.file_name())).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
**Issue number:**

Follows #249 

**Description of changes:**

Add integration tests that build each of the kits in the local-kit project. These can be skipped by undefining the integ-tests Cargo feature.

**Testing done:**

They seem to work locally, let's see about GitHub CI (what will docker do with all the simultaneous SDK fetches? :thinking:)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
