### PR TITLE
stop caring about generated code and variants

### DIFF
--- a/local/alpha-sdk.Dockerfile
+++ b/local/alpha-sdk.Dockerfile
@@ -12,10 +12,6 @@ COPY build/rpms/*/*.rpm /twoliter/alpha/build/rpms/
 COPY .cargo/sbkeys/generate-local-sbkeys /twoliter/alpha/sbkeys/generate-local-sbkeys
 COPY .cargo/sbkeys/generate-aws-sbkeys /twoliter/alpha/sbkeys/generate-aws-sbkeys
 
-# These directories are needed by the build system's Dockerfile. To be eliminated later.
-COPY sources/logdog/conf/current /twoliter/alpha/sources/logdog/conf/current
-COPY sources/models/src/variant /twoliter/alpha/sources/models/src/variant
-
 # TODO - move these to an RPM package so we don't need to copy them here.
 COPY LICENSE-APACHE /twoliter/alpha/licenses/LICENSE-APACHE
 COPY LICENSE-MIT /twoliter/alpha/licenses/LICENSE-MIT

--- a/tests/projects/local-kit/sources/models/src/variant/.keep
+++ b/tests/projects/local-kit/sources/models/src/variant/.keep
@@ -1,1 +1,0 @@
-For the time being, this directory is needed because it gets mounted by the build Dockerfile.

--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -101,21 +101,6 @@ pub(crate) struct BuildPackageArgs {
     #[arg(long, env = "BUILDSYS_PACKAGES_DIR")]
     pub(crate) packages_dir: PathBuf,
 
-    #[arg(long, env = "BUILDSYS_VARIANT")]
-    pub(crate) variant: String,
-
-    #[arg(long, env = "BUILDSYS_VARIANT_PLATFORM")]
-    pub(crate) variant_platform: String,
-
-    #[arg(long, env = "BUILDSYS_VARIANT_RUNTIME")]
-    pub(crate) variant_runtime: String,
-
-    #[arg(long, env = "BUILDSYS_VARIANT_FAMILY")]
-    pub(crate) variant_family: String,
-
-    #[arg(long, env = "BUILDSYS_VARIANT_FLAVOR")]
-    pub(crate) variant_flavor: String,
-
     /// version_build is used along with version_build_timestamp in setting the Release of a Package. The Release is
     /// set in the form "<timestamp of latest project commit>.<latest project commit short sha>.br1" in RPMs.
     /// The value defaults to the latest commit of a project.

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -33,43 +33,6 @@ COPY --chown=1000:1000 --from=sdk /tmp /cache
 COPY --chown=1000:1000 Twoliter.toml /cache/.${PACKAGE}.${ARCH}.${TOKEN}
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
-# Generate the expected RPM macros and bconds.
-FROM sdk as rpm-macros-and-bconds
-ARG VARIANT
-ARG VARIANT_PLATFORM
-ARG VARIANT_RUNTIME
-ARG VARIANT_FAMILY
-ARG VARIANT_FLAVOR
-ARG GRUB_SET_PRIVATE_VAR
-ARG UEFI_SECURE_BOOT
-ARG SYSTEMD_NETWORKD
-ARG UNIFIED_CGROUP_HIERARCHY
-ARG XFS_DATA_PARTITION
-ARG FIPS
-
-USER builder
-WORKDIR /home/builder
-RUN \
-   export RPM_MACROS="generated.rpmmacros" \
-   && export RPM_BCONDS="generated.bconds" \
-   && echo "%_cross_variant ${VARIANT}" > "${RPM_MACROS}" \
-   && echo "%_cross_variant_platform ${VARIANT_PLATFORM}" >> "${RPM_MACROS}" \
-   && echo "%_cross_variant_runtime ${VARIANT_RUNTIME}" >> "${RPM_MACROS}" \
-   && echo "%_cross_variant_family ${VARIANT_FAMILY}" >> "${RPM_MACROS}" \
-   && echo "%_cross_variant_flavor ${VARIANT_FLAVOR:-none}" >> "${RPM_MACROS}" \
-   && echo "%_topdir /home/builder/rpmbuild" >> "${RPM_MACROS}" \
-   && echo "%bcond_without $(V=${VARIANT_PLATFORM,,}; echo ${V//-/_})_platform" > "${RPM_BCONDS}" \
-   && echo "%bcond_without $(V=${VARIANT_RUNTIME,,}; echo ${V//-/_})_runtime" >> "${RPM_BCONDS}" \
-   && echo "%bcond_without $(V=${VARIANT_FAMILY,,}; echo ${V//-/_})_family" >> "${RPM_BCONDS}" \
-   && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> "${RPM_BCONDS}" \
-   && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${FIPS:+%bcond_without fips\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> "${RPM_BCONDS}"
-
-# =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Builds an RPM package from a spec file.
 FROM sdk AS rpmbuild
 ARG PACKAGE
@@ -78,14 +41,10 @@ ARG KIT_DEPENDENCIES
 ARG EXTERNAL_KIT_DEPENDENCIES
 ARG ARCH
 ARG NOCACHE
-ARG VARIANT
-ARG SYSTEMD_NETWORKD
 ARG BUILD_ID
 ARG BUILD_ID_TIMESTAMP
 ARG BUILD_EPOCH
-ENV SYSTEMD_NETWORKD=${SYSTEMD_NETWORKD}
-ENV VARIANT=${VARIANT}
-ENV BUILD_ID=${BUILD_ID} 
+ENV BUILD_ID=${BUILD_ID}
 ENV BUILD_ID_TIMESTAMP=${BUILD_ID_TIMESTAMP}
 ENV BUILD_EPOCH=${BUILD_EPOCH}
 WORKDIR /home/builder
@@ -94,18 +53,16 @@ USER builder
 ENV PACKAGE=${PACKAGE} ARCH=${ARCH}
 COPY ./packages/${PACKAGE}/ .
 
-COPY --chown=builder --from=rpm-macros-and-bconds /home/builder/generated.* .
-
-# Merge generated bconds with the package spec, and put sources in the right place. Set Epoch values for the package 
+# Copy over the target-specific macros, and put sources in the right place. Set Epoch values for the package
 # and all of its subpackages. Additionally, for packages declaring explicit package versions requirements via 
 # "{Requires,Conflicts,Obsoletes}: = ...", ensure the epoch for the specified package is set.
 # "[Requires|Conflicts|Obsoletes]:.*[=>,>,<,<=,=]\) \(\%{version}\-\%{release}$\)" matches any line in a form like:
 # "Requires: %{name}-modules = %{version}-%{release}". The full `sed` expression below captures this match into
 # two groups and insert the Epoch value such that the result is "Requires: %{name}-modules = EPOCH:%{version}-%{release}"
 RUN \
-   cat "/usr/lib/rpm/platform/${ARCH}-bottlerocket/macros" generated.rpmmacros > .rpmmacros \
+   cp "/usr/lib/rpm/platform/${ARCH}-bottlerocket/macros" .rpmmacros \
    && echo "Epoch: ${BUILD_EPOCH}" >> rpmbuild/SPECS/${PACKAGE}.spec \
-   && cat generated.bconds ${PACKAGE}.spec >> rpmbuild/SPECS/${PACKAGE}.spec \
+   && cat ${PACKAGE}.spec >> rpmbuild/SPECS/${PACKAGE}.spec \
    && sed -i "/^%package\s.*$/a Epoch: ${BUILD_EPOCH}" rpmbuild/SPECS/${PACKAGE}.spec \
    && sed -i "s;\([Requires|Conflicts|Obsoletes]:.*[=>,>,<,<=,=]\) \(\%{version}\-\%{release}$\);\1 ${BUILD_EPOCH}:\2;" rpmbuild/SPECS/${PACKAGE}.spec \
    && find . -maxdepth 1 -not -path '*/\.*' -type f -exec mv {} rpmbuild/SOURCES/ \; \
@@ -152,7 +109,6 @@ RUN --mount=target=/host \
 # Ensure that the target binutils that `find-debuginfo.sh` uses are present in $PATH.
 ENV PATH="/usr/${ARCH}-bottlerocket-linux-gnu/debuginfo/bin:${PATH}"
 
-# We use the "nocache" writable space to generate code where necessary.
 USER builder
 RUN --mount=source=.cargo,target=/home/builder/.cargo \
     --mount=type=cache,target=/home/builder/.cache,from=cache,source=/cache \
@@ -213,8 +169,46 @@ COPY --from=kitbuild /home/builder/output/. /output/
 # the rpm files have been created by repeatedly using Sections 1 and 2.
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
+# Generate the expected RPM macros and bconds.
+FROM sdk as rpm-macros-and-bconds
+ARG VARIANT
+ARG VARIANT_PLATFORM
+ARG VARIANT_RUNTIME
+ARG VARIANT_FAMILY
+ARG VARIANT_FLAVOR
+ARG GRUB_SET_PRIVATE_VAR
+ARG UEFI_SECURE_BOOT
+ARG SYSTEMD_NETWORKD
+ARG UNIFIED_CGROUP_HIERARCHY
+ARG XFS_DATA_PARTITION
+ARG FIPS
+
+USER builder
+WORKDIR /home/builder
+RUN \
+   export RPM_MACROS="generated.rpmmacros" \
+   && export RPM_BCONDS="generated.bconds" \
+   && echo "%_cross_variant ${VARIANT}" > "${RPM_MACROS}" \
+   && echo "%_cross_variant_platform ${VARIANT_PLATFORM}" >> "${RPM_MACROS}" \
+   && echo "%_cross_variant_runtime ${VARIANT_RUNTIME}" >> "${RPM_MACROS}" \
+   && echo "%_cross_variant_family ${VARIANT_FAMILY}" >> "${RPM_MACROS}" \
+   && echo "%_cross_variant_flavor ${VARIANT_FLAVOR:-none}" >> "${RPM_MACROS}" \
+   && echo "%_topdir /home/builder/rpmbuild" >> "${RPM_MACROS}" \
+   && echo "%bcond_without $(V=${VARIANT_PLATFORM,,}; echo ${V//-/_})_platform" > "${RPM_BCONDS}" \
+   && echo "%bcond_without $(V=${VARIANT_RUNTIME,,}; echo ${V//-/_})_runtime" >> "${RPM_BCONDS}" \
+   && echo "%bcond_without $(V=${VARIANT_FAMILY,,}; echo ${V//-/_})_family" >> "${RPM_BCONDS}" \
+   && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> "${RPM_BCONDS}" \
+   && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${FIPS:+%bcond_without fips\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> "${RPM_BCONDS}"
+
+
+# =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an RPM repository from packages created in Section 1 and kits from Section 2.
-FROM sdk AS repobuild
+FROM rpm-macros-and-bconds AS repobuild
 # The list of packages from the variant Cargo.toml package.metadata.build-variant.packages section.
 ARG PACKAGES
 # The complete list of non-kit packages required by way of pure package-to-package dependencies.
@@ -226,8 +220,6 @@ ARG NOCACHE
 
 WORKDIR /home/builder
 USER builder
-
-COPY --chown=builder --from=rpm-macros-and-bconds /home/builder/generated.* .
 
 # Build the metadata RPM for the variant.
 RUN --mount=target=/host \

--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -59,15 +59,6 @@ impl BuildKit {
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");
 
-        // TODO: Remove once models is no longer conditionally compiled.
-        // Create the models directory because it is mounted in build.Dockerfile
-        let models_dir = project.project_dir().join("sources/models/src/variant");
-        if !models_dir.is_dir() {
-            fs::create_dir_all(&models_dir)
-                .await
-                .context("Unable to create models source directory")?;
-        }
-
         let mut optional_envs = Vec::new();
 
         if let Some(lookaside_cache) = &self.lookaside_cache {
@@ -155,8 +146,6 @@ impl BuildVariant {
             fs::rename(entry.path(), rpms_dir.join(entry.file_name())).await?;
         }
 
-        let mut created_files = Vec::new();
-
         let sbkeys_dir = project.project_dir().join("sbkeys");
         if !sbkeys_dir.is_dir() {
             // Create a sbkeys directory in the main project
@@ -169,17 +158,6 @@ impl BuildVariant {
                 )
                 .await?;
         };
-
-        // TODO: Remove once models is no longer conditionally compiled.
-        // Create the models directory for the sdk to mount
-        let models_dir = project.project_dir().join("sources/models");
-        if !models_dir.is_dir() {
-            debug!("models source dir not found. Creating a temporary directory");
-            fs::create_dir_all(&models_dir.join("src/variant"))
-                .await
-                .context("Unable to create models source directory")?;
-            created_files.push(models_dir)
-        }
 
         let mut optional_envs = Vec::new();
 
@@ -194,8 +172,7 @@ impl BuildVariant {
             ))
         }
 
-        // Hold the result of the cargo make call so we can clean up the project directory first.
-        let res = CargoMake::new(&project)?
+        CargoMake::new(&project)?
             .env("TWOLITER_TOOLS_DIR", toolsdir.display().to_string())
             .env("BUILDSYS_ARCH", &self.arch)
             .env("BUILDSYS_VARIANT", &self.variant)
@@ -210,18 +187,6 @@ impl BuildVariant {
             .makefile(makefile_path)
             .project_dir(project.project_dir())
             .exec("build")
-            .await;
-
-        // Clean up all of the files we created
-        for file_name in created_files {
-            let added = Path::new(&file_name);
-            if added.is_file() {
-                fs::remove_file(added).await?;
-            } else if added.is_dir() {
-                fs::remove_dir_all(added).await?;
-            }
-        }
-
-        res
+            .await
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #193

- [x] Requires https://github.com/bottlerocket-os/bottlerocket/pull/4038 (DRAFT until then)

**Description of changes:**

stop caring about the models and logdog dirs

With https://github.com/bottlerocket-os/bottlerocket/pull/4038 we can
finally stop mounting the models directory (and a vestige of logdog
could also be removed).

**Testing done:**

- [x] Checked out  https://github.com/bottlerocket-os/bottlerocket/pull/4038 and built it
- [x] Local tests including build-kit tests pass

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
