### PR TITLE
rpm2kit: fix architecture rpms going in both architecture kit directo…

### DIFF
--- a/twoliter/embedded/rpm2kit
+++ b/twoliter/embedded/rpm2kit
@@ -52,13 +52,10 @@ esac
 
 # Create the content layer
 mkdir -p "${WORK_DIR}/blobs/sha256"
-DIFF_ARCHIVE="${WORK_DIR}/content-layer.tar"
-tar -cf "${DIFF_ARCHIVE}" -C "${KIT_DIR}" .
-DIFF_ID="$(digest_from_file "${DIFF_ARCHIVE}")"
-gzip "${DIFF_ARCHIVE}"
-CONTENT_ARCHIVE="${DIFF_ARCHIVE}.gz"
+CONTENT_ARCHIVE="${WORK_DIR}/content-layer.tar"
+tar -cvf "${CONTENT_ARCHIVE}" -C "${KIT_DIR}" .
 CONTENT_DIGEST="$(digest_from_file "${CONTENT_ARCHIVE}")"
-mv "${WORK_DIR}/content-layer.tar.gz" "${WORK_DIR}/blobs/sha256/${CONTENT_DIGEST}"
+mv "${CONTENT_ARCHIVE}" "${WORK_DIR}/blobs/sha256/${CONTENT_DIGEST}"
 
 METADATA_TEMPLATE=$(cat <<EOF
 {
@@ -99,7 +96,7 @@ CONFIG="$(jq --compact-output <<EOF
   "rootfs": {
     "type": "layers",
     "diff_ids": [
-      "sha256:${DIFF_ID}"
+      "sha256:${CONTENT_DIGEST}"
     ]
   }
 }
@@ -122,7 +119,7 @@ MANIFEST="$(jq --compact-output <<EOF
   },
   "layers": [
     {
-      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
       "digest": "sha256:${CONTENT_DIGEST}",
       "size": ${CONTENT_SIZE}
     }

--- a/twoliter/embedded/rpm2kit
+++ b/twoliter/embedded/rpm2kit
@@ -27,6 +27,7 @@ for pkg in ${PACKAGES} ; do
   find "${PACKAGES_DIR}/${pkg}" \
     -mindepth 1 \
     -maxdepth 1 \
+    -name "*.${ARCH}.rpm" \
     ! -name '*-debuginfo-*' \
     ! -name '*-debugsource-*' \
     -size +0c \

--- a/twoliter/src/lock.rs
+++ b/twoliter/src/lock.rs
@@ -271,10 +271,9 @@ impl OCIArchive {
         // Extract each layer into the target directory
         for layer in manifest_layout.layers {
             let digest = layer.digest.to_string().replace(':', "/");
-            let mut layer_blob = File::open(temp_dir.path().join(format!("blobs/{digest}")))
+            let layer_blob = File::open(temp_dir.path().join(format!("blobs/{digest}")))
                 .context("failed to read layer of oci image")?;
-            let decompressed = flate2::read::GzDecoder::new(&mut layer_blob);
-            let mut layer_archive = TarArchive::new(decompressed);
+            let mut layer_archive = TarArchive::new(layer_blob);
             layer_archive
                 .unpack(path)
                 .context("failed to unpack layer to disk")?;


### PR DESCRIPTION
…ries

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Fixes rpm packages for both architectures falling in the kit directory


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
