### PR TITLE
workflow: fix MATRIX_INSTALL_DIST variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install cargo-dist
-        run: "${MATRIX_INSTALL_DIST}"
+        run: ${MATRIX_INSTALL_DIST}
       - name: Install Cross
         # Pin cargo cross to a version that we know is working for us.
         run: |


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Removes extra `"` from the MATRIX_INSTALL_DIST variable which was failing the [release](https://github.com/bottlerocket-os/twoliter/actions/runs/10821364662/job/30023296625).

```
error: invalid url `"https://github.com/webern/cargo-dist"`: relative URL without a base
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
