### PR TITLE
application-inventory: adjust Release and Version fields

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -158,15 +158,10 @@ INSTALL_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 rpm -iv --ignorearch --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
 
 # Inventory installed packages.
-# Values specified as %{field-name} are retrieved from the package's corresponding 
-# "field-name:" in the RPM. Note the "Epoch" field is retrieved - its value is set
-# in build.Dockerfile. Epoch is used to trump breaking changes that may occur when
-# the versioning scheme for a package changes between releases - for example, if a
-# newer release of a package were to have a lower "Release". 
 INVENTORY_QUERY="\{\"Name\":\"%{NAME}\"\
 ,\"Publisher\":\"Bottlerocket\"\
-,\"Version\":\"${VERSION_ID}\"\
-,\"Release\":\"${BUILD_ID}\"\
+,\"Version\":\"%{Version}\"\
+,\"Release\":\"%{Release}\"\
 ,\"InstalledTime\":\"${INSTALL_TIME}\"\
 ,\"ApplicationType\":\"%{GROUP}\"\
 ,\"Architecture\":\"%{ARCH}\"\
@@ -190,6 +185,12 @@ CORE_KIT_VENDOR=$(jq --raw-output '.kit[]|select(.name == "bottlerocket-core-kit
 CORE_KIT_PATH="${EXTERNAL_KITS_PATH}/${CORE_KIT_VENDOR}/bottlerocket-core-kit/${ARCH}"
 
 if [[ -n "${CORE_KIT_VERSION}" && -n "${CORE_KIT_VENDOR}" ]]; then
+  # Query the bottlerocket-core-kit repo for a single package's Release in order
+  # to extract the commit that built the core kit.
+  CORE_KIT_GIT_SHA="$(dnf --repofrompath \
+    core-kit,file://"${CORE_KIT_PATH}" \
+    --repo=core-kit repoquery \
+    --queryformat '%{Release}' 2>/dev/null | awk '/^1/{print $1}' | cut -d '.' -f 3)"
   # Query the bottlerocket-core-kit repo of RPMs for all package names.
   CORE_KIT_INVENTORY_QUERY="%{NAME}"
   # shellcheck disable=SC2312 # Array is validated elsewhere.
@@ -217,7 +218,9 @@ if [[ -n "${CORE_KIT_VERSION}" && -n "${CORE_KIT_VENDOR}" ]]; then
   INVENTORY_DATA="$(jq \
     --argfile replace core-kit-replacements.json \
     --arg CORE_KIT_VERSION "${CORE_KIT_VERSION}" \
+    --arg CORE_KIT_GIT_SHA "${CORE_KIT_GIT_SHA}" \
     '(.Content[] | select(.Name | $replace[.] != null) | .Version) = $CORE_KIT_VERSION |
+     (.Content[] | select(.Name | $replace[.] != null) | .Release) = $CORE_KIT_GIT_SHA |
      .Content[].Name |= (if $replace[.] then $replace[.] else . end)' \
     <<<"${INVENTORY_DATA}")"
 fi


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #309 

**Description of changes:**

Right now, application inventory sets `Release` to the commit sha of the project building the final Bottlerocket image. Instead, this field should be:

* git commit sha of the core-kit project if the package came from the core kit
* otherwise, `Release` from the spec of the package

the `Version` field in app inventory also needs updating. It should be:

* core kit release version for a package coming from the core-kit (already implemented)
* otherwise, `Version` from the spec of the package.

Also, remove outdated epoch comment for the inventory query.

**Testing done:**

Verified produced application inventory is as expected:

```
{
  "Content": [
    {
      "Name": "acpid",
      "Publisher": "Bottlerocket",
      "Version": "2.0.0",
       // commit that built this core kit
      "Release": "6939dd23",
      "InstalledTime": "2024-06-20T21:14:47Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://sourceforge.net/projects/acpid2/",
      "Summary": "ACPI event daemon"
    },
...
  // non-core-kit package
    {
      "Name": "bottlerocket-settings-defaults",
      "Publisher": "Bottlerocket",
      // Release and Version pulled directly from the spec
      "Version": "0.0",
      "Release": "0.1718664918.7a7b5dd3.br1",
      "InstalledTime": "2024-06-20T21:14:47Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Settings defaults"
    },
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
