### PR TITLE
rpm2img: ensure /usr/share/bottlerocket exists

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -254,6 +254,7 @@ if [[ "${INVENTORY_COUNT}" -ne "${RPM_COUNT}" ]]; then
 fi
 
 # Write the inventory.
+mkdir -p "${ROOT_MOUNT}/usr/share/bottlerocket"
 printf "%s\n" "${INVENTORY_DATA}" >"${ROOT_MOUNT}/usr/share/bottlerocket/application-inventory.json"
 
 # Write the the inventory to a file in the local build output directory so that builders


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/163

**Description of changes:**
Create the `/usr/share/bottlerocket` directory before writing any files to it, just in case a package hasn't already created it.


**Testing done:**
This was annoying to test, given the implicit expectations in `rpm2img` that a kernel package will be installed, but with some local hacks I was able to confirm that a version of `aws-dev` which removed the `kernel-6.1` package dependency failed later in the script:
```
  #18 6.266 + KMOD_DIR=/tmp/tmp.93mm5b2Vug/lib/modules
  #18 6.266 + [[ yes == \y\e\s ]]
  #18 6.266 + find /tmp/tmp.93mm5b2Vug/lib/modules -name '*.ko.gz' -exec gunzip '{}' ';'
  #18 6.269 find: '/tmp/tmp.93mm5b2Vug/lib/modules': No such file or directory
  #18 6.270 + cleanup
```

Said hacks:
```
❯ git diff
diff --git a/twoliter/embedded/rpm2img b/twoliter/embedded/rpm2img
index 855791c..4d4a592 100755
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash

-set -eu -o pipefail
+set -eux -o pipefail
 shopt -qs failglob

 OUTPUT_FMT="raw"
diff --git a/twoliter/embedded/rpm2kmodkit b/twoliter/embedded/rpm2kmodkit
index 079d98c..1626b4b 100755
--- a/twoliter/embedded/rpm2kmodkit
+++ b/twoliter/embedded/rpm2kmodkit
@@ -31,7 +31,7 @@ mkdir -p "${OUTPUT_DIR}" "${KIT_DIR}/${KMOD_KIT}"
 # Extract any RPMs and find the kernel development archive.
 pushd "${EXTRACT_DIR}" >/dev/null
 find "${ARCHIVE_DIR}" -type f -name '*.rpm' \
-  -exec rpm2cpio {} \; | cpio -idm --quiet
+  -exec rpm2cpio {} \; | cpio -idm --quiet ||:
 find -name 'kernel-devel.tar.xz' \
   -exec mv {} "${KIT_DIR}/${KMOD_KIT}" \;
 popd >/dev/null
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
