### PR TITLE
get rid of the ManifestParse printout

### DIFF
--- a/tools/buildsys/src/bin/bottlerocket-variant/main.rs
+++ b/tools/buildsys/src/bin/bottlerocket-variant/main.rs
@@ -51,15 +51,15 @@ mod error {
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
     pub(super) enum Error {
+        #[snafu(display("{source}"))]
         VariantParse {
             source: bottlerocket_variant::error::Error,
         },
 
-        ManifestParse {
-            source: buildsys::manifest::Error,
-        },
+        #[snafu(display("{source}"))]
+        ManifestParse { source: buildsys::manifest::Error },
 
-        #[snafu(display("Missing environment variable '{}'", var))]
+        #[snafu(display("Missing environment variable '{var}'"))]
         Environment {
             var: String,
             source: std::env::VarError,

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -789,13 +789,6 @@ fi
 
 export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
-# Parse the variant into its components and set additional variables.
-eval "$(bottlerocket-variant)"
-export BUILDSYS_VARIANT_PLATFORM="${BUILDSYS_VARIANT_PLATFORM:?}"
-export BUILDSYS_VARIANT_RUNTIME="${BUILDSYS_VARIANT_RUNTIME:?}"
-export BUILDSYS_VARIANT_FAMILY="${BUILDSYS_VARIANT_FAMILY:?}"
-export BUILDSYS_VARIANT_FLAVOR="${BUILDSYS_VARIANT_FLAVOR}"
-
 # Relocate an existing target directory to the new location, to avoid breaking
 # compatibility on upgrade. On downgrade, the missing directory will trigger a
 # full rebuild, which is good because the new layout of RPM artifacts is not
@@ -840,14 +833,6 @@ if [ -z "${BUILDSYS_KIT}" ]; then
     exit 1
 fi
 export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
-
-# TODO - remove this once package builds no longer require variant variables.
-# Parse the variant into its components and set additional variables.
-eval "$(bottlerocket-variant)"
-export BUILDSYS_VARIANT_PLATFORM="${BUILDSYS_VARIANT_PLATFORM:?}"
-export BUILDSYS_VARIANT_RUNTIME="${BUILDSYS_VARIANT_RUNTIME:?}"
-export BUILDSYS_VARIANT_FAMILY="${BUILDSYS_VARIANT_FAMILY:?}"
-export BUILDSYS_VARIANT_FLAVOR="${BUILDSYS_VARIANT_FLAVOR}"
 
 # Save built artifacts for each architecture.  We don't set this everywhere
 # because we build host tools with cargo as well, like buildsys and pubsys.


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

We were seeing `ManifestParse` in the output when building a kit. This was from `eval $(bottlerocket-variant)` which was hitting an error because the variant `Cargo.toml` didn't exist.

This PR fixes the missing error message and stops running `bottlerocket-variant` when it's not needed.

**Testing done:**

Build a test kit, saw `ManifestParse`

After fixing the error message, did the same and saw the actual error message.

Removed the `bottlerocket-variant` calls from `build-kit` and `build-package` and no longer saw an error message.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
