### PR TITLE
ci: merge erroneous if statements in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,12 @@ jobs:
 
   # Build and packages all the things
   upload-artifacts:
-    if: github.repository == 'bottlerocket-os/twoliter'
     # Let the initial task tell us to not run (currently very blunt)
     needs: create-release
-    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    if: >-
+      ${{ needs.create-release.outputs.has-releases == 'true'
+          && github.repository == 'bottlerocket-os/twoliter'
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -151,10 +153,15 @@ jobs:
 
   # Mark the Github Release™ as a non-draft now that everything has succeeded!
   publish-release:
-    if: github.repository == 'bottlerocket-os/twoliter'
     # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
     needs: [create-release, upload-artifacts]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-artifacts.result == 'skipped' || needs.upload-artifacts.result == 'success') }}
+    if: >-
+      ${{ github.repository == 'bottlerocket-os/twoliter'
+          && always()
+          && needs.create-release.result == 'success'
+          && (needs.upload-artifacts.result == 'skipped'
+            || needs.upload-artifacts.result == 'success')
+      }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description of changes:**
Our release action is failing: https://github.com/bottlerocket-os/twoliter/actions/runs/10892134510

This is due to my change in #373, which added a duplicate `if` key to one of the release workflow
s yaml blocks.


**Testing done:**
I loaded the actions workflow with a yaml parser, and noted that it now succeeds:

```
release['jobs']['upload-artifacts']['if']
"${{ needs.create-release.outputs.has-releases == 'true'\n    && github.repository == 'bottlerocket-os/twoliter'\n}}\n"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
