### PR TITLE
twoliter: fix purge-go-vendor task

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1760,10 +1760,12 @@ dependencies = [
 [tasks.purge-go-vendor]
 script_runner = "bash"
 script = [
-    '''
-    chmod -R 755 ${GO_MOD_CACHE}
-    rm -rf ${GO_MOD_CACHE}
-    '''
+'''
+if [ -d "${GO_MOD_CACHE}" ] ; then
+  chmod -R 755 "${GO_MOD_CACHE}"
+  rm -rf "${GO_MOD_CACHE}"
+fi
+'''
 ]
 
 # This task will remove all the cached Rust code found in the cargo home dir


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Fixes a failure observed in the core kit CI, where `purge-go-vendor` fails if the Go module cache doesn't yet exist.


**Testing done:**
Tested locally on a clean checkout.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
