### PR TITLE
pubsys: allow publishing a kit with only one arch

### DIFF
--- a/tools/pubsys/src/kit/publish_kit/mod.rs
+++ b/tools/pubsys/src/kit/publish_kit/mod.rs
@@ -78,6 +78,11 @@ pub(crate) async fn run(args: &Args, publish_kit_args: &PublishKitArgs) -> Resul
         let kit_filename = format!("{}-{}-{}.tar", &kit_name, &kit_version, arch);
         let path = kit_path.join(&kit_filename);
 
+        if !path.exists() {
+            debug!("Kit image does not exist for arch {}", arch);
+            continue;
+        }
+
         let out = docker!(["load", format!("--input={}", path.display()).as_str(),]);
         let out = String::from_utf8_lossy(&out);
         let digest_expression =


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Fix bug that does not allow publishing a kit for which only one architecture exists.

**Testing done:**

Tested pushing to a local registry with only one arch.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
