### PR TITLE
makefile: remove dependencies from build-variant task

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -857,7 +857,7 @@ cargo build \
 ]
 
 [tasks.build-variant]
-dependencies = ["fetch", "build-sbkeys", "publish-setup", "validate-kits"]
+dependencies = ["fetch-sdk", "build-sbkeys", "publish-setup", "validate-kits"]
 script = [
 '''
 export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Due to the changes in build requirements created by the switch to building from kits, only the sdk and the kits should now be required to build a botlerocket variant


**Testing done:**
Used resulting twoliter binary to build a bottlerocket variant from the bottlerocket repo.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
