### PR TITLE
pubsys: remove build id from tag when publishing kit

### DIFF
--- a/tools/pubsys/src/kit/publish_kit/mod.rs
+++ b/tools/pubsys/src/kit/publish_kit/mod.rs
@@ -112,6 +112,10 @@ pub(crate) async fn run(args: &Args, publish_kit_args: &PublishKitArgs) -> Resul
 
         platform_images.push((docker_arch, arch_specific_target_uri.clone()));
     }
+    ensure!(
+        !platform_images.is_empty(),
+        error::NoArchiveSnafu { path: kit_path }
+    );
 
     let target_uri = format!("{}/{}:{}", vendor_registry_uri, kit_name, kit_version);
 

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1547,6 +1547,36 @@ pubsys \
 '''
 ]
 
+[tasks.publish-kit]
+dependencies = ["fetch-sources"]
+script_runner = "bash"
+script = [
+'''
+set -e
+if [ -z "${BUILDSYS_KIT}" ]; then
+    echo "The BUILDSYS_KIT environment variable must be set. For example:"
+    echo "cargo make -e BUILDSYS_KIT=core-kit publish-kit"
+    exit 1
+fi
+
+if [ -z "${PUBLISH_VENDOR}" ]; then
+    echo "The PUBLISH_VENDOR environment variable must be set."
+    exit 1
+fi
+
+export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
+
+pubsys \
+   --log-level "${PUBLISH_LOG_LEVEL}" \
+   --infra-config-path "${PUBLISH_INFRA_CONFIG_PATH}" \
+   publish-kit \
+   --kit-path "${BUILDSYS_BUILD_DIR}/kits/${BUILDSYS_KIT}" \
+   --vendor "${PUBLISH_VENDOR}" \
+   --version "v${BUILDSYS_VERSION_IMAGE}" \
+   --build-id "${BUILDSYS_VERSION_BUILD}"
+'''
+]
+
 [tasks._upload-ova-base]
 # Rather than depend on "build", which currently rebuilds images each run, we
 # depend on publish-tools and check for the image files below to save time.

--- a/twoliter/src/cmd/publish_kit.rs
+++ b/twoliter/src/cmd/publish_kit.rs
@@ -1,9 +1,9 @@
+use crate::cargo_make::CargoMake;
 use crate::project;
 use crate::tools::install_tools;
-use anyhow::{ensure, Context, Result};
+use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
-use tokio::process::Command;
 
 /// Group all publish commands
 #[derive(Debug, Parser)]
@@ -31,12 +31,6 @@ pub(crate) struct PublishKit {
 
     /// Vendor to publish to
     vendor: String,
-
-    /// Version of the kit to publish
-    version: String,
-
-    /// Build ID of the kit to publish
-    build_id: String,
 }
 
 impl PublishKit {
@@ -44,35 +38,16 @@ impl PublishKit {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let toolsdir = project.project_dir().join("build/tools");
         install_tools(&toolsdir).await?;
-        let pubsys_path = toolsdir.join("pubsys");
-        let infra_path = project.project_dir().join("Infra.toml");
-        let kit_path = project
-            .project_dir()
-            .join("build")
-            .join("kits")
-            .join(self.kit_name.as_str());
+        let makefile_path = toolsdir.join("Makefile.toml");
 
-        let infra_arg = format!("--infra-config-path={}", infra_path.display());
-        let kit_arg = format!("--kit-path={}", kit_path.display());
-        let vendor_arg = format!("--vendor={}", self.vendor);
-        let version_arg = format!("--version={}", self.version);
-        let build_id_arg = format!("--build-id={}", self.build_id);
-        // Now we want to offload this operation to pubsys
-        let res = Command::new(pubsys_path)
-            .args([
-                infra_arg.as_str(),
-                "publish-kit",
-                kit_arg.as_str(),
-                vendor_arg.as_str(),
-                version_arg.as_str(),
-                build_id_arg.as_str(),
-            ])
-            .spawn()
-            .context("failed to spawn pubsys")?
-            .wait()
+        CargoMake::new(&project)?
+            .env("TWOLITER_TOOLS_DIR", toolsdir.display().to_string())
+            .env("BUILDSYS_KIT", &self.kit_name)
+            .env("BUILDSYS_VERSION_IMAGE", project.release_version())
+            .env("PUBLISH_VENDOR", &self.vendor)
+            .makefile(makefile_path)
+            .project_dir(project.project_dir())
+            .exec("publish-kit")
             .await
-            .context("failed to publish a kit with pubsys")?;
-        ensure!(res.success(), "failed to publish a kit with pubsys");
-        Ok(())
     }
 }

--- a/twoliter/src/cmd/publish_kit.rs
+++ b/twoliter/src/cmd/publish_kit.rs
@@ -32,8 +32,11 @@ pub(crate) struct PublishKit {
     /// Vendor to publish to
     vendor: String,
 
-    /// Version and build id of the kit to publish, e.g. v1.0.0-abcd123
+    /// Version of the kit to publish
     version: String,
+
+    /// Build ID of the kit to publish
+    build_id: String,
 }
 
 impl PublishKit {
@@ -53,6 +56,7 @@ impl PublishKit {
         let kit_arg = format!("--kit-path={}", kit_path.display());
         let vendor_arg = format!("--vendor={}", self.vendor);
         let version_arg = format!("--version={}", self.version);
+        let build_id_arg = format!("--build-id={}", self.build_id);
         // Now we want to offload this operation to pubsys
         let res = Command::new(pubsys_path)
             .args([
@@ -61,6 +65,7 @@ impl PublishKit {
                 kit_arg.as_str(),
                 vendor_arg.as_str(),
                 version_arg.as_str(),
+                build_id_arg.as_str(),
             ])
             .spawn()
             .context("failed to spawn pubsys")?


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Removes the build ID from the tag of the kit manifest list.

Also, has `twoliter` automatically discover the build id and version from the project context so that it doesn't need to be manually specified on the command line.

**Testing done:**

Pushed a kit to an ECR repository

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
