### PR TITLE
buildsys: drop variant arg for variant subcommands

### DIFF
--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -162,9 +162,6 @@ pub(crate) struct BuildVariantArgs {
     #[arg(long, env = "BUILDSYS_PRETTY_NAME")]
     pub(crate) pretty_name: String,
 
-    #[arg(long, env = "CARGO_MANIFEST_DIR")]
-    pub(crate) variant: PathBuf,
-
     #[arg(long, env = "BUILDSYS_VERSION_BUILD")]
     pub(crate) version_build: String,
 
@@ -183,9 +180,6 @@ pub(crate) struct BuildVariantArgs {
 pub(crate) struct RepackVariantArgs {
     #[arg(long, env = "BUILDSYS_NAME")]
     pub(crate) name: String,
-
-    #[arg(long, env = "CARGO_MANIFEST_DIR")]
-    pub(crate) variant: PathBuf,
 
     #[arg(long, env = "BUILDSYS_VERSION_BUILD")]
     pub(crate) version_build: String,

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -420,7 +420,7 @@ impl DockerBuild {
         let (os_image_publish_size_gib, data_image_publish_size_gib) =
             image_layout.publish_image_sizes_gib();
 
-        let variant = filename(args.variant);
+        let variant = filename(args.common.cargo_manifest_dir);
 
         let v = Variant::new(&variant).context(error::VariantParseSnafu)?;
         let variant_platform = v.platform().into();
@@ -509,7 +509,7 @@ impl DockerBuild {
         let (os_image_publish_size_gib, data_image_publish_size_gib) =
             image_layout.publish_image_sizes_gib();
 
-        let variant = filename(args.variant);
+        let variant = filename(args.common.cargo_manifest_dir);
 
         Ok(Self {
             dockerfile: args.common.tools_dir.join("build.Dockerfile"),


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Fixes the `repack-variant` task by using the common `cargo_manifest_dir` arg instead of the redundant `variant` arg.


**Testing done:**
Confirmed that `build-variant`, `repack-variant`, and `build-all` tasks worked.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
