### PR TITLE
twoliter: build only binary RPMs

### DIFF
--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -157,7 +157,7 @@ RUN --mount=source=.cargo,target=/home/builder/.cargo \
     --mount=type=cache,target=/home/builder/.cache,from=cache,source=/cache \
     --mount=type=cache,target=/home/builder/rpmbuild/BUILD/sources/models/src/variant,from=variantcache,source=/variantcache \
     --mount=source=sources,target=/home/builder/rpmbuild/BUILD/sources \
-    rpmbuild -ba --clean \
+    rpmbuild -bb --clean \
       --undefine _auto_set_build_flags \
       --define "_target_cpu ${ARCH}" \
       rpmbuild/SPECS/${PACKAGE}.spec


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Don't bother creating source RPMs, since they're never used.


**Testing done:**
Verified that `*.src.rpm` packages are no longer mentioned in `rpmbuild` output. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
