### PR TITLE
twoliter: add kit overrides for test interactions

### DIFF
--- a/twoliter/src/cmd/fetch.rs
+++ b/twoliter/src/cmd/fetch.rs
@@ -2,6 +2,9 @@ use crate::lock::Lock;
 use crate::project;
 use anyhow::Result;
 use clap::Parser;
+use log::warn;
+use std::collections::HashMap;
+use std::error::Error;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -12,13 +15,51 @@ pub(crate) struct Fetch {
 
     #[clap(long = "arch", default_value = "x86_64")]
     pub(crate) arch: String,
+
+    #[clap(long = "kit-override", short = 'K', value_parser = parse_key_val::<String, PathBuf>)]
+    pub(crate) kit_override: Option<Vec<(String, PathBuf)>>,
+}
+
+/// Parse a single key-value pair
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: Error + Send + Sync + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
 impl Fetch {
     pub(super) async fn run(&self) -> Result<()> {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let lock_file = Lock::load(&project).await?;
-        lock_file.fetch(&project, self.arch.as_str()).await?;
+        if self.kit_override.is_some() {
+            warn!(
+                r#"
+!!!
+Bottlerocket is being built with an overwritten kit.
+This means that the resulting variant images are not based on a remotely
+hosted and officially tagged version of kits.         
+!!!
+"#
+            );
+        }
+        lock_file
+            .fetch(
+                &project,
+                self.arch.as_str(),
+                self.kit_override
+                    .clone()
+                    .map(|x| crate::lock::LockOverrides {
+                        kit: HashMap::from_iter(x),
+                    }),
+            )
+            .await?;
         Ok(())
     }
 }

--- a/twoliter/src/cmd/mod.rs
+++ b/twoliter/src/cmd/mod.rs
@@ -140,6 +140,7 @@ mod test {
         let command = Fetch {
             project_path: Some(project_path.to_path_buf()),
             arch: arch.into(),
+            kit_override: None,
         };
         command.run().await.unwrap()
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** 331

Closes #331 

**Description of changes:**

Adds a kit override option for testing and development use. Twoliter now accepts a variable --kit-override or -K where you can provide <kit-name>=<path to kit repo>. Twoliter will then look for a successfull build in that path to use the oci archive in-place of a kit in ECR. This does bypass Twoliter.lock though


**Testing done:**
* Built bottlerocket core kit at <home>/bottlerocket-core-kit
* Bypassed twoliter update and built a variant using the built core kit via:
```
twoliter fetch --arch=x86_64 -K bottlerocket-core-kit=../bottlerocket-core-kit
twoliter build variant aws-ecs-2 --arch=x86_64
```
Verified it used the ../bottlerocket-core-kit/build/kits/bottlerocket-core-kit/bottlerocket-core-kit-....-x86_64.tar OCI archive


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
