### PR TITLE
rpm2img: use latest rpm release for inventory

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -196,7 +196,19 @@ if [[ -n "${CORE_KIT_VERSION}" && -n "${CORE_KIT_VENDOR}" ]]; then
   CORE_KIT_GIT_SHA="$(dnf --repofrompath \
     core-kit,file://"${CORE_KIT_PATH}" \
     --repo=core-kit repoquery \
-    --queryformat '%{Release}' 2>/dev/null | awk '/^1/{print $1}' | cut -d '.' -f 3)"
+    --queryformat '%{Buildtime} %{Release}' 2>/dev/null | \
+    sort -k 1,2 | \
+    awk -F '.' 'END {print $--NF}')"
+  if [[ -z "${CORE_KIT_GIT_SHA}" ]]; then
+    echo "Could not find Git sha for bottlerocket-core-kit" >&2
+    exit 1
+  fi
+  # If the Git sha contains whitespace, we may have accidentally grabbed multiple
+  if [[ "${CORE_KIT_GIT_SHA}" =~ [[:space:]] ]]; then
+    echo "Extracted invalid Git sha from bottlerocket-core-kit: '${CORE_KIT_GIT_SHA}'" >&2
+    exit 1
+  fi
+
   # Query the bottlerocket-core-kit repo of RPMs for all package names.
   CORE_KIT_INVENTORY_QUERY="%{NAME}"
   # shellcheck disable=SC2312 # Array is validated elsewhere.


### PR DESCRIPTION
**Description of changes:**
In cases where Kits contained RPMs built from multiple git checkouts, the `Release` field in the inventory could be malformed.

This always selects the most-recent release present for the inventory.


**Testing done:**
* [x] test using multiple COMMIT_SHAs present
*Before:*
```
  "Content": [
    {
      "Name": "acpid",
      "Publisher": "Bottlerocket",
      "Version": "2.3.0",
      "Release": "2c1d0136\n27f37680\nbr1",
      "InstalledTime": "2024-08-02T19:22:04Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://sourceforge.net/projects/acpid2/",
      "Summary": "ACPI event daemon"
    },
    {
      "Name": "apiclient",
      "Publisher": "Bottlerocket",
      "Version": "2.3.0",
      "Release": "2c1d0136\n27f37680\nbr1",
      "InstalledTime": "2024-08-02T19:22:04Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket API client"
    },
```
*After:*
```
  "Content": [
    {
      "Name": "acpid",
      "Publisher": "Bottlerocket",
      "Version": "2.3.0",
      "Release": "2c1d0136",
      "InstalledTime": "2024-08-02T19:29:12Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://sourceforge.net/projects/acpid2/",
      "Summary": "ACPI event daemon"
    },
    {
      "Name": "apiclient",
      "Publisher": "Bottlerocket",
      "Version": "2.3.0",
      "Release": "2c1d0136",
      "InstalledTime": "2024-08-02T19:29:12Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket API client"
    },
```

* [x] test a situation in which the GIT_SHA is empty
I actually couldn't create a package with no BUILD_ID. RPM rejected it.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
