### PR TITLE
twoliter: drop PATH override for debuginfo

### DIFF
--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -104,9 +104,6 @@ RUN --mount=target=/host \
       -exec cp {} ./rpmbuild/SOURCES/ \; && \
     rm /bypass
 
-# Ensure that the target binutils that `find-debuginfo.sh` uses are present in $PATH.
-ENV PATH="/usr/${ARCH}-bottlerocket-linux-gnu/debuginfo/bin:${PATH}"
-
 USER builder
 RUN --mount=source=.cargo,target=/home/builder/.cargo \
     --mount=type=cache,target=/home/builder/.cache,from=cache,source=/cache \


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/210

**Description of changes:**
`find-debuginfo` overrides $PATH to prefer its own directory, so this wasn't working as expected.

Drop this workaround to avoid conflating host and target tools, which can mask build logic errors in package specs.


**Testing done:**
Built the core kit on both host architectures, for both target architectures, after taking the SDK change. No `objcopy` failures were logged.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
