### PR TITLE
testing: build local kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ We welcome ideas and requirements in the form of issues and comments!
 
 This section includes information for maintainers about testing and releasing Twoliter.
 
-## Testing
+## Unit Tests and Integration Tests
+
+If you run `cargo test` you will get the default features which includes the feature `integ-tests`.
+These will be quite slow as some of them do complete builds.
+If you don't have time for that, run `cargo test --no-default-features` to run only the fast tests.
+
+## Testing the Binary in a Project
 
 In general, if you have changes to Twoliter and want to try them out in a Twoliter project, it is as simple as building the Twoliter binary and using it in your project.
 Different projects will have different ways of making sure the correct Twoliter binary is being used.

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -42,3 +42,7 @@ tuftool = { version = "0.10", artifact = [ "bin:tuftool" ] }
 bytes = "1"
 flate2 = "1"
 tar = "0.4"
+
+[features]
+default = ["integ-tests"]
+integ-tests = []

--- a/twoliter/src/test/mod.rs
+++ b/twoliter/src/test/mod.rs
@@ -4,9 +4,15 @@ This directory and module are for tests, test data, and re-usable test code. Thi
 be compiled for `cfg(test)`, which is accomplished at its declaration in `main.rs`.
 
 !*/
+
+#![allow(unused)]
+
+#[cfg(feature = "integ-tests")]
 mod cargo_make;
 
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
 /// Return the canonical path to the directory where we store test data.
 pub(crate) fn data_dir() -> PathBuf {
@@ -22,4 +28,37 @@ pub(crate) fn projects_dir() -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.pop();
     path.join("tests").join("projects").canonicalize().unwrap()
+}
+
+pub(crate) fn project_dir(name: &str) -> PathBuf {
+    let path = projects_dir().join(name);
+    path.canonicalize()
+        .expect(&format!("Unable to canonicalize '{}'", path.display()))
+}
+
+pub(crate) fn copy_project_to_temp_dir(project: &str) -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    let src = project_dir(project);
+    let dst = temp_dir.path();
+    copy_most_dirs_recursively(&src, dst);
+    temp_dir
+}
+
+/// Copy dirs recursively except for some of the larger "ignoreable" dirs that may exist in the
+/// user's checkout.
+fn copy_most_dirs_recursively(src: &Path, dst: &Path) {
+    for entry in fs::read_dir(src).unwrap() {
+        fs::create_dir_all(&dst).unwrap();
+        let entry = entry.unwrap();
+        let file_type = entry.file_type().unwrap();
+        if file_type.is_dir() {
+            let name = entry.file_name().to_str().unwrap().to_string();
+            if matches!(name.as_ref(), "target" | "build" | ".gomodcache" | ".cargo") {
+                continue;
+            }
+            copy_most_dirs_recursively(&entry.path(), &dst.join(entry.file_name()));
+        } else {
+            fs::copy(entry.path(), dst.join(entry.file_name())).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
**Issue number:**

Follows #249 

**Description of changes:**

Add integration tests that build each of the kits in the local-kit project. These can be skipped by undefining the integ-tests Cargo feature.

**Testing done:**

They seem to work locally, and on GitHub CI.
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
