### PR TITLE
buildsys: add CI/CD hack, fix mtime for external files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ dependencies = [
  "buildsys-config",
  "clap",
  "duct",
+ "filetime",
  "guppy",
  "hex",
  "lazy_static",

--- a/tools/buildsys/Cargo.toml
+++ b/tools/buildsys/Cargo.toml
@@ -13,6 +13,7 @@ bottlerocket-variant.workspace = true
 buildsys-config.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 duct.workspace = true
+filetime.workspace = true
 guppy.workspace = true
 hex.workspace = true
 lazy_static.workspace = true

--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -92,6 +92,14 @@ pub(crate) struct Common {
 
     #[arg(long, env = "TWOLITER_TOOLS_DIR")]
     pub(crate) tools_dir: PathBuf,
+
+    /// cicd_hack is used to suppress builds from running after all the cargo-related metadata is
+    /// emitted. This allows cargo to create a fresh crate, and assumes that the corresponding
+    /// build artifacts are already present. It is intended for use in a CI/CD scenario where some
+    /// other process populates the build directory from a cache. Other uses may lead to unexpected
+    /// build failures that are difficult to troubleshoot.
+    #[arg(long, env = "BUILDSYS_CICD_HACK")]
+    pub(crate) cicd_hack: bool,
 }
 
 /// Build RPMs from a spec file and sources.

--- a/tools/buildsys/src/cache/error.rs
+++ b/tools/buildsys/src/cache/error.rs
@@ -45,6 +45,9 @@ pub(crate) enum Error {
     #[snafu(display("Failed to delete file '{}': {}", path.display(), source))]
     ExternalFileDelete { path: PathBuf, source: io::Error },
 
+    #[snafu(display("Failed to set modification time for file '{}': {}", path.display(), source))]
+    SetMtime { path: PathBuf, source: io::Error },
+
     #[snafu(display("Failed to get path segments from URL '{}'", url))]
     UrlPathSegments { url: String },
 }

--- a/tools/buildsys/src/gomod/error.rs
+++ b/tools/buildsys/src/gomod/error.rs
@@ -41,6 +41,12 @@ pub(crate) enum Error {
         source: std::io::Error,
     },
 
+    #[snafu(display("Failed to set modification time for file '{}': {}", path.display(), source))]
+    SetMtime {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
     #[snafu(display("Failed to write contents to '{}': {}", path.display(), source))]
     WriteFile {
         path: PathBuf,

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -190,6 +190,10 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
         println!("cargo:rerun-if-changed={}", f.display());
     }
 
+    if args.common.cicd_hack {
+        return Ok(());
+    }
+
     DockerBuild::new_package(args, &manifest)
         .context(error::BuilderInstantiationSnafu)?
         .build()
@@ -209,6 +213,10 @@ fn build_kit(args: BuildKitArgs) -> Result<()> {
         &args.common.cargo_metadata_path,
     )
     .context(error::ManifestParseSnafu)?;
+
+    if args.common.cicd_hack {
+        return Ok(());
+    }
 
     DockerBuild::new_kit(args, &manifest)
         .context(error::BuilderInstantiationSnafu)?
@@ -232,6 +240,10 @@ fn build_variant(args: BuildVariantArgs) -> Result<()> {
 
     supported_arch(manifest.info(), args.common.arch)?;
 
+    if args.common.cicd_hack {
+        return Ok(());
+    }
+
     DockerBuild::new_variant(args, &manifest)
         .context(error::BuilderInstantiationSnafu)?
         .build()
@@ -248,6 +260,10 @@ fn repack_variant(args: RepackVariantArgs) -> Result<()> {
     .context(error::ManifestParseSnafu)?;
 
     supported_arch(manifest.info(), args.common.arch)?;
+
+    if args.common.cicd_hack {
+        return Ok(());
+    }
 
     DockerBuild::repack_variant(args, &manifest)
         .context(error::BuilderInstantiationSnafu)?

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -23,6 +23,7 @@ use buildsys::manifest::{BundleModule, Manifest, ManifestInfo, SupportedArch};
 use buildsys_config::EXTERNAL_KIT_METADATA;
 use cache::LookasideCache;
 use clap::Parser;
+use filetime::FileTime;
 use gomod::GoMod;
 use project::ProjectInfo;
 use snafu::{ensure, ResultExt};
@@ -46,6 +47,12 @@ mod error {
 
         #[snafu(display("{source}"))]
         ExternalFileFetch { source: super::cache::error::Error },
+
+        #[snafu(display("Failed to get metadata for '{}': {}", path.display(), source))]
+        FileMetadata {
+            path: PathBuf,
+            source: std::io::Error,
+        },
 
         #[snafu(display("{source}"))]
         GoMod { source: super::gomod::error::Error },
@@ -136,14 +143,24 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
     ensure_package_is_not_variant_sensitive(&manifest, &manifest_path)?;
 
     if let Some(files) = manifest.info().external_files() {
+        // We need the modification time for any external files or bundled modules to be no later
+        // than the manifest's modification time, to avoid triggering spurious rebuilds.
+        let metadata =
+            std::fs::metadata(manifest_path.clone()).context(error::FileMetadataSnafu {
+                path: manifest_path,
+            })?;
+        let mtime = FileTime::from_last_modification_time(&metadata);
+
         let lookaside_cache = LookasideCache::new(
             &args.common.version_full,
             args.lookaside_cache.clone(),
             args.upstream_source_fallback == "true",
         );
+
         lookaside_cache
-            .fetch(files)
+            .fetch(files, mtime)
             .context(error::ExternalFileFetchSnafu)?;
+
         for f in files {
             if f.bundle_modules.is_none() {
                 continue;
@@ -156,6 +173,7 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
                         &args.common.cargo_manifest_dir,
                         f,
                         &args.common.sdk_image,
+                        mtime,
                     )
                     .context(error::GoModSnafu)?,
                 }


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Two `buildsys` changes, one potentially controversial, one hopefully not.

The first is the `BUILDSYS_CICD_HACK` variable - naming suggestions wanted! - to allow `cargo` to recreate crates without actually running expensive package builds. It's a hack because it assumes the `build` directory is fully populated; if it's not, then bad things will happen the next time a package is rebuilt.

The second fixes an edge case related to external files or bundled Go modules; these can end up being tracked by `cargo` for changes, so we need to ensure that their modification time is no later than the start of the build. `Cargo.toml` is already tracked for changes and is a useful sentinel for this purpose.

**Testing done:**
Tested in https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/67. With both changes, I was able to reuse cached package builds, touch the files modified by a pull request, and observe that only the affected packages were rebuilt.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
