### PR TITLE
Fix image handling bugs in `twoliter update`

### DIFF
--- a/.github/actions/install-crane/action.yaml
+++ b/.github/actions/install-crane/action.yaml
@@ -1,0 +1,45 @@
+name: "Install crane"
+description: "Installs crane for use in testing."
+inputs:
+  crane-version:
+    description: "Version of crane to install"
+    required: false
+    default: latest
+  install-dir:
+    description: "Directory to install crane"
+    required: false
+    default: $HOME/.crane
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        mkdir -p ${{ inputs.install-dir }}
+
+        VERSION=${{ inputs.crane-version }}
+        if [[ "${VERSION}" == "latest" ]]; then
+          VERSION=$(gh release list \
+            --exclude-pre-releases \
+            -R google/go-containerregistry \
+            --json name \
+            | jq -r '.[0].name')
+        fi
+
+        case ${{ runner.arch }} in
+          X64)
+            ARCH=x86_64
+            ;;
+          ARM64)
+            ARCH=arm64
+            ;;
+        esac
+
+        ARTIFACT_NAME="go-containerregistry_Linux_${ARCH}.tar.gz"
+        gh release download "${VERSION}" \
+          -R google/go-containerregistry \
+          -p "${ARTIFACT_NAME}" \
+          --output - \
+          | tar -zxvf - -C "${{ inputs.install-dir }}" crane
+
+        echo "${{ inputs.install-dir }}" >> "${GITHUB_PATH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Install crane for testing
+        uses: ./.github/actions/install-crane
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install cargo-dist
         run: |
           cargo install --locked \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,10 @@ jobs:
       labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
+      - name: Install crane for testing
+        uses: ./.github/actions/install-crane
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo install cargo-deny --locked
       - run: cargo install cargo-make --locked
       - run: make build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "log",
+ "olpc-cjson",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,6 +2167,7 @@ name = "oci-cli-wrapper"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "log",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "integration-tests"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+ "twoliter",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ members = [
     "tools/unplug",
     "tools/update-metadata",
     "twoliter",
+
+    "tests/integration-tests",
 ]
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,12 @@ fmt:
 test:
 	cargo test --release --locked
 
+.PHONY: integ
+integ:
+	cargo test --manifest-path tests/integration-tests/Cargo.toml -- --include-ignored
+
 .PHONY: check
-check: fmt clippy deny test
+check: fmt clippy deny test integ
 
 .PHONY: build
 build: check

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "integration-tests"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dev-dependencies]
+tokio = { version = "1", default-features = false, features = ["process", "fs", "rt-multi-thread"] }
+twoliter = { version = "0", path = "../../twoliter", artifact = [ "bin:twoliter" ] }

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -1,0 +1,44 @@
+#![cfg(test)]
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use tokio::process::Command;
+
+mod twoliter_update;
+
+pub const TWOLITER_PATH: &'static str = env!("CARGO_BIN_FILE_TWOLITER");
+
+pub fn test_projects_dir() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.join("projects")
+}
+
+pub async fn run_command<I, S, E>(cmd: S, args: I, env: E) -> std::process::Output
+where
+    I: IntoIterator<Item = S>,
+    E: IntoIterator<Item = (S, S)>,
+    S: AsRef<OsStr>,
+{
+    let args: Vec<S> = args.into_iter().collect();
+
+    println!(
+        "Executing '{}' with args [{}]",
+        cmd.as_ref().to_string_lossy(),
+        args.iter()
+            .map(|arg| format!("'{}'", arg.as_ref().to_string_lossy()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let output = Command::new(cmd)
+        .args(args.into_iter())
+        .envs(env.into_iter())
+        .output()
+        .await
+        .expect("failed to execute process");
+
+    println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+    println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+    output
+}

--- a/tests/integration-tests/src/twoliter_update.rs
+++ b/tests/integration-tests/src/twoliter_update.rs
@@ -1,0 +1,76 @@
+use super::{run_command, test_projects_dir, TWOLITER_PATH};
+
+const EXPECTED_LOCKFILE: &str = r#"schema-version = 1
+release-version = "1.0.0"
+digest = "m/6DbBacnIBHMo34GCuzA4pAHzrnQJ2G/XJMMguZXjw="
+
+[sdk]
+name = "bottlerocket-sdk"
+version = "0.42.0"
+vendor = "bottlerocket"
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.42.0"
+digest = "myHHKE41h9qfeyR6V6HB0BfiLPwj3QEFLUFy4TXcR10="
+
+[[kit]]
+name = "bottlerocket-core-kit"
+version = "2.0.0"
+vendor = "custom-vendor"
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v2.0.0"
+digest = "vlTsAAbSCzXFZofVmw8pLLkRjnG/y8mtb2QsQBSz1zk="
+"#;
+
+#[tokio::test]
+#[ignore]
+/// Generates a Twoliter.lock file for the `external-kit` project using docker
+async fn test_twoliter_update_docker() {
+    let external_kit = test_projects_dir().join("external-kit");
+
+    let lockfile = external_kit.join("Twoliter.lock");
+    tokio::fs::remove_file(&lockfile).await.ok();
+
+    let output = run_command(
+        TWOLITER_PATH,
+        [
+            "update",
+            "--project-path",
+            external_kit.join("Twoliter.toml").to_str().unwrap(),
+        ],
+        [("TWOLITER_KIT_IMAGE_TOOL", "docker")],
+    )
+    .await;
+
+    assert!(output.status.success());
+
+    let lock_contents = tokio::fs::read_to_string(&lockfile).await.unwrap();
+    assert_eq!(lock_contents, EXPECTED_LOCKFILE);
+
+    tokio::fs::remove_file(&lockfile).await.ok();
+}
+
+#[tokio::test]
+#[ignore]
+/// Generates a Twoliter.lock file for the `external-kit` project using crane
+async fn test_twoliter_update_crane() {
+    let external_kit = test_projects_dir().join("external-kit");
+
+    let lockfile = external_kit.join("Twoliter.lock");
+    tokio::fs::remove_file(&lockfile).await.ok();
+
+    let output = run_command(
+        TWOLITER_PATH,
+        [
+            "update",
+            "--project-path",
+            external_kit.join("Twoliter.toml").to_str().unwrap(),
+        ],
+        [("TWOLITER_KIT_IMAGE_TOOL", "crane")],
+    )
+    .await;
+
+    assert!(output.status.success());
+
+    let lock_contents = tokio::fs::read_to_string(&lockfile).await.unwrap();
+    assert_eq!(lock_contents, EXPECTED_LOCKFILE);
+
+    tokio::fs::remove_file(&lockfile).await.ok();
+}

--- a/tests/projects/external-kit/Twoliter.toml
+++ b/tests/projects/external-kit/Twoliter.toml
@@ -1,19 +1,13 @@
 schema-version = 1
 release-version = "1.0.0"
 
-[sdk]
-name = "bottlerocket-sdk"
-vendor = "bottlerocket"
-version = "0.41.0"
-
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"
 
 [vendor.custom-vendor]
-# We need to figure out how we can do integration testing with this
 registry = "public.ecr.aws/bottlerocket"
 
 [[kit]]
-name = "core-kit"
-version = "0.1.0"
+name = "bottlerocket-core-kit"
+version = "2.0.0"
 vendor = "custom-vendor"

--- a/tools/oci-cli-wrapper/Cargo.toml
+++ b/tools/oci-cli-wrapper/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+log = "0.4"
 regex = "1"
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"

--- a/tools/oci-cli-wrapper/Cargo.toml
+++ b/tools/oci-cli-wrapper/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 log = "0.4"
+olpc-cjson = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"

--- a/tools/oci-cli-wrapper/src/cli.rs
+++ b/tools/oci-cli-wrapper/src/cli.rs
@@ -4,6 +4,7 @@ use tokio::process::Command;
 
 use crate::{error, Result};
 
+#[derive(Debug)]
 pub(crate) struct CommandLine {
     pub(crate) path: PathBuf,
 }

--- a/tools/oci-cli-wrapper/src/cli.rs
+++ b/tools/oci-cli-wrapper/src/cli.rs
@@ -10,6 +10,14 @@ pub(crate) struct CommandLine {
 
 impl CommandLine {
     pub(crate) async fn output(&self, args: &[&str], error_msg: String) -> Result<Vec<u8>> {
+        log::debug!(
+            "Executing '{}' with args [{}]",
+            self.path.display(),
+            args.iter()
+                .map(|arg| format!("'{}'", arg))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
         let output = Command::new(&self.path)
             .args(args)
             .output()
@@ -23,10 +31,22 @@ impl CommandLine {
                 args: args.iter().map(|x| x.to_string()).collect::<Vec<_>>()
             }
         );
+        log::debug!(
+            "stdout: {}",
+            String::from_utf8_lossy(&output.stdout).to_string()
+        );
         Ok(output.stdout)
     }
 
     pub(crate) async fn spawn(&self, args: &[&str], error_msg: String) -> Result<()> {
+        log::debug!(
+            "Executing '{}' with args [{}]",
+            self.path.display(),
+            args.iter()
+                .map(|arg| format!("'{}'", arg))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
         let status = Command::new(&self.path)
             .args(args)
             .spawn()

--- a/tools/oci-cli-wrapper/src/crane.rs
+++ b/tools/oci-cli-wrapper/src/crane.rs
@@ -7,15 +7,16 @@ use tar::Archive as TarArchive;
 use tempfile::TempDir;
 
 use crate::{
-    cli::CommandLine, error, ConfigView, DockerArchitecture, ImageTool, ImageView, Result,
+    cli::CommandLine, error, ConfigView, DockerArchitecture, ImageToolImpl, ImageView, Result,
 };
 
+#[derive(Debug)]
 pub struct CraneCLI {
     pub(crate) cli: CommandLine,
 }
 
 #[async_trait]
-impl ImageTool for CraneCLI {
+impl ImageToolImpl for CraneCLI {
     async fn pull_oci_image(&self, path: &Path, uri: &str) -> Result<()> {
         let archive_path = path.to_string_lossy();
         self.cli

--- a/tools/oci-cli-wrapper/src/docker.rs
+++ b/tools/oci-cli-wrapper/src/docker.rs
@@ -8,14 +8,15 @@ use tar::Archive;
 use tempfile::NamedTempFile;
 
 use crate::cli::CommandLine;
-use crate::{error, ConfigView, DockerArchitecture, ImageTool, Result};
+use crate::{error, ConfigView, DockerArchitecture, ImageToolImpl, Result};
 
+#[derive(Debug)]
 pub struct DockerCLI {
     pub(crate) cli: CommandLine,
 }
 
 #[async_trait]
-impl ImageTool for DockerCLI {
+impl ImageToolImpl for DockerCLI {
     async fn pull_oci_image(&self, path: &Path, uri: &str) -> Result<()> {
         // First we pull the image to local daemon
         self.cli

--- a/tools/oci-cli-wrapper/src/docker.rs
+++ b/tools/oci-cli-wrapper/src/docker.rs
@@ -57,13 +57,7 @@ impl ImageTool for DockerCLI {
         let bytes = self
             .cli
             .output(
-                &[
-                    "image",
-                    "inspect",
-                    uri,
-                    "--format",
-                    "\"{{ json .Config }}\"",
-                ],
+                &["image", "inspect", uri, "--format", "{{ json .Config }}"],
                 format!("failed to fetch image config from {}", uri),
             )
             .await?;


### PR DESCRIPTION
**Issue number:**
n/a

**Description of changes:**

> always canonicalize image manifests
> 
> Prior to canonicalizing image manifests, crane and docker would result in slightly different image digests due to non-semantic formatting differences.
---
> fix bug in call to 'docker image inspect'
>
> The --format string erroneously surrounded the output of `docker image
> inspect` in quotes, causing the JSON parser to read the output as a string instead of an object.


**Testing done:**
* The provided integration tests pass (but on github actions? :grimacing:)
* I'm able to `twoliter update` the `bottlerocket` repo to core-kit 2.1.0.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
