### PR TITLE
twoliter: prevent timestamp bumping of external kit metadata

### DIFF
--- a/twoliter/src/lock.rs
+++ b/twoliter/src/lock.rs
@@ -371,6 +371,18 @@ impl Lock {
         self.external_kit_metadata()
             .serialize(&mut ser)
             .context("failed to serialize external kit metadata")?;
+        // Compare the output of the serialize if the file exists
+        let external_metadata_file = project.external_kits_metadata();
+        if external_metadata_file.exists() {
+            let existing = read(&external_metadata_file).await.context(format!(
+                "failed to read external kit metadata: {}",
+                external_metadata_file.display()
+            ))?;
+            // If this is the same as what we generated skip the write
+            if existing == kit_list {
+                return Ok(());
+            }
+        }
         write(project.external_kits_metadata(), kit_list.as_slice())
             .await
             .context(format!(


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Make it so fetch does not bump the timestamp to prevent constant rebuilds

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
