### PR TITLE
rpm2kit: find first package via awk

### DIFF
--- a/twoliter/embedded/rpm2kit
+++ b/twoliter/embedded/rpm2kit
@@ -35,7 +35,7 @@ for pkg in ${PACKAGES} ; do
     -exec install -p -m 0644 -t "${KIT_DIR}/Packages/${pkg}" {} \+
   # Set a reproducible timestamp on the directory, so that the tar archive for
   # this package will be the same if the package has not otherwise changed.
-  refpkg="$(ls -1 "${PACKAGES_DIR}/${pkg}" | head -n1)"
+  refpkg="$(ls -1 "${PACKAGES_DIR}/${pkg}" | awk 'NR==1 {pkg = $0} END {print pkg}')"
   touch -r "${PACKAGES_DIR}/${pkg}/${refpkg}" "${KIT_DIR}/Packages/${pkg}"
 done
 


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
`head` will exit as soon as it reads the desired number of lines, and potentially without reading all data from the stdin pipe. That leads to occasional SIGPIPE errors which cause the build to fail.

Instead, tell `awk` to read all input and print the first line before it exits.


**Testing done:**
Before, I observed occasional failures building the core kit repo:
```
  ERROR: failed to solve: process "...  /host/build/tools/rpm2kit ..." did not complete successfully: exit code: 141
```

After, I could run ten core kit builds for both architectures to completion:
```
for i in {1..10} ; do
  echo $i
  touch packages/release/release.spec
  make ARCH=x86_64 && make ARCH=aarch64 || break
done
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
