### PR TITLE
twoliter: allow relative project path

### DIFF
--- a/twoliter/src/project.rs
+++ b/twoliter/src/project.rs
@@ -63,7 +63,7 @@ pub(crate) struct Project {
 impl Project {
     /// Load a `Twoliter.toml` file from the given file path (it can have any filename).
     pub(crate) async fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let path = path.as_ref();
+        let path = fs::canonicalize(path).await?;
         let data = fs::read_to_string(&path)
             .await
             .context(format!("Unable to read project file '{}'", path.display()))?;


### PR DESCRIPTION


**Issue number:**

Closes #279

**Description of changes:**

Make it work.

**Testing done:**

This was broken, now it works.

```
cargo run --package twoliter \
  --bin twoliter -- build kit extra-3-kit \
  --project-path ./tests/projects/local-kit/Twoliter.toml --arch x86_64
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
