### PR TITLE
improve logging in lock generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,6 +3792,7 @@ dependencies = [
  "testsys",
  "tokio",
  "toml",
+ "tracing",
  "tuftool",
  "unplug",
  "uuid",

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -31,6 +31,7 @@ tar = "0.4"
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["fs", "macros", "process", "rt-multi-thread"] }
 toml = "0.8"
+tracing = { version = "0.1", features = ["log"] }
 uuid = { version = "1", features = [ "v4" ] }
 
 # Binary dependencies. These are binaries that we want to embed in the Twoliter binary.

--- a/twoliter/src/cargo_make.rs
+++ b/twoliter/src/cargo_make.rs
@@ -1,8 +1,8 @@
 use crate::common::{exec_log, BUILDSYS_OUTPUT_GENERATION_ID};
 use anyhow::{bail, Result};
-use log::trace;
 use std::path::PathBuf;
 use tokio::process::Command;
+use tracing::trace;
 
 /// A struct used to invoke `cargo make` tasks with `twoliter`'s `Makefile.toml`.
 /// ```rust

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -2,12 +2,12 @@ use crate::common::fs;
 use anyhow::{Context, Result};
 use filetime::{set_file_handle_times, set_file_mtime, FileTime};
 use flate2::read::ZlibDecoder;
-use log::debug;
 use std::path::Path;
 use tar::Archive;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::runtime::Handle;
+use tracing::debug;
 
 const TAR_GZ_DATA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/tools.tar.gz"));
 const BOTTLEROCKET_VARIANT: &[u8] =


### PR DESCRIPTION
**Description of changes:**
I had a `twoliter update` fail and it was difficult to determine why, so I've added additional logging to lockfile generation. I've also done some minor refactoring of the Kit metadata extraction code that threw the error in question.

This (potentially controversially) adds a dependency on the `tracing` crate. Here's why I like this dependency:
* Makes it easy to emit `trace`-level logs for each function call using the `instrument` macro
* Makes it easy to add context to log messages with helpful variable values
* Integrates with the `log` crate for output, or optionally allows more complex IO via the `subscriber` concept.

Here's an example:

```
[2024-07-28T03:18:49Z INFO  twoliter::lock] Resolving project references to create lock file
[2024-07-28T03:18:50Z ERROR twoliter::lock] Mismatched kit metadata in manifest
list canonical_metadata=<ImageMetadata(decoded) [ImageMetadata { name: "bottlerocket-core-kit", version: Version { major: 2, minor: 0, patch: 0 }, sdk: Image {
name: ValidIdentifier("thar-be-beta-sdk"), version: Version { major: 0, minor: 43, patch: 0 }, vendor: ValidIdentifier("bottlerocket-new") }, kits: [] }]> kit_metadata=<ImageMetadata(decoded) [ImageMetadata { name: "bottlerocket-core-kit",
version: Version { major: 2, minor: 0, patch: 0 }, sdk: Image { name: ValidIdentifier("thar-be-beta-sdk"), version: Version { major: 0, minor: 43, patch: 0 }, vendor: ValidIdentifier("bottlerocket") }, kits: [] }]>
Error: Metadata does not match between images in manifest list
```


**Testing done:**
* `make build` succeeds
* `twoliter update` emits helpful logs on failure
* `twoliter update` succeeds within existing workspaces


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
