### PR TITLE
application-inventory: use core-kit version for packages sourced from the bottlerocket-core-kit

### DIFF
--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -313,6 +313,7 @@ RUN --mount=target=/host \
     /host/build/tools/rpm2img \
       --package-dir=/local/rpms \
       --output-dir=/local/output \
+      --external-kits-path="/host/build/external-kits" \
       --output-fmt="${IMAGE_FORMAT}" \
       --os-image-size-gib="${OS_IMAGE_SIZE_GIB}" \
       --data-image-size-gib="${DATA_IMAGE_SIZE_GIB}" \

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -16,6 +16,7 @@ for opt in "$@"; do
   --package-dir=*) PACKAGE_DIR="${optarg}" ;;
   --output-dir=*) OUTPUT_DIR="${optarg}" ;;
   --output-fmt=*) OUTPUT_FMT="${optarg}" ;;
+  --external-kits-path=*) EXTERNAL_KITS_PATH="${optarg}" ;;
   --os-image-size-gib=*) OS_IMAGE_SIZE_GIB="${optarg}" ;;
   --data-image-size-gib=*) DATA_IMAGE_SIZE_GIB="${optarg}" ;;
   --os-image-publish-size-gib=*) OS_IMAGE_PUBLISH_SIZE_GIB="${optarg}" ;;
@@ -178,11 +179,48 @@ mapfile -t installed_rpms <<<"$(rpm -qa --root "${ROOT_MOUNT}" \
 
 # Wrap installed_rpms mapfile into json.
 INVENTORY_DATA="$(jq --raw-output . <<<"${installed_rpms[@]}")"
-# Remove the 'bottlerocket-' prefix from package names.
-INVENTORY_DATA="$(jq --arg PKG_PREFIX "bottlerocket-" \
-  '(.Name) |= sub($PKG_PREFIX; "")' <<<"${INVENTORY_DATA}")"
 # Sort by package name and add 'Content' as top-level.
 INVENTORY_DATA="$(jq --slurp 'sort_by(.Name)' <<<"${INVENTORY_DATA}" | jq '{"Content": .}')"
+
+# Get the core kit version and vendor from external kit metadata.
+EXTERNAL_KIT_METADATA_PATH="${EXTERNAL_KITS_PATH}/external-kit-metadata.json"
+CORE_KIT_VERSION=$(jq --raw-output '.kit[]|select(.name == "bottlerocket-core-kit")|.version' "${EXTERNAL_KIT_METADATA_PATH}")
+CORE_KIT_VENDOR=$(jq --raw-output '.kit[]|select(.name == "bottlerocket-core-kit")|.vendor' "${EXTERNAL_KIT_METADATA_PATH}")
+# Set the path inside the build container to the core kit RPMs and repo.
+CORE_KIT_PATH="${EXTERNAL_KITS_PATH}/${CORE_KIT_VENDOR}/bottlerocket-core-kit/${ARCH}"
+
+if [[ -n "${CORE_KIT_VERSION}" && -n "${CORE_KIT_VENDOR}" ]]; then
+  # Query the bottlerocket-core-kit repo of RPMs for all package names.
+  CORE_KIT_INVENTORY_QUERY="%{NAME}"
+  # shellcheck disable=SC2312 # Array is validated elsewhere.
+  mapfile -t CORE_KIT_PKGS <<<"$(dnf --repofrompath \
+    core-kit,file://"${CORE_KIT_PATH}" \
+    --repo=core-kit repoquery \
+    --queryformat "${CORE_KIT_INVENTORY_QUERY}")"
+  # Convert the bash array of core kit packages to a JSON array.
+  CORE_KIT_LIST="$(\
+    jq \
+      --null-input \
+      --compact-output \
+      '$ARGS.positional // []' \
+      --args "${CORE_KIT_PKGS[@]}")"
+
+  # Convert the JSON array to a map of 'bottlerocket-' prefixed names to unprefixed package names
+  # for search and replace in the installed application inventory.
+  jq \
+    --compact-output \
+    'map({ (.|tostring): (.|sub("^bottlerocket-";""))}) | add' <<<"${CORE_KIT_LIST}" \
+    > core-kit-replacements.json
+
+  # For any packages in the installed app inventory that exist in the core kit, replace
+  # the version with the core kit's version, and replace the name with the unprefixed name.
+  INVENTORY_DATA="$(jq \
+    --argfile replace core-kit-replacements.json \
+    --arg CORE_KIT_VERSION "${CORE_KIT_VERSION}" \
+    '(.Content[] | select(.Name | $replace[.] != null) | .Version) = $CORE_KIT_VERSION |
+     .Content[].Name |= (if $replace[.] then $replace[.] else . end)' \
+    <<<"${INVENTORY_DATA}")"
+fi
 
 # Verify we successfully inventoried some RPMs.
 INVENTORY_COUNT="$(jq '.Content | length' <<<"${INVENTORY_DATA}")"

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -195,6 +195,10 @@ fi
 # Write the inventory.
 printf "%s\n" "${INVENTORY_DATA}" >"${ROOT_MOUNT}/usr/share/bottlerocket/application-inventory.json"
 
+# Write the the inventory to a file in the local build output directory so that builders
+# can access the inventory without needed to dig into the generated image.
+printf "%s\n" "${INVENTORY_DATA}" >"${OUTPUT_DIR}/application-inventory.json"
+
 # Regenerate module dependencies, if possible.
 KMOD_DIR="${ROOT_MOUNT}/lib/modules"
 # shellcheck disable=SC2066


### PR DESCRIPTION
**Description of changes:**

  In order for package version comparisons to be valid in the OOTB and
  kits style builds of Bottlerocket, application inventory is generated to
  list the version of a package by where it was sourced from. This will be
  the kit version.
  
  This is a first iteration on this approach and must be extended
  in future work to apply to any external kit and not just the
  bottlerocket-core-kit, although that is the only external kit for now.



This change will help resolve cases where downstream consumers of application inventory and security updates do not respect the Epoch field.


**Testing done:**

Local checkout of https://github.com/bottlerocket-os/bottlerocket/pull/4060, built Bottlerocket and verified:

1. The version of packages matches the version of the core kit
2. The packages listed in app inventory are limited to those defined for the variant (i.e., does not include all packages in the core-kit)

Given that the version of the core kit I was using matched Bottlerocket's version, for testing purposes I overrode `CORE_KIT_VERSION` to "2.0" to observe changes:

```
{
  "Content": [
    {
      "Name": "acpid",
      "Publisher": "Bottlerocket",
      "Version": "2.0",
      "Release": "7a7b5dd3",
      "InstalledTime": "2024-06-18T21:52:21Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://sourceforge.net/projects/acpid2/",
      "Summary": "ACPI event daemon"
    }
```

and a package that is not in core kit retains Bottlerocket's version:

```
    {
      "Name": "settings-defaults",
      "Publisher": "Bottlerocket",
      "Version": "1.21.0",
      "Release": "7a7b5dd3",
      "InstalledTime": "2024-06-18T21:52:21Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Settings defaults"
    }
```
**Testing on a Bottlerocket 1.0.0**

To test that these changes work as expected, I created an `aws-dev` variant, with a `release-version` of `1.0.0` in both `Twoliter.toml` and `Release.toml`. SSM reports inventory as expected:

<img width="946" alt="Screenshot 2024-06-18 at 5 22 55 PM" src="https://github.com/bottlerocket-os/twoliter/assets/43075615/3050a5e6-ccb4-47ee-925f-e5d8b03c2f9f">

And the generated app inventory is as expected:

```
{
  "Content": [
    {
      "Name": "acpid",
      "Publisher": "Bottlerocket",
      "Version": "2.0.0",
      "Release": "7a7b5dd3-dirty",
      "InstalledTime": "2024-06-19T04:56:22Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://sourceforge.net/projects/acpid2/",
      "Summary": "ACPI event daemon"
    },
...
  {
      "Name": "settings-defaults",
      "Publisher": "Bottlerocket",
      "Version": "1.0.0",
      "Release": "7a7b5dd3-dirty",
      "InstalledTime": "2024-06-19T04:56:22Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Settings defaults"
    },
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
