### PR TITLE
twoliter: external kit test project and include rpm repositories

### DIFF
--- a/tests/projects/external-kit/.dockerignore
+++ b/tests/projects/external-kit/.dockerignore
@@ -1,0 +1,10 @@
+/.git
+/.gomodcache
+/build/*
+!/build/rpms/
+/build/rpms/*
+!/build/rpms/*.rpm
+/build/rpms/*-debuginfo-*.rpm
+/build/rpms/*-debugsource-*.rpm
+**/target/*
+/sbkeys

--- a/tests/projects/external-kit/.gitignore
+++ b/tests/projects/external-kit/.gitignore
@@ -1,0 +1,10 @@
+/build/
+**/target/
+/.cargo/
+/.gomodcache/
+/keys/
+/roles/
+/sbkeys/
+Test.toml
+testsys.kubeconfig
+Infra.toml

--- a/tests/projects/external-kit/Cargo.toml
+++ b/tests/projects/external-kit/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+resolver = "2"
+members = [
+    "kits/extra-1-kit",
+    "variants/hello-ootb",
+]
+
+[profile.dev]
+debug = false
+opt-level = 'z'
+
+[profile.dev.build-override]
+opt-level = 'z'

--- a/tests/projects/external-kit/README.md
+++ b/tests/projects/external-kit/README.md
@@ -1,0 +1,1 @@
+This project represents a project structure with a single local kit with an external kit dependency

--- a/tests/projects/external-kit/Twoliter.toml
+++ b/tests/projects/external-kit/Twoliter.toml
@@ -1,0 +1,19 @@
+schema-version = 1
+release-version = "1.0.0"
+
+[sdk]
+name = "bottlerocket-sdk"
+vendor = "bottlerocket"
+version = "0.41.0"
+
+[vendor.bottlerocket]
+registry = "public.ecr.aws/bottlerocket"
+
+[vendor.custom-vendor]
+# We need to figure out how we can do integration testing with this
+registry = "public.ecr.aws/bottlerocket"
+
+[[kit]]
+name = "core-kit"
+version = "0.1.0"
+vendor = "custom-vendor"

--- a/tests/projects/external-kit/kits/build.rs
+++ b/tests/projects/external-kit/kits/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-kit").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/tests/projects/external-kit/kits/extra-1-kit/Cargo.toml
+++ b/tests/projects/external-kit/kits/extra-1-kit/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "extra-1-kit"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[package.metadata.build-kit]
+vendor = "bottlerocket"
+
+[lib]
+path = "../kit.rs"
+
+[build-dependencies]
+pkg-b = { path = "../../packages/pkg-b" }

--- a/tests/projects/external-kit/kits/kit.rs
+++ b/tests/projects/external-kit/kits/kit.rs
@@ -1,0 +1,7 @@
+/*!
+
+This is an intentionally empty file that all of the variant `Cargo.toml` files can point to as their
+`lib.rs`. The build system uses `build.rs` to invoke `buildsys` but Cargo needs something to compile
+so we give it an empty `lib.rs` file.
+
+!*/

--- a/tests/projects/external-kit/packages/build.rs
+++ b/tests/projects/external-kit/packages/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-package").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/tests/projects/external-kit/packages/packages.rs
+++ b/tests/projects/external-kit/packages/packages.rs
@@ -1,0 +1,7 @@
+/*!
+
+This is an intentionally empty file that all of the package `Cargo.toml` files can point to as their
+`lib.rs`. The build system uses `build.rs` to invoke `buildsys` but Cargo needs something to compile
+so we give it an empty `lib.rs` file.
+
+!*/

--- a/tests/projects/external-kit/packages/pkg-b/Cargo.toml
+++ b/tests/projects/external-kit/packages/pkg-b/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pkg-b"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[package.metadata.build-package]
+source-groups = []
+
+[lib]
+path = "../packages.rs"
+
+# RPM BuildRequires
+[build-dependencies]
+
+# RPM Requires
+[dependencies]
+# None

--- a/tests/projects/external-kit/packages/pkg-b/pkg-b.spec
+++ b/tests/projects/external-kit/packages/pkg-b/pkg-b.spec
@@ -1,0 +1,29 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+Name: %{_cross_os}pkg-b
+Version: 0.0
+Release: 0%{?dist}
+Summary: pkg-b
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+Source100: pkg-b.txt
+
+# This package comes from the core-kit defined in the local-kit project
+BuildRequires: %{_cross_os}pkg-a
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_cross_datadir}
+install -p -m 0644 %{S:100} %{buildroot}%{_cross_datadir}/pkg-b.txt
+
+%files
+%{_cross_datadir}/pkg-b.txt

--- a/tests/projects/external-kit/packages/pkg-b/pkg-b.txt
+++ b/tests/projects/external-kit/packages/pkg-b/pkg-b.txt
@@ -1,0 +1,1 @@
+This file gives the package something to install!

--- a/tests/projects/external-kit/variants/build.rs
+++ b/tests/projects/external-kit/variants/build.rs
@@ -1,0 +1,9 @@
+use std::process::{exit, Command};
+
+fn main() -> Result<(), std::io::Error> {
+    let ret = Command::new("buildsys").arg("build-variant").status()?;
+    if !ret.success() {
+        exit(1);
+    }
+    Ok(())
+}

--- a/tests/projects/external-kit/variants/hello-ootb/Cargo.toml
+++ b/tests/projects/external-kit/variants/hello-ootb/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "hello-ootb"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+systemd-networkd = true
+
+[package.metadata.build-variant]
+included-packages = ["pkg-b"]
+kernel-parameters = []
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+extra-1-kit = { path = "../../kits/extra-1-kit" }

--- a/tests/projects/external-kit/variants/variants.rs
+++ b/tests/projects/external-kit/variants/variants.rs
@@ -1,0 +1,7 @@
+/*!
+
+This is an intentionally empty file that all of the variant `Cargo.toml` files can point to as their
+`lib.rs`. The build system uses `build.rs` to invoke `buildsys` but Cargo needs something to compile
+so we give it an empty `lib.rs` file.
+
+!*/

--- a/tools/buildsys-config/src/lib.rs
+++ b/tools/buildsys-config/src/lib.rs
@@ -6,6 +6,7 @@ pub const EXTERNAL_KIT_DIRECTORY: &str = "build/external-kits";
 pub const EXTERNAL_KIT_METADATA: &str = "build/external-kits/external-kit-metadata.json";
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
 pub enum DockerArchitecture {
     Amd64,
     Arm64,

--- a/tools/buildsys/src/manifest/error.rs
+++ b/tools/buildsys/src/manifest/error.rs
@@ -30,6 +30,15 @@ pub(super) enum Error {
         source: toml::de::Error,
     },
 
+    #[snafu(display("Failed to read external kit metadata file '{}': {}", path.display(), source))]
+    ExternalKitMetadataFileRead { path: PathBuf, source: io::Error },
+
+    #[snafu(display("Failed to load external kit metadata file '{}': {}", path.display(), source))]
+    ExternalKitMetadataLoad {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
     #[snafu(display("Failed to parse image feature '{}'", what))]
     ParseImageFeature { what: String },
 

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -96,6 +96,7 @@ FROM sdk AS rpmbuild
 ARG PACKAGE
 ARG PACKAGE_DEPENDENCIES
 ARG KIT_DEPENDENCIES
+ARG EXTERNAL_KIT_DEPENDENCIES
 ARG ARCH
 ARG NOCACHE
 ARG VARIANT
@@ -152,11 +153,19 @@ RUN --mount=target=/host \
       KIT_REPOS+=("--repofrompath=${kit},/host/build/kits/${kit}/${ARCH}" --enablerepo "${kit}") ; \
     done && \
     echo "${KIT_REPOS[@]}" && \
+    declare -a EXTERNAL_KIT_REPOS && \
+    for kit in ${EXTERNAL_KIT_DEPENDENCIES} ; do \
+       REPO_NAME="$(tr -s '/' '-' <<< "${kit}")" && \
+       REPO_PATH="/host/build/external-kits/${kit}/${ARCH}" && \
+       EXTERNAL_KIT_REPOS+=("--repofrompath=${REPO_NAME},${REPO_PATH}" --enablerepo "${REPO_NAME}"); \
+    done && \
+    echo "${EXTERNAL_KIT_REPOS[@]}" && \
     dnf -y \
         --disablerepo '*' \
         --repofrompath repo,./rpmbuild/RPMS \
         --enablerepo 'repo' \
         "${KIT_REPOS[@]}" \
+        "${EXTERNAL_KIT_REPOS[@]}" \
         --nogpgcheck \
         --forcearch "${ARCH}" \
         builddep rpmbuild/SPECS/${PACKAGE}.spec
@@ -234,6 +243,7 @@ ARG PACKAGES
 # The complete list of non-kit packages required by way of pure package-to-package dependencies.
 ARG PACKAGE_DEPENDENCIES
 ARG KIT_DEPENDENCIES
+ARG EXTERNAL_KIT_DEPENDENCIES
 ARG ARCH
 ARG NOCACHE
 
@@ -276,11 +286,19 @@ RUN --mount=target=/host \
     for kit in ${KIT_DEPENDENCIES} ; do \
       KIT_REPOS+=("--repofrompath=${kit},/host/build/kits/${kit}/${ARCH}" --enablerepo "${kit}") ; \
     done && \
+    declare -a EXTERNAL_KIT_REPOS && \
+    for kit in ${EXTERNAL_KIT_DEPENDENCIES} ; do \
+       REPO_NAME="$(tr -s '/' '-' <<< "${kit}")" && \
+       REPO_PATH="/host/build/external-kits/${kit}/${ARCH}" && \
+       EXTERNAL_KIT_REPOS+=("--repofrompath=${REPO_NAME},${REPO_PATH}" --enablerepo "${REPO_NAME}"); \
+    done && \
+    echo "${EXTERNAL_KIT_REPOS[@]}" && \
     dnf -y \
         --disablerepo '*' \
         --repofrompath repo,./rpmbuild/RPMS \
         --enablerepo 'repo' \
         "${KIT_REPOS[@]}" \
+        "${EXTERNAL_KIT_REPOS[@]}" \
         --nogpgcheck \
         --downloadonly \
         --downloaddir . \

--- a/twoliter/src/lock.rs
+++ b/twoliter/src/lock.rs
@@ -222,13 +222,14 @@ impl OCIArchive {
     {
         let path = out_dir.as_ref();
         let digest_file = path.join("digest");
-        ensure!(digest_file.exists(), "digest file '{}' does not exist, most likely because the oci archive has not been pulled", digest_file.display());
-        let digest = read_to_string(&digest_file).await.context(format!(
-            "failed to read digest file at {}",
-            digest_file.display()
-        ))?;
-        if digest == self.digest {
-            return Ok(());
+        if digest_file.exists() {
+            let digest = read_to_string(&digest_file).await.context(format!(
+                "failed to read digest file at {}",
+                digest_file.display()
+            ))?;
+            if digest == self.digest {
+                return Ok(());
+            }
         }
 
         remove_dir_all(path).await?;
@@ -246,7 +247,7 @@ impl OCIArchive {
         oci_archive
             .unpack(temp_dir.path())
             .context("failed to unpack oci image")?;
-        let index_bytes = read(path.join("index.json")).await?;
+        let index_bytes = read(temp_dir.path().join("index.json")).await?;
         let index: IndexView = serde_json::from_slice(index_bytes.as_slice())
             .context("failed to deserialize oci image index")?;
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** 257

Closes #257

**Description of changes:**

* Adds a test project for external kits
* Adds discovery of external kit repositories

**Testing done:**

* Built local kit project and manually published the core-kit oci image to a private ecr
* Changed external-kit test project Twoliter.toml to use the private ecr for custom-vendor
* twoliter update
* twoliter fetch --arch=aarch64
* twoliter build kit extra-1-kit --arch=aarch64

extra-1-kit built successfully with pkg-b dependening on pkg-a from external core-kit


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
