### PR TITLE
pubsys: move update wave schedules into twoliter embedded

### DIFF
--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -39,6 +39,10 @@ fn main() {
     paths.copy_file("rpm2migrations");
     paths.copy_file("metadata.spec");
     paths.copy_file("ocihelper");
+    paths.copy_file("waves/accelerated-waves.toml");
+    paths.copy_file("waves/default-waves.toml");
+    paths.copy_file("waves/ohno.toml");
+    paths.copy_file("waves/slow-roll.toml");
 
     // Create tarball in memory.
     println!("Starting tarball creation at {:?}", SystemTime::now());
@@ -102,6 +106,12 @@ where
 {
     let source = source.as_ref();
     let dest = dest.as_ref();
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).expect(&format!(
+            "Unable to create destination directory '{}'",
+            parent.display()
+        ));
+    }
     fs::copy(source, dest).expect(&format!(
         "Unable to copy `{}' to '{}'",
         source.display(),

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -47,7 +47,7 @@ BUILDSYS_PRETTY_NAME = "Bottlerocket OS"
 # starting now.  (This can be an RFC3339 date, or an offset like "in X
 # hours/days/weeks".)
 PUBLISH_EXPIRATION_POLICY_PATH = "${BUILDSYS_ROOT_DIR}/tools/pubsys/policies/repo-expiration/2w-2w-1w.toml"
-PUBLISH_WAVE_POLICY_PATH = "${BUILDSYS_ROOT_DIR}/sources/updater/waves/default-waves.toml"
+PUBLISH_WAVE_POLICY_PATH = "${BUILDSYS_BUILD_DIR}/tools/waves/default-waves.toml"
 PUBLISH_INFRA_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Infra.toml"
 # Default repo to read from PUBLISH_INFRA_CONFIG_PATH
 PUBLISH_REPO = "default"

--- a/twoliter/embedded/waves/accelerated-waves.toml
+++ b/twoliter/embedded/waves/accelerated-waves.toml
@@ -1,0 +1,24 @@
+# The following represents an "accelerated" set of update waves for a much
+# quicker deployment. The deployment lasts for 1 day, and quickly increases the
+# nodes updated at once.
+[[waves]]
+start_after = '1 hour'
+fleet_percentage = 3
+
+[[waves]]
+start_after = '4 hours'
+fleet_percentage = 12
+
+[[waves]]
+start_after = '8 hours'
+fleet_percentage = 40
+
+[[waves]]
+start_after = '16 hours'
+fleet_percentage = 80
+
+# Last 20 percent of the hosts will update immediately after 24 hours since the start of
+# deployment. Unlike the other waves, there will be no velocity control.
+[[waves]]
+start_after = '1 day'
+fleet_percentage = 100

--- a/twoliter/embedded/waves/default-waves.toml
+++ b/twoliter/embedded/waves/default-waves.toml
@@ -1,0 +1,32 @@
+# The following represents a "normal" set of update waves for a typical
+# deployment. The deployment lasts for 6 days, and gradually increases the
+# nodes updated at once.
+[[waves]]
+start_after = '1 hour'
+fleet_percentage = 1
+
+[[waves]]
+start_after = '4 hours'
+fleet_percentage = 5
+
+[[waves]]
+start_after = '1 day'
+fleet_percentage = 15
+
+[[waves]]
+start_after = '2 days'
+fleet_percentage = 40
+
+[[waves]]
+start_after = '4 days'
+fleet_percentage = 60
+
+[[waves]]
+start_after = '5 days'
+fleet_percentage = 90
+
+# Last 10 percent of the hosts will update immediately after 6 days since the start of
+# deployment. Unlike the other waves, there will be no velocity control.
+[[waves]]
+start_after = '6 days'
+fleet_percentage = 100

--- a/twoliter/embedded/waves/ohno.toml
+++ b/twoliter/embedded/waves/ohno.toml
@@ -1,0 +1,23 @@
+# The following represents an "emergency" set of update waves for a rapid
+# deployment. The deployment lasts for 3 hours, with a small initial wave.
+[[waves]]
+start_after = '30 minutes'
+fleet_percentage = 5
+
+[[waves]]
+start_after = '60 minutes'
+fleet_percentage = 25
+
+[[waves]]
+start_after = '120 minutes'
+fleet_percentage = 50
+
+[[waves]]
+start_after = '150 minutes'
+fleet_percentage = 90
+
+# Last 10 percent of the hosts will update immediately after 3 hours since the start of
+# deployment. Unlike the other waves, there will be no velocity control.
+[[waves]]
+start_after = '180 minutes'
+fleet_percentage = 100

--- a/twoliter/embedded/waves/slow-roll.toml
+++ b/twoliter/embedded/waves/slow-roll.toml
@@ -1,0 +1,32 @@
+# The following represents a set of update waves that rolls out more slowly
+# than default. The deployment lasts for 13 days, and gradually increases the
+# nodes updated at once.
+[[waves]]
+start_after = '1 hour'
+fleet_percentage = 1
+
+[[waves]]
+start_after = '1 day'
+fleet_percentage = 5
+
+[[waves]]
+start_after = '3 days'
+fleet_percentage = 15
+
+[[waves]]
+start_after = '7 days'
+fleet_percentage = 40
+
+[[waves]]
+start_after = '9 days'
+fleet_percentage = 60
+
+[[waves]]
+start_after = '12 days'
+fleet_percentage = 90
+
+# Last 10 percent of the hosts will update immediately after 13 days since the start of
+# deployment. Unlike the other waves, there will be no velocity control.
+[[waves]]
+start_after = '13 days'
+fleet_percentage = 100


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

* Moves the default wave toml files from bottlerocket-core-kit repo into the twoliter embeded. Following this PR and twoliter release, i will update Makefile.toml in bottlerocket/ with appropriate path in its cargo makefile.toml and remove the files from core-kit repo in another PR


**Testing done:**

* Built aws-ecs-2 variant on dev instance
* Built repositories successfully


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
