### PR TITLE
add and remove image features

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -187,16 +187,6 @@ flag is meant primarily for development, and will be removed when development ha
 systemd-networkd = true
 ```
 
-`unified-cgroup-hierarchy` makes systemd set up a unified cgroup hierarchy on
-boot, i.e. the host will use cgroup v2 by default. This feature flag allows
-old variants to continue booting with cgroup v1 and new variants to move to
-cgroup v2, while users will still be able to override the default via command
-line arguments set in the boot configuration.
-```ignore
-[package.metadata.build-variant.image-features]
-unified-cgroup-hierarchy = true
-```
-
 `xfs-data-partition` changes the filesystem for the data partition from ext4 to xfs. The
 default will remain ext4 and xfs is opt-in.
 
@@ -766,7 +756,6 @@ impl SupportedArch {
 pub enum ImageFeature {
     GrubSetPrivateVar,
     SystemdNetworkd,
-    UnifiedCgroupHierarchy,
     XfsDataPartition,
     UefiSecureBoot,
     Fips,
@@ -778,7 +767,6 @@ impl TryFrom<String> for ImageFeature {
         match s.as_str() {
             "grub-set-private-var" => Ok(ImageFeature::GrubSetPrivateVar),
             "systemd-networkd" => Ok(ImageFeature::SystemdNetworkd),
-            "unified-cgroup-hierarchy" => Ok(ImageFeature::UnifiedCgroupHierarchy),
             "xfs-data-partition" => Ok(ImageFeature::XfsDataPartition),
             "uefi-secure-boot" => Ok(ImageFeature::UefiSecureBoot),
             "fips" => Ok(ImageFeature::Fips),
@@ -792,7 +780,6 @@ impl fmt::Display for ImageFeature {
         match self {
             ImageFeature::GrubSetPrivateVar => write!(f, "GRUB_SET_PRIVATE_VAR"),
             ImageFeature::SystemdNetworkd => write!(f, "SYSTEMD_NETWORKD"),
-            ImageFeature::UnifiedCgroupHierarchy => write!(f, "UNIFIED_CGROUP_HIERARCHY"),
             ImageFeature::XfsDataPartition => write!(f, "XFS_DATA_PARTITION"),
             ImageFeature::UefiSecureBoot => write!(f, "UEFI_SECURE_BOOT"),
             ImageFeature::Fips => write!(f, "FIPS"),

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -203,6 +203,8 @@ ARG GRUB_SET_PRIVATE_VAR
 ARG UEFI_SECURE_BOOT
 ARG SYSTEMD_NETWORKD
 ARG XFS_DATA_PARTITION
+ARG IN_PLACE_UPDATES
+ARG HOST_CONTAINERS
 ARG FIPS
 
 USER builder
@@ -224,7 +226,9 @@ RUN \
    && echo -e -n "${FIPS:+%bcond_without fips\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> "${RPM_BCONDS}"
+   && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${IN_PLACE_UPDATES:+%bcond_without in_place_updates\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${HOST_CONTAINERS:+%bcond_without host_containers\n}" >> "${RPM_BCONDS}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an RPM repository from packages created in Section 1 and kits from Section 2.
@@ -328,6 +332,7 @@ ARG KERNEL_PARAMETERS
 ARG GRUB_SET_PRIVATE_VAR
 ARG XFS_DATA_PARTITION
 ARG UEFI_SECURE_BOOT
+ARG IN_PLACE_UPDATES
 ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
     PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
     KERNEL_PARAMETERS=${KERNEL_PARAMETERS}
@@ -363,9 +368,10 @@ RUN --mount=target=/host \
       --data-image-publish-size-gib="${DATA_IMAGE_PUBLISH_SIZE_GIB}" \
       --partition-plan="${PARTITION_PLAN}" \
       --ovf-template="/bypass/variants/${VARIANT}/template.ovf" \
-      ${XFS_DATA_PARTITION:+--xfs-data-partition=yes} \
+      ${XFS_DATA_PARTITION:+--with-xfs-data-partition=yes} \
       ${GRUB_SET_PRIVATE_VAR:+--with-grub-set-private-var=yes} \
-      ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} && \
+      ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
+      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} && \
     rm -rf /local/rpms && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
@@ -467,6 +473,7 @@ ARG PARTITION_PLAN
 ARG OS_IMAGE_PUBLISH_SIZE_GIB
 ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG UEFI_SECURE_BOOT
+ARG IN_PLACE_UPDATES
 ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 WORKDIR /root
 
@@ -500,7 +507,8 @@ RUN --mount=target=/host \
       --data-image-publish-size-gib="${DATA_IMAGE_PUBLISH_SIZE_GIB}" \
       --partition-plan="${PARTITION_PLAN}" \
       --ovf-template="/bypass/variants/${VARIANT}/template.ovf" \
-      ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} && \
+      ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
+      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
     rm /bypass && \

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -202,7 +202,6 @@ ARG VARIANT_FLAVOR
 ARG GRUB_SET_PRIVATE_VAR
 ARG UEFI_SECURE_BOOT
 ARG SYSTEMD_NETWORKD
-ARG UNIFIED_CGROUP_HIERARCHY
 ARG XFS_DATA_PARTITION
 ARG FIPS
 
@@ -225,7 +224,6 @@ RUN \
    && echo -e -n "${FIPS:+%bcond_without fips\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${UNIFIED_CGROUP_HIERARCHY:+%bcond_without unified_cgroup_hierarchy\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> "${RPM_BCONDS}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -7,6 +7,7 @@ OUTPUT_FMT="raw"
 OVF_TEMPLATE=""
 
 UEFI_SECURE_BOOT="no"
+IN_PLACE_UPDATES="no"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -21,6 +22,7 @@ for opt in "$@"; do
   --partition-plan=*) PARTITION_PLAN="${optarg}" ;;
   --ovf-template=*) OVF_TEMPLATE="${optarg}" ;;
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
+  --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -81,7 +83,8 @@ EFI_MOUNT="$(mktemp -p "${WORKDIR}" -d efi.XXXXXXXXXX)"
 # Collect partition sizes and offsets from the partition plan.
 declare -A partsize partoff
 set_partition_sizes \
-  "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" "${PARTITION_PLAN}" \
+  "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
+  "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
   partsize partoff
 
 # Process and stage the input images to the working directory.
@@ -91,10 +94,12 @@ stage_images "${INPUT_DIR}" "${OUTPUT_FMT}" OS_IMAGE DATA_IMAGE
 # Collect partition sizes and offsets from the OS image.
 declare -A imgsize imgoff
 get_partition_sizes \
-  "${OS_IMAGE}" "" "${PARTITION_PLAN}" imgsize imgoff
+  "${OS_IMAGE}" "" \
+  imgsize imgoff
 
 # Compare the offsets between the partition plan and the input image.
-for part in "${!imgoff[@]}"; do
+for part in "${!partoff[@]}"; do
+  [[ "${part}" == DATA-* ]] && continue
   if [[ "${partoff["${part}"]}" -ne "${imgoff["${part}"]}" ]]; then
     echo "start mismatch between partition plan and disk: '${part}'" >&2
     exit 1
@@ -102,7 +107,8 @@ for part in "${!imgoff[@]}"; do
 done
 
 # Compare the sizes between the partition plan and the input image.
-for part in "${!imgsize[@]}"; do
+for part in "${!partsize[@]}"; do
+  [[ "${part}" == DATA-* ]] && continue
   if [[ "${partsize["${part}"]}" -ne "${imgsize["${part}"]}" ]]; then
     echo "size mismatch between partition plan and disk: '${part}'" >&2
     exit 1

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -32,12 +32,6 @@ Provides: %{_cross_os}image-feature(systemd-networkd)
 Provides: %{_cross_os}image-feature(no-systemd-networkd)
 %endif
 
-%if %{with unified_cgroup_hierarchy}
-Provides: %{_cross_os}image-feature(unified-cgroup-hierarchy)
-%else
-Provides: %{_cross_os}image-feature(no-unified-cgroup-hierarchy)
-%endif
-
 %if %{with xfs_data_partition}
 Provides: %{_cross_os}image-feature(xfs-data-partition)
 %else

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -14,6 +14,18 @@ Provides: %{_cross_os}variant-runtime(%{_cross_variant_runtime})
 Provides: %{_cross_os}variant-family(%{_cross_variant_family})
 Provides: %{_cross_os}variant-flavor(%{_cross_variant_flavor})
 
+%if %{with in_place_updates}
+Provides: %{_cross_os}image-feature(in-place-updates)
+%else
+Provides: %{_cross_os}image-feature(no-in-place-updates)
+%endif
+
+%if %{with host_containers}
+Provides: %{_cross_os}image-feature(host-containers)
+%else
+Provides: %{_cross_os}image-feature(no-host-containers)
+%endif
+
 %if %{with grub_set_private_var}
 Provides: %{_cross_os}image-feature(grub-set-private-var)
 %else

--- a/twoliter/embedded/partyplanner
+++ b/twoliter/embedded/partyplanner
@@ -91,8 +91,9 @@ PRIVATE_SCALE_FACTOR="24"
 ###############################################################################
 # Section 4: ASCII art gallery
 
-# Layout for a 1 GiB OS image. Sizes marked with (*) scale with overall image
-# size, based on the constant factors above.
+# Layout for a 1 GiB OS image that supports in-place updates.
+# Sizes marked with (*) scale with overall image size, based on the constant
+# factors above.
 
 #          +---------------------------------+
 #  Prelude | GPT header               1 MiB  | 5 MiB
@@ -115,100 +116,82 @@ PRIVATE_SCALE_FACTOR="24"
 # Postlude | GPT footer               1 MiB  | GPT is fixed, private partition grows.
 #          +---------------------------------+
 
+# Layout for a 1 GiB OS image that does not support in-place updates.
+# Sizes marked with (*) scale with overall image size, based on the constant
+# factors above.
+
+#          +---------------------------------+
+#  Prelude | GPT header               1 MiB  | 5 MiB
+#          | BIOS boot partition      4 MiB  | Fixed size.
+#          +---------------------------------+
+#          | EFI system partition    10 MiB  |
+#          | Boot partition          40 MiB* | (image size - prelude - postlude) / 2
+#   Bank A | Root partition         920 MiB* | Example: (1 GiB - 5 MiB - 19 MiB) / 2
+#          | Hash partition          10 MiB* |          1000 MiB
+#          | Reserved partition      20 MiB* |
+#          +---------------------------------+
+#          | Private partition       17 MiB* | (image size * 24 as MiB) - prelude - DATA-A size
+#          | Data partition A         1 MiB  | Data partition A
+# Postlude | GPT footer               1 MiB  | GPT is fixed, private partition grows.
+#          +---------------------------------+
+
 ##############################################################################
 # Section 5: library functions
 
-# Populate the caller's tables with sizes and offsets for known partitions of
+# Populate the caller's tables with sizes and offsets for partitions of
 # existing images.
 get_partition_sizes() {
-  local os_image data_image partition_plan
+  local os_image data_image
   local -n pt_size pt_offset
   os_image="$1"
   data_image="$2"
 
-  # Whether we're building a layout for a "split" image, where OS and data
-  # volumes are on separate disks, or a "unified" image, where they share the
-  # same disk.
-  partition_plan="${3:?}"
-
   # Table for partition sizes, in MiB.
-  pt_size="${4:?}"
+  pt_size="${3:?}"
 
   # Table for partition offsets from start of disk, in MiB.
-  pt_offset="${5:?}"
+  pt_offset="${4:?}"
 
-  local os_image_table=""
-  if [[ -n "${os_image}" ]]; then
-    os_image_table="$(sgdisk --print "${os_image}")"
+  local -a images
+  images=("${os_image}")
+  if [[ -n "${data_image}" ]]; then
+    images+=("${data_image}")
   fi
 
-  local data_image_table=""
-  if [[ "${partition_plan}" == "split" ]] && [[ -n "${data_image}" ]]; then
-    data_image_table="$(sgdisk --print "${data_image}")"
-  else
-    data_image_table="${os_image_table}"
-  fi
+  local partitions part_info part_name part_offset part_size part_key
+  for image in "${images[@]}" ; do
+    partitions="$(sgdisk --print "${image}" | awk 'END {print $1}')"
+    for p in $(seq 1 "${partitions}") ; do
+      part_info="$(sgdisk -i "${p}" "${os_image}")"
+      part_name="$(awk -F"'" '/Partition name:/{print $2}'<<<"${part_info}")"
+      [ -n "${part_name}" ] || continue
+      part_offset="$(awk '/First sector:/{print $3}'<<<"${part_info}")"
+      part_size="$(awk '/Partition size:/{print $3}'<<<"${part_info}")"
+      case "${part_name}" in
+      BIOS-BOOT)
+        part_key="BIOS"
+        ;;
+      EFI-SYSTEM)
+        part_key="EFI-A"
+        ;;
+      EFI-BACKUP)
+        part_key="EFI-B"
+        ;;
+      *)
+        part_key="${part_name#BOTTLEROCKET-}"
+        ;;
+      esac
 
-  local offset sectors
-  for part in \
-    BIOS \
-    EFI-A BOOT-A ROOT-A HASH-A RESERVED-A \
-    EFI-B BOOT-B ROOT-B HASH-B RESERVED-B \
-    PRIVATE DATA-A DATA-B; do
-    case "${part}" in
-    BIOS)
-      offset="$(awk /BIOS-BOOT/'{print $2}' <<<"${os_image_table}")"
-      sectors="$(awk /BIOS-BOOT/'{print $4}' <<<"${os_image_table}")"
-      ;;
-    EFI-A)
-      offset="$(awk /EFI-SYSTEM/'{print $2}' <<<"${os_image_table}")"
-      sectors="$(awk /EFI-SYSTEM/'{print $4}' <<<"${os_image_table}")"
-      ;;
-    EFI-B)
-      offset="$(awk /EFI-BACKUP/'{print $2}' <<<"${os_image_table}")"
-      sectors="$(awk /EFI-BACKUP/'{print $4}' <<<"${os_image_table}")"
-      ;;
-    RESERVED-A)
-      offset="$(awk /BOTTLEROCKET-RESERV/'{print $2}' \
-        <<<"${os_image_table}" | head -1 || true)"
-      sectors="$(awk /BOTTLEROCKET-RESERV/'{print $4}' \
-        <<<"${os_image_table}" | head -1 || true)"
-      ;;
-    RESERVED-B)
-      offset="$(awk /BOTTLEROCKET-RESERV/'{print $2}' \
-        <<<"${os_image_table}" | tail -1 || true)"
-      sectors="$(awk /BOTTLEROCKET-RESERV/'{print $4}' \
-        <<<"${os_image_table}" | tail -1 || true)"
-      ;;
-    DATA)
-      offset="$(awk /BOTTLEROCKET-"${part}"/'{print $2}' \
-        <<<"${data_image_table}")"
-      sectors="$(awk /BOTTLEROCKET-"${part}"/'{print $4}' \
-        <<<"${data_image_table}")"
-      ;;
-    *)
-      offset="$(awk /BOTTLEROCKET-"${part}"/'{print $2}' \
-        <<<"${os_image_table}")"
-      sectors="$(awk /BOTTLEROCKET-"${part}"/'{print $4}' \
-        <<<"${os_image_table}")"
-      ;;
-    esac
-
-    if [[ -n "${offset}" ]]; then
       # 1 MiB contains 2048 512-byte sectors.
-      offset_mib="$((offset / 2048))"
-      pt_offset["${part}"]="${offset_mib}"
-    fi
-
-    if [[ -n "${sectors}" ]]; then
-      pt_size["${part}"]="${sectors%.0}"
-    fi
+      pt_offset["${part_key}"]="$(( part_offset / 2048 ))"
+      pt_size["${part_key}"]="$(( part_size / 2048 ))"
+    done
   done
 }
 
 # Populate the caller's tables with sizes and offsets for known partitions.
 set_partition_sizes() {
-  local os_image_gib data_image_gib partition_plan
+  local os_image_gib data_image_gib partition_plan in_place_updates
   local -n pp_size pp_offset
   os_image_gib="${1:?}"
   data_image_gib="${2:?}"
@@ -218,11 +201,15 @@ set_partition_sizes() {
   # same disk.
   partition_plan="${3:?}"
 
+  # Whether the image should support in-place updates, where two banks of OS
+  # partitions are available to store active/passive update images.
+  in_place_updates="${4:?}"
+
   # Table for partition sizes, in MiB.
-  pp_size="${4:?}"
+  pp_size="${5:?}"
 
   # Table for partition offsets from start of disk, in MiB.
-  pp_offset="${5:?}"
+  pp_offset="${6:?}"
 
   # Most of the partitions on the main image scale with the overall size.
   local boot_mib root_mib hash_mib reserved_mib private_mib
@@ -247,27 +234,51 @@ set_partition_sizes() {
   pp_size["BIOS"]="${BIOS_MIB}"
   ((offset += BIOS_MIB))
 
-  for bank in A B; do
-    pp_offset["EFI-${bank}"]="${offset}"
-    pp_size["EFI-${bank}"]="${EFI_MIB}"
-    ((offset += EFI_MIB))
+  if [[ "${in_place_updates}" == "yes" ]]; then
+    # Allocate two partition banks to support in-place updates.
+    for bank in A B; do
+      pp_offset["EFI-${bank}"]="${offset}"
+      pp_size["EFI-${bank}"]="${EFI_MIB}"
+      ((offset += EFI_MIB))
 
-    pp_offset["BOOT-${bank}"]="${offset}"
-    pp_size["BOOT-${bank}"]="${boot_mib}"
-    ((offset += boot_mib))
+      pp_offset["BOOT-${bank}"]="${offset}"
+      pp_size["BOOT-${bank}"]="${boot_mib}"
+      ((offset += boot_mib))
 
-    pp_offset["ROOT-${bank}"]="${offset}"
-    pp_size["ROOT-${bank}"]="${root_mib}"
-    ((offset += root_mib))
+      pp_offset["ROOT-${bank}"]="${offset}"
+      pp_size["ROOT-${bank}"]="${root_mib}"
+      ((offset += root_mib))
 
-    pp_offset["HASH-${bank}"]="${offset}"
-    pp_size["HASH-${bank}"]="${hash_mib}"
-    ((offset += hash_mib))
+      pp_offset["HASH-${bank}"]="${offset}"
+      pp_size["HASH-${bank}"]="${hash_mib}"
+      ((offset += hash_mib))
 
-    pp_offset["RESERVED-${bank}"]="${offset}"
-    pp_size["RESERVED-${bank}"]="${reserved_mib}"
-    ((offset += reserved_mib))
-  done
+      pp_offset["RESERVED-${bank}"]="${offset}"
+      pp_size["RESERVED-${bank}"]="${reserved_mib}"
+      ((offset += reserved_mib))
+    done
+  else
+    # Allocate a single partition bank, where each partition is twice as large.
+    pp_offset["EFI-A"]="${offset}"
+    pp_size["EFI-A"]="$(( EFI_MIB * 2 ))"
+    ((offset += EFI_MIB * 2))
+
+    pp_offset["BOOT-A"]="${offset}"
+    pp_size["BOOT-A"]="$(( boot_mib * 2 ))"
+    ((offset += boot_mib * 2))
+
+    pp_offset["ROOT-A"]="${offset}"
+    pp_size["ROOT-A"]="$(( root_mib * 2 ))"
+    ((offset += root_mib * 2))
+
+    pp_offset["HASH-A"]="${offset}"
+    pp_size["HASH-A"]="$(( hash_mib * 2 ))"
+    ((offset += hash_mib * 2))
+
+    pp_offset["RESERVED-A"]="${offset}"
+    pp_size["RESERVED-A"]="$(( reserved_mib * 2 ))"
+    ((offset += reserved_mib * 2))
+  fi
 
   pp_offset["PRIVATE"]="${offset}"
   pp_size["PRIVATE"]="${private_mib}"

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -9,6 +9,7 @@ OVF_TEMPLATE=""
 GRUB_SET_PRIVATE_VAR="no"
 XFS_DATA_PARTITION="no"
 UEFI_SECURE_BOOT="no"
+IN_PLACE_UPDATES="no"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -24,8 +25,9 @@ for opt in "$@"; do
   --partition-plan=*) PARTITION_PLAN="${optarg}" ;;
   --ovf-template=*) OVF_TEMPLATE="${optarg}" ;;
   --with-grub-set-private-var=*) GRUB_SET_PRIVATE_VAR="${optarg}" ;;
-  --xfs-data-partition=*) XFS_DATA_PARTITION="${optarg}" ;;
+  --with-xfs-data-partition=*) XFS_DATA_PARTITION="${optarg}" ;;
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
+  --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -98,18 +100,23 @@ esac
 
 declare -A partlabel parttype partguid partsize partoff
 set_partition_sizes \
-  "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" "${PARTITION_PLAN}" \
+  "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
+  "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
   partsize partoff
 set_partition_labels partlabel
 set_partition_types parttype
 set_partition_uuids partguid "${PARTITION_PLAN}"
 
+declare -a partitions
+partitions=(BIOS)
+partitions+=(EFI-A BOOT-A ROOT-A HASH-A RESERVED-A)
+if [[ "${IN_PLACE_UPDATES}" == "yes" ]]; then
+  partitions+=(EFI-B BOOT-B ROOT-B HASH-B RESERVED-B)
+fi
+partitions+=(PRIVATE DATA-A DATA-B)
+
 declare -a partargs
-for part in \
-  BIOS \
-  EFI-A BOOT-A ROOT-A HASH-A RESERVED-A \
-  EFI-B BOOT-B ROOT-B HASH-B RESERVED-B \
-  PRIVATE DATA-A DATA-B; do
+for part in "${partitions[@]}"; do
   # We create the DATA-B partition separately if we're using the split layout
   if [[ "${part}" == "DATA-B" ]]; then
     continue


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Remove support for the `unified-cgroup-hierarchy` image feature, which is effectively no longer implemented.

Add support for two new features that are enabled by default:
* `in-place-updates`, which affects the partition layout
* `host-containers`, which only affects what software might be installed

These features can be targeted by RPM boolean dependencies in package specs to arrange for software to be installed only if the feature is enabled for a given variant.

Most of the non-boilerplate work was in `partyplanner`. `get_partition_sizes` needed better handling for the `RESERVED` partitions (rather than assuming there would always be two), and `set_partition_sizes` needed a new mode for laying out partitions.

**Testing done:**
Built `aws-dev` with both new features disabled, and `aws-k8s-1.24` with both enabled.

`aws-dev` partition layout:
```
Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           10239   4.0 MiB     EF02  BIOS-BOOT
   2           10240           30719   10.0 MiB    EF00  EFI-SYSTEM
   3           30720          194559   80.0 MiB    FFFF  BOTTLEROCKET-BOOT-A
   4          194560         3962879   1.8 GiB     FFFF  BOTTLEROCKET-ROOT-A
   5         3962880         4003839   20.0 MiB    FFFF  BOTTLEROCKET-HASH-A
   6         4003840         4106239   50.0 MiB    FFFF  BOTTLEROCKET-RESERV...
   7         4106240         4190207   41.0 MiB    FFFF  BOTTLEROCKET-PRIVATE
   8         4190208         4192255   1024.0 KiB  FFFF
```

`aws-k8s-1.24` partition layout:
```
Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           10239   4.0 MiB     EF02  BIOS-BOOT
   2           10240           20479   5.0 MiB     EF00  EFI-SYSTEM
   3           20480          102399   40.0 MiB    FFFF  BOTTLEROCKET-BOOT-A
   4          102400         1986559   920.0 MiB   FFFF  BOTTLEROCKET-ROOT-A
   5         1986560         2007039   10.0 MiB    FFFF  BOTTLEROCKET-HASH-A
   6         2007040         2058239   25.0 MiB    FFFF  BOTTLEROCKET-RESERV...
   7         2058240         2068479   5.0 MiB     FFFF  EFI-BACKUP
   8         2068480         2150399   40.0 MiB    FFFF  BOTTLEROCKET-BOOT-B
   9         2150400         4034559   920.0 MiB   FFFF  BOTTLEROCKET-ROOT-B
  10         4034560         4055039   10.0 MiB    FFFF  BOTTLEROCKET-HASH-B
  11         4055040         4106239   25.0 MiB    FFFF  BOTTLEROCKET-RESERV...
  12         4106240         4190207   41.0 MiB    FFFF  BOTTLEROCKET-PRIVATE
  13         4190208         4192255   1024.0 KiB  FFFF
```

`cargo make repack-variant` worked for both.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
