### PR TITLE
imghelper: remove full path from .vmlinuz.hmac

### DIFF
--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -478,6 +478,7 @@ sbsetup_signing_profile() {
 undo_sign() {
   local what
   what="${1:?}"
+  # shellcheck disable=SC2076 # literal match is intended.
   if [[ ! "$(pesign -i "${what}" -l)" =~ 'No signatures found.' ]]; then
     mv "${what}" "${what}.orig"
     pesign -i "${what}.orig" -o "${what}" -u 0 -r

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -574,7 +574,7 @@ generate_hmac() {
   local vmlinuz
   vmlinuz="${1:?}"
   openssl sha512 -hmac FIPS-FTW-RHT2009 -hex "${vmlinuz}" |
-    awk -v vmlinuz="${vmlinuz}" '{ print $2 "  " vmlinuz }' \
+    awk '{ print $2 "  vmlinuz" }' \
       >"${vmlinuz%/*}/.${vmlinuz##*/}.hmac"
 }
 


### PR DESCRIPTION
**Description of changes:**

When hmac generation moved to `imghelper`, the `vmlinuz` variable went from the basename to the full-path. This makes sure that the full-path doesn't make it into the final artifact.

Also adds a missing ShellCheck exception.

**Testing done:**

Built and smoke tested Bottlerocket.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
