### PR TITLE
twoliter: clean target dirs for both arches

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1621,9 +1621,12 @@ for ws in variants .; do
   # The targets directory could be under variants, or at the root, for either of
   # the possible workspace manifest locations.
   for td in target variants/target ; do
-    targets="${BUILDSYS_ROOT_DIR}/${td}/${BUILDSYS_ARCH}"
-    [ -d "${targets}" ] || continue
-    CARGO_TARGET_DIR="${targets}" cargo clean --manifest-path "${manifest}"
+    # Clean up both architectures, since other clean tasks are not arch-specific.
+    for arch in x86_64 aarch64 ; do
+      targets="${BUILDSYS_ROOT_DIR}/${td}/${arch}"
+      [ -d "${targets}" ] || continue
+      CARGO_TARGET_DIR="${targets}" cargo clean --manifest-path "${manifest}"
+    done
   done
 done
 '''


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Clean target dirs for both arches. Otherwise, builds for the other architecture may fail because RPMs were cleaned up, while cargo still thinks the crates are ready for use by dependencies.


**Testing done:**
Ran `cargo make clean` and confirmed that the `target` directory was fully cleaned up.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
