### PR TITLE
twoliter: fix compat for build-package task

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -807,11 +807,19 @@ fi
 # because we build host tools with cargo as well, like buildsys and pubsys.
 export CARGO_TARGET_DIR="${BUILDSYS_ROOT_DIR}/target/${BUILDSYS_ARCH}"
 
+# The workspace manifest directory could be under variants, or at the root.
+for ws in variants .; do
+  manifest="${BUILDSYS_ROOT_DIR}/${ws}/Cargo.toml"
+  [ -s "${manifest}" ] || continue
+  WORKSPACE_MANIFEST="${manifest}"
+done
+
 cargo build \
   ${CARGO_BUILD_ARGS} \
   ${CARGO_MAKE_CARGO_ARGS} \
   ${CARGO_MAKE_CARGO_LIMIT_JOBS} \
-  --manifest-path "${BUILDSYS_ROOT_DIR}/packages/${PACKAGE}/Cargo.toml"
+  --manifest-path "${WORKSPACE_MANIFEST:?}" \
+  --package "${PACKAGE}"
 '''
 ]
 


### PR DESCRIPTION
**Issue number:**

Closes #281

**Description of changes:**
Look for a workspace manifest in either of the potential locations.

Otherwise, the build can fail with a misleading message:
```
error: the lock file .../packages/<PACKAGE>/Cargo.lock needs to be updated but --locked was passed to prevent this
```

**Testing done:**
Before:
```
❯ cargo make -e PACKAGE=runc build-package
...
[cargo-make][1] INFO - Running Task: build-package
error: the lock file /home/fedora/brdev/packages/runc/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
[cargo-make][1] ERROR - Error while executing command, exit code: 101
[cargo-make][1] WARN - Build Failed.
Error: Command was unsuccessful, exit code 1
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```

After:
```
❯ cargo make -e PACKAGE=runc build-package
...
[cargo-make][1] INFO - Running Task: build-package
   Compiling glibc v0.1.0 (/home/fedora/brdev/packages/glibc)
   Compiling libseccomp v0.1.0 (/home/fedora/brdev/packages/libseccomp)
   Compiling runc v0.1.0 (/home/fedora/brdev/packages/runc)
    Finished `dev` profile [optimized] target(s) in 3m 23s
[cargo-make][1] INFO - Build Done in 207.03 seconds.
[cargo-make] INFO - Build Done in 207.40 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
