### PR TITLE
attribution: upload dependency attributions as part of GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,10 +151,31 @@ jobs:
           gh release upload "${GITHUB_REF_NAME}" $(cat uploads.txt)
           echo "uploaded!"
 
+  # Upload dependency attributions
+  upload-attributions:
+    needs: [create-release, upload-artifacts]
+    if: >-
+      ${{ needs.create-release.outputs.has-releases == 'true'
+          && github.repository == 'bottlerocket-os/bottlerocket'
+      }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REF_NAME: ${{ github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Upload attributions
+        run: |
+          make attributions
+          gh release upload "${GITHUB_REF_NAME}" twoliter-attributions.tar.gz
+
   # Mark the Github Release™ as a non-draft now that everything has succeeded!
   publish-release:
     # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-artifacts]
+    needs: [create-release, upload-artifacts, upload-attributions]
     if: >-
       ${{ github.repository == 'bottlerocket-os/twoliter'
           && always()

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 .ignore/
+twoliter-attributions.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,32 @@
-.PHONY: design
+TOP := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
+BOTTLEROCKET_SDK_VERSION ?= v0.45.0
+BOTTLEROCKET_SDK_IMAGE ?= public.ecr.aws/bottlerocket/bottlerocket-sdk:$(BOTTLEROCKET_SDK_VERSION)
+
+.PHONY: design
 design: ## render design diagrams
 	./docs/design/bin/render-plantuml.sh \
 		./docs/design/diagrams/build-sequence.plantuml \
 		./docs/design/diagrams/build-sequence.svg
+
+.PHONY: attributions
+attributions:
+	docker build \
+		--build-arg BOTTLEROCKET_SDK_IMAGE=$(BOTTLEROCKET_SDK_IMAGE) \
+		--build-arg UID=$(shell id -u) \
+		--build-arg GID=$(shell id -g) \
+		--tag twoliter-attributions-image:latest \
+		-f "$(TOP)/tools/attribution/Dockerfile.attribution" \
+		.
+	docker run --rm \
+		--volume "$(TOP):/src" \
+		--user "$(shell id -u):$(shell id -g)" \
+		--security-opt label=disable \
+		--workdir "/src" \
+		twoliter-attributions-image:latest \
+		bash -c "/src/tools/attribution/attribution.sh"
+
+	docker rmi twoliter-attributions-image:latest
 
 .PHONY: deny
 deny:
@@ -26,7 +49,7 @@ integ:
 	cargo test --manifest-path tests/integration-tests/Cargo.toml -- --include-ignored
 
 .PHONY: check
-check: fmt clippy deny test integ
+check: fmt clippy deny attributions test integ
 
 .PHONY: build
 build: check

--- a/clarify.toml
+++ b/clarify.toml
@@ -1,0 +1,44 @@
+[clarify.bstr]
+version = "=1"
+expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+license-files = [
+    { path = "COPYING", hash = 0x278afbcf },
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0x462dee44 },
+    { path = "src/unicode/data/LICENSE-UNICODE", hash = 0x70f7339 },
+]
+
+[clarify.petgraph]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0xc97e30bd },
+]
+skip-files = [
+    # this license applies to graphical assets which we do not distribute
+    "assets/LICENSE.md",
+]
+
+[clarify.regex-syntax]
+expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x24b54f4b },
+    { path = "LICENSE-MIT", hash = 0xb755395b },
+    { path = "src/unicode_tables/LICENSE-UNICODE", hash = 0xa7f28b93 },
+]
+
+[clarify.typenum]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0x91d5a0a7 },
+    { path = "LICENSE-MIT", hash = 0xb9f15462 },
+    { path = "LICENSE", hash = 0xa4618a29 },
+]
+
+[clarify.unicode-ident]
+expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0xb5518783 },
+    { path = "LICENSE-MIT", hash = 0x386ca1bc },
+    { path = "LICENSE-UNICODE", hash = 0x9698cbbe },
+]

--- a/tools/attribution/Dockerfile.attribution
+++ b/tools/attribution/Dockerfile.attribution
@@ -1,0 +1,19 @@
+# This dockerfile installs rustup into the Bottlerocket SDK so that attributions can be generated
+# using the same nightly compiler as is used to build twoliter.
+ARG BOTTLEROCKET_SDK_IMAGE
+FROM ${BOTTLEROCKET_SDK_IMAGE}
+
+# Rustup is installed using the given user, allowing the container to write the results to a
+# mounted filesystem to which the given user has write access.
+ARG UID
+ARG GID
+
+USER root
+
+RUN mkdir /home/attribution-creator \
+    && chown ${UID}:${GID} /home/attribution-creator
+
+USER ${UID}:${GID}
+RUN export HOME=/home/attribution-creator \
+    && curl --proto '=https' --tlsv1.2 -sS 'https://sh.rustup.rs' \
+    | sh -s -- -q --default-toolchain none -y

--- a/tools/attribution/attribution.sh
+++ b/tools/attribution/attribution.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Generates attributions for dependencies of Twoliter
+# Meant to be run from Bottlerocket's SDK container:
+# https://github.com/bottlerocket-os/bottlerocket-sdk
+
+# See the "attribution" target in the project Makefile.
+
+set -eo pipefail
+
+LICENSEDIR=/tmp/twoliter-attributions
+
+# Use the toolchain installed via `Dockerfile.attribution`
+export HOME="/home/attribution-creator"
+source ~/.cargo/env
+
+# Source code is mounted to /src
+# rustup will automatically use the toolchain in rust-toolchain.toml
+cd /src
+
+# =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=
+echo "Clarifying crate dependency licenses..."
+/usr/libexec/tools/bottlerocket-license-scan \
+    --clarify /src/clarify.toml \
+    --spdx-data /usr/libexec/tools/spdx-data \
+    --out-dir ${LICENSEDIR}/vendor \
+    cargo --locked Cargo.toml
+
+# =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=
+# cargo-make (we currently use cargo-make from the SDK, but will ship it in Twoliter in the future)
+echo "Clarifying bottlerocket-sdk & dependency licenses..."
+mkdir -p ${LICENSEDIR}/bottlerocket-sdk/
+cp -r /usr/share/licenses/cargo-make \
+    ${LICENSEDIR}/bottlerocket-sdk/
+
+# =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=  =^.^=
+# Twoliter licenses
+cp /src/COPYRIGHT /src/LICENSE-MIT /src/LICENSE-APACHE \
+    ${LICENSEDIR}/
+
+pushd $(dirname ${LICENSEDIR})
+tar czf /src/twoliter-attributions.tar.gz $(basename ${LICENSEDIR})
+popd


### PR DESCRIPTION
**Description of changes:**
This change:
* Uses the `license-scan` tool in the Bottlerocket SDK to generate attributions for 3rd party dependencies.
* Modifies the release workflow to upload these attributions during the release process.


**Testing done:**
* Ran the GH actions in my account [here](https://github.com/cbgbt/twoliter/actions/runs/11075272834)
* Here's the [created release](https://github.com/cbgbt/twoliter/releases), with the attributions tarball attached.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
