### PR TITLE
imghelper: hoist AWS vars into global environment

### DIFF
--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -414,7 +414,7 @@ sbsetup_aws_profile() {
     val="${var,,}"
     val="${HOME}/.aws/${val//_/-}.env"
     [[ -s "${val}" ]] || continue
-    declare -x "${var}=$(cat "${val}")"
+    declare -g -x "${var}=$(cat "${val}")"
   done
   # Verify that AWS credentials are functional.
   aws sts get-caller-identity


### PR DESCRIPTION
When secure boot signing was refactored in 310cadd8, the code that exports AWS credential variables into the global environment was moved into a bash function.

When used in a bash function, the `declare` keyword makes the declared symbol local, unless the -g option is also supplied. This adds the -g option to export the variables into the caller's environment as intended.

**Testing done:**
Prior to this change, attempting to build with an AWS secureboot profile resulted in this error:
```
  10.46 AWS_KMS: Configured slots:
  10.46 AWS_KMS:   arn:aws:kms:us-west-2:REDACTED/shim-sign-key/gen-2023
  10.46 AWS_KMS:   arn:aws:kms:us-west-2:REDACTED/code-sign-key/gen-2023
  10.46 AWS_KMS:   arn:aws:kms:us-west-2:REDACTED/config-sign-key/gen-2023
  10.46 AWS_KMS: Getting public key for key arn:aws:kms:us-west-2:REDACTED/shim-sign-key/gen-2023
  10.46 AWS_KMS: Got error from AWS fetching public key for key id arn:aws:kms:us-west-2:REDACTED/shim-sign-key/gen-2023: User: arn:aws:sts:REDACTED is not authorized to perform: kms:GetPublicKey on this resource because the resource does not exist in this Region, no resource-based policies allow access, or a resource-based policy explicitly denies access
  10.46 AWS_KMS: Getting public key for key arn:aws:kms:us-west-2:REDACTED/code-sign-key/gen-2023
  10.46 AWS_KMS: Got error from AWS fetching public key for key id arn:aws:kms:us-west-2:REDACTED/code-sign-key/gen-2023: User: arn:aws:sts::REDACTED is not authorized to perform: kms:GetPublicKey on this resource because the resource does not exist in this Region, no resource-based policies allow access, or a resource-based policy explicitly denies access
  10.46 AWS_KMS: Getting public key for key arn:aws:kms:us-west-2:REDACTED/config-sign-key/gen-2023
  10.46 AWS_KMS: Got error from AWS fetching public key for key id arn:aws:kms:us-west-2:REDACTED/config-sign-key/gen-2023: User: arn:aws:sts::REDACTED is not authorized to perform: kms:GetPublicKey on this resource because the resource does not exist in this Region, no resource-based policies allow access, or a resource-based policy explicitly denies access
```

After this change, the build successfully retrieved the needed credentials and completed secureboot signing.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
