### PR TITLE
twoliter: improve logging on lockfile mismatch

### DIFF
--- a/twoliter/src/project/mod.rs
+++ b/twoliter/src/project/mod.rs
@@ -313,11 +313,19 @@ impl Display for ProjectImage {
         match self.vendor {
             ArtifactVendor::Overridden(_) => write!(
                 f,
-                "{} (overridden-to: {})",
-                self.image,
-                self.project_image_uri()
+                "{}-{}@{} (overridden-to: {})",
+                self.name(),
+                self.version(),
+                self.original_source_uri(),
+                self.project_image_uri(),
             ),
-            ArtifactVendor::Verbatim(_) => write!(f, "{}", self.image),
+            ArtifactVendor::Verbatim(_) => write!(
+                f,
+                "{}-{}@{}",
+                self.name(),
+                self.version(),
+                self.original_source_uri()
+            ),
         }
     }
 }


### PR DESCRIPTION
This also improves clarity on image resolution for overridden images.

**Testing done:**
Created situations in which the lockfile would mismatch and saw that both images were displayed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
