### PR TITLE
publish-kit: allow overridding image repository

### DIFF
--- a/tools/pubsys/src/kit/publish_kit/mod.rs
+++ b/tools/pubsys/src/kit/publish_kit/mod.rs
@@ -17,6 +17,10 @@ pub(crate) struct PublishKitArgs {
     #[arg(long)]
     vendor: String,
 
+    /// Optionally push the kit a different repository name
+    #[arg(long)]
+    repo: Option<String>,
+
     /// The version of the kit that should be published
     #[arg(long)]
     version: String,
@@ -66,6 +70,11 @@ async fn publish_kit(
     let kit_version = publish_kit_args.version.clone();
     let build_id = publish_kit_args.build_id.clone();
 
+    let repository_target = match publish_kit_args.repo.as_ref() {
+        Some(repo) => repo.clone(),
+        None => kit_name.to_string(),
+    };
+
     let mut platform_images = Vec::new();
     for arch in ["aarch64", "x86_64"] {
         let docker_arch =
@@ -81,7 +90,7 @@ async fn publish_kit(
 
         let arch_specific_target_uri = format!(
             "{}/{}:{}-{}-{}",
-            vendor_registry_uri, kit_name, &kit_version, &build_id, arch
+            vendor_registry_uri, repository_target, &kit_version, &build_id, arch
         );
 
         info!(

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1541,6 +1541,7 @@ pubsys \
    publish-kit \
    --kit-path "${BUILDSYS_BUILD_DIR}/kits/${BUILDSYS_KIT}" \
    --vendor "${PUBLISH_VENDOR}" \
+   --repo "${PUBLISH_KIT_REPO}" \
    --version "v${BUILDSYS_VERSION_IMAGE}" \
    --build-id "${BUILDSYS_VERSION_BUILD}"
 '''

--- a/twoliter/src/cmd/publish_kit.rs
+++ b/twoliter/src/cmd/publish_kit.rs
@@ -31,6 +31,9 @@ pub(crate) struct PublishKit {
 
     /// Vendor to publish to
     vendor: String,
+
+    /// Publish kit image to a different repository than the kit's name
+    kit_repo: Option<String>,
 }
 
 impl PublishKit {
@@ -41,11 +44,16 @@ impl PublishKit {
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");
 
+        let publish_kit_repo = match &self.kit_repo {
+            Some(kit_repo) => kit_repo,
+            None => &self.kit_name,
+        };
         CargoMake::new(project.sdk_image().project_image_uri().to_string().as_str())?
             .env("TWOLITER_TOOLS_DIR", toolsdir.display().to_string())
             .env("BUILDSYS_KIT", &self.kit_name)
             .env("BUILDSYS_VERSION_IMAGE", project.release_version())
             .env("PUBLISH_VENDOR", &self.vendor)
+            .env("PUBLISH_KIT_REPO", publish_kit_repo)
             .makefile(makefile_path)
             .project_dir(project.project_dir())
             .exec("publish-kit")


### PR DESCRIPTION
**Description of changes:**
This allows pushing new kits to a staging repository before copying the artifacts to a final destination.


**Testing done:**
* built bottlerocket-core-kit
* ran `PUBLISH_REPO=cbgbt-test make publish` after some modifications to the `Makefile` to take advantage of this change
* 19:34:46 [INFO] Pushing kit image for platform aarch64 to public.ecr.aws/REDACTED/cbgbt-test:v2.5.0-cc1ca341-dirty-aarch64

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
