### PR TITLE
twoliter: specify infra.toml for build variant

### DIFF
--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -114,6 +114,10 @@ pub(crate) struct BuildVariant {
     /// from the upstream URL found in a package's `Cargo.toml`.
     #[clap(long = "upstream-source-fallback")]
     upstream_source_fallback: bool,
+
+    /// Path to the Infra.toml file
+    #[clap(long)]
+    infra_toml: Option<PathBuf>,
 }
 
 impl BuildVariant {
@@ -180,7 +184,14 @@ impl BuildVariant {
         let mut optional_envs = Vec::new();
 
         if let Some(lookaside_cache) = &self.lookaside_cache {
-            optional_envs.push(("BUILDSYS_LOOKASIDE_CACHE", lookaside_cache))
+            optional_envs.push(("BUILDSYS_LOOKASIDE_CACHE", lookaside_cache.to_string()))
+        }
+
+        if let Some(infra_toml) = &self.infra_toml {
+            optional_envs.push((
+                "PUBLISH_INFRA_CONFIG_PATH",
+                infra_toml.display().to_string(),
+            ))
         }
 
         // Hold the result of the cargo make call so we can clean up the project directory first.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Partial fix for #277 

**Description of changes:**

Make Infra.toml configurable when running `twoliter build variant`.

**Testing done:**

With some additional tweaks (like pointing at an Alpha SDK and running twoliter update...)

```
$ cargo run --package twoliter \
  --bin twoliter -- build variant hello-ootb \
  --project-path $REPOS/twoliter/tests/projects/local-kit/Twoliter.toml --arch x86_64 --infra-toml $HOME/Desktop/Foo.toml

...
[cargo-make] INFO - Running Task: publish-setup
23:34:26 [INFO] No infra config at '/home/myhome/Desktop/Foo.toml' - using local roles/keys
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
