### PR TITLE
imghelper: disable pkix in nss

### DIFF
--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -495,7 +495,7 @@ do_sign() {
   pesign -i "${what}" -o "${what}.signed" -s "${sign_key[@]}"
   mv "${what}.signed" "${what}"
   pesign -i "${what}" -l
-  pesigcheck -i "${what}" -n 0 -c "${cert}"
+  NSS_DISABLE_PKIX_VERIFY=1 pesigcheck -i "${what}" -n 0 -c "${cert}"
 }
 
 sign_shim() {


### PR DESCRIPTION
**Description of changes:**
During image creation, bottlerocket uses the `pesigcheck` utility to verify secureboot signatures on all signed artifacts. The signature validation is implemented via libnss.

The next Bottlerocket SDK release will move to NSS 3.101.

In NSS 3.101, lib::pkix was enabled as the default X.509 validator. This causes pesigcheck to fail with "Peer's Certificate issuer is not recognized," despite the CA issuer being provided to pesigcheck.

This change sets `NSS_DISABLE_PKIX_VERIFY=1`, which reverts to the previous default verifier.

I've opened https://github.com/bottlerocket-os/twoliter/issues/334 to root-cause the changes in pkix which cause the issue. We will revert to the previous validator while working to become compatible with pkix.

**Testing done:**
* Bottlerocket builds succeed using SDK `0.42.0` and test artifacts for `0.43.0`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
