### PR TITLE
deny: add workspace dependency lints

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -90,6 +90,11 @@ skip-tree = [
     { name = "windows-sys" },
 ]
 
+[bans.workspace-dependencies]    
+duplicates = "deny"                                                                                                                                                                                                                                   
+include-path-dependencies = true    
+unused = "deny"
+
 [sources]
 allow-git = [
     "https://github.com/bottlerocket-os/bottlerocket-test-system",


### PR DESCRIPTION
**Description of changes:**
This adds [workspace dependency checks](https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-workspace-dependencies-field-optional) with `cargo-deny`.

The options enforce the following:
* `duplicates = deny`: emit an error for each dependency declaration that does not use `workspace = true`
* `include-path-dependencies = true`: Include path dependencies in duplication check
* `unused = "deny"`: emit an error for each dependency not used in the workspace

**Testing done:**
I rewrote twoliter's `Cargo.toml` under sources to express its own dependency on `serde-json`, and noted that `make deny` flagged this as an error.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
