### PR TITLE
twoliter: fix sdk inspect handling

### DIFF
--- a/twoliter/src/lock.rs
+++ b/twoliter/src/lock.rs
@@ -30,7 +30,11 @@ macro_rules! docker {
             .output()
             .await
             .context($error_msg)?;
-        ensure!(output.status.success(), $error_msg);
+        ensure!(
+            output.status.success(),
+            "docker failed to run operation: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
         output.stdout
     }};
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Fixes issue with locked image trying to inspect manifest for sdk

Closes #284
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
