### PR TITLE
Respect GO_MODULES environment variable when preparing modules from `sources` directory

### DIFF
--- a/twoliter/embedded/docker-go
+++ b/twoliter/embedded/docker-go
@@ -51,12 +51,12 @@ parse_args() {
   required_arg "--command" "${COMMAND}"
 }
 
-# We need to mount the ../.. parent of GO_MOD_CACHE
-GOPATH=$(cd "${GO_MOD_CACHE}/../.." && pwd)
-
 DOCKER_RUN_ARGS="--network=host"
 
 parse_args "${@}"
+
+# We need to mount the ../.. parent of GO_MOD_CACHE
+GOPATH=$(cd "${GO_MOD_CACHE}/../.." && pwd)
 
 # Pass through relevant Go variables, from the config or environment.
 go_env=( )

--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -69,7 +69,7 @@ impl BuildKit {
             .env("BUILDSYS_ARCH", &self.arch)
             .env("BUILDSYS_KIT", &self.kit)
             .env("BUILDSYS_VERSION_IMAGE", project.release_version())
-            .env("GO_MODULES", project.find_go_modules().await?.join(" "))
+            .env("GO_MODULES", project.find_go_modules_env().await?.join(" "))
             .env(
                 "BUILDSYS_UPSTREAM_SOURCE_FALLBACK",
                 self.upstream_source_fallback.to_string(),
@@ -141,7 +141,7 @@ impl BuildVariant {
             .env("BUILDSYS_ARCH", &self.arch)
             .env("BUILDSYS_VARIANT", &self.variant)
             .env("BUILDSYS_VERSION_IMAGE", project.release_version())
-            .env("GO_MODULES", project.find_go_modules().await?.join(" "))
+            .env("GO_MODULES", project.find_go_modules_env().await?.join(" "))
             .env(
                 "BUILDSYS_UPSTREAM_SOURCE_FALLBACK",
                 self.upstream_source_fallback.to_string(),

--- a/twoliter/src/project.rs
+++ b/twoliter/src/project.rs
@@ -153,6 +153,26 @@ impl Project {
         }
     }
 
+    fn get_env_go_modules() -> Option<Vec<String>> {
+        std::env::var("GO_MODULES").ok().map(|env_go_modules| {
+            env_go_modules
+                .split_whitespace()
+                .map(str::to_string)
+                .collect()
+        })
+    }
+
+    /// Returns a list of the names of Go modules by searching the `sources` directory for `go.mod`
+    /// files.
+    ///
+    /// If "GO_MODULES" environment variable is set, uses those modules instead.
+    pub(crate) async fn find_go_modules_env(&self) -> Result<Vec<String>> {
+        match Self::get_env_go_modules() {
+            Some(go_modules) => Ok(go_modules),
+            None => self.find_go_modules().await,
+        }
+    }
+
     /// Returns a list of the names of Go modules by searching the `sources` directory for `go.mod`
     /// files.
     pub(crate) async fn find_go_modules(&self) -> Result<Vec<String>> {


### PR DESCRIPTION
**Issue number:**

Closes #312

**Description of changes:**
* twoliter: allow overriding GO_MODULES
* docker-go: fix GOPATH to be set after arg parse

**Testing done:**
* Provided unit tests pass


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
