### PR TITLE
buildsys: fix rerun-if-changed on external kit metadata

### DIFF
--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -124,7 +124,10 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
     let manifest_file = "Cargo.toml";
     let manifest_path = args.common.cargo_manifest_dir.join(manifest_file);
     println!("cargo:rerun-if-changed={}", manifest_file);
-    println!("cargo:rerun-if-changed={}", EXTERNAL_KIT_METADATA);
+    println!(
+        "cargo:rerun-if-changed={}",
+        args.common.root_dir.join(EXTERNAL_KIT_METADATA).display()
+    );
 
     let manifest = Manifest::new(&manifest_path, &args.common.cargo_metadata_path)
         .context(error::ManifestParseSnafu)?;
@@ -196,7 +199,10 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
 fn build_kit(args: BuildKitArgs) -> Result<()> {
     let manifest_file = "Cargo.toml";
     println!("cargo:rerun-if-changed={}", manifest_file);
-    println!("cargo:rerun-if-changed={}", EXTERNAL_KIT_METADATA);
+    println!(
+        "cargo:rerun-if-changed={}",
+        args.common.root_dir.join(EXTERNAL_KIT_METADATA).display()
+    );
 
     let manifest = Manifest::new(
         args.common.cargo_manifest_dir.join(manifest_file),
@@ -213,7 +219,10 @@ fn build_kit(args: BuildKitArgs) -> Result<()> {
 fn build_variant(args: BuildVariantArgs) -> Result<()> {
     let manifest_file = "Cargo.toml";
     println!("cargo:rerun-if-changed={}", manifest_file);
-    println!("cargo:rerun-if-changed={}", EXTERNAL_KIT_METADATA);
+    println!(
+        "cargo:rerun-if-changed={}",
+        args.common.root_dir.join(EXTERNAL_KIT_METADATA).display()
+    );
 
     let manifest = Manifest::new(
         args.common.cargo_manifest_dir.join(manifest_file),


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Fixes rerun-if-changed on external kit metadata to use absolute path from root_dir

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
