### PR TITLE
lock: update lock change resolution to fix mutating image collision

### DIFF
--- a/tests/integration-tests/src/twoliter_update.rs
+++ b/tests/integration-tests/src/twoliter_update.rs
@@ -1,8 +1,6 @@
 use super::{run_command, test_projects_dir, TWOLITER_PATH};
 
 const EXPECTED_LOCKFILE: &str = r#"schema-version = 1
-release-version = "1.0.0"
-digest = "m/6DbBacnIBHMo34GCuzA4pAHzrnQJ2G/XJMMguZXjw="
 
 [sdk]
 name = "bottlerocket-sdk"

--- a/twoliter/src/cmd/fetch.rs
+++ b/twoliter/src/cmd/fetch.rs
@@ -10,6 +10,7 @@ pub(crate) struct Fetch {
     #[clap(long = "project-path")]
     pub(crate) project_path: Option<PathBuf>,
 
+    /// Architecture of images to fetch
     #[clap(long = "arch", default_value = "x86_64")]
     pub(crate) arch: String,
 }

--- a/twoliter/src/test/cargo_make.rs
+++ b/twoliter/src/test/cargo_make.rs
@@ -14,8 +14,6 @@ async fn test_cargo_make() {
     let vendor = project.vendor().get(&vendor_id).unwrap();
     let lock = Lock {
         schema_version: project.schema_version(),
-        release_version: project.release_version().to_string(),
-        digest: project.digest().unwrap(),
         kit: Vec::new(),
         sdk: LockedImage {
             name: "my-bottlerocket-sdk".to_string(),


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

* Changes lock change resolution to no longer only rely on the Twoliter.toml digest. Instead it will rerun the resolution and compare the result in order to verify that the remote images haven't mutated
* Adds --update flag to twoliter fetch to allow for performing an update at fetch time
* Removes release-version and root digest from Twoliter.toml
* Consolidates the constructors


**Testing done:**

Tested that Twoliter.lock collision still correctly occurs including remote digest change.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
