### PR TITLE
rpm2img: use package version, release, and epoch

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -170,6 +170,7 @@ INVENTORY_QUERY="\{\"Name\":\"%{NAME}\"\
 ,\"Publisher\":\"Bottlerocket\"\
 ,\"Version\":\"%{Version}\"\
 ,\"Release\":\"%{Release}\"\
+,\"Epoch\":\"%|Epoch?{%{EPOCH}}:{0}|\"\
 ,\"InstalledTime\":\"${INSTALL_TIME}\"\
 ,\"ApplicationType\":\"%{GROUP}\"\
 ,\"Architecture\":\"%{ARCH}\"\
@@ -237,11 +238,7 @@ if [[ -n "${CORE_KIT_VERSION}" && -n "${CORE_KIT_VENDOR}" ]]; then
   # the version with the core kit's version, and replace the name with the unprefixed name.
   INVENTORY_DATA="$(jq \
     --argfile replace core-kit-replacements.json \
-    --arg CORE_KIT_VERSION "${CORE_KIT_VERSION}" \
-    --arg CORE_KIT_GIT_SHA "${CORE_KIT_GIT_SHA}" \
-    '(.Content[] | select(.Name | $replace[.] != null) | .Version) = $CORE_KIT_VERSION |
-     (.Content[] | select(.Name | $replace[.] != null) | .Release) = $CORE_KIT_GIT_SHA |
-     .Content[].Name |= (if $replace[.] then $replace[.] else . end)' \
+     '.Content[].Name |= (if $replace[.] then $replace[.] else . end)' \
     <<<"${INVENTORY_DATA}")"
 fi
 


### PR DESCRIPTION
When building application inventory, use a package's actual version and use the <timestamp>.<commit>.br1 for all packages, not just first party packages. Additionally, expose a package's Epoch - set to 0 if "(none)".

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #364 

**Description of changes:**

When building application inventory, use a package's actual version
and use the `<timestamp>.<commit>.br1` for all packages, not just
first party packages. Additionally, expose a package's Epoch -
set to 0 if "(none)".

⚠️ **This change is dependent on changes to https://github.com/bottlerocket-os/bottlerocket-core-kit to add an `Epoch: 1` to all package spec defns for which the package version is < any core kit release versions.**


**Testing done:**

1. `make test`

2. Build a Bottlerocket k8s-1.29 variant with these changes; in the local Bottlerocket repo, I modified the first party packages to have an `Epoch: 1` to ensure this is passed properly.

```
cargo make \                                                                                                                                                                                               
          -e BUILDSYS_ARCH=aarch64 \
          -e=TWOLITER_REPO=https://github.com/ginglis13/twoliter \
          -e=TWOLITER_VERSION=d1f98f6dd873144be9a6d076662fd3de4a943e29 \
          -e=TWOLITER_ALLOW_SOURCE_INSTALL=true \
          -e=TWOLITER_ALLOW_BINARY_INSTALL=false \
          -e=TWOLITER_SKIP_VERSION_CHECK=true \
          -e BUILDSYS_VARIANT=aws-k8s-1.29
```

results in an application inventory file below:
<details>

```
{
  "Content": [
    {
      "Name": "acpid",
      "Publisher": "Bottlerocket",
      "Version": "2.0.34",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://sourceforge.net/projects/acpid2/",
      "Summary": "ACPI event daemon"
    },
    {
      "Name": "apiclient",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket API client"
    },
    {
      "Name": "apiserver",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket API server"
    },
    {
      "Name": "audit",
      "Publisher": "Bottlerocket",
      "Version": "3.1.4",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/linux-audit/audit-userspace/",
      "Summary": "Tools for the audit subsystem"
    },
    {
      "Name": "aws-iam-authenticator",
      "Publisher": "Bottlerocket",
      "Version": "0.6.26",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/kubernetes-sigs/aws-iam-authenticator",
      "Summary": "AWS IAM authenticator"
    },
    {
      "Name": "aws-iam-authenticator-bin",
      "Publisher": "Bottlerocket",
      "Version": "0.6.26",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/kubernetes-sigs/aws-iam-authenticator",
      "Summary": "AWS IAM authenticator binaries"
    },
    {
      "Name": "aws-signing-helper",
      "Publisher": "Bottlerocket",
      "Version": "1.2.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/aws/rolesanywhere-credential-helper",
      "Summary": "AWS signing helper for IAM Roles Anywhere support"
    },
    {
      "Name": "aws-signing-helper-bin",
      "Publisher": "Bottlerocket",
      "Version": "1.2.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/aws/rolesanywhere-credential-helper",
      "Summary": "AWS signing helper binaries"
    },
    {
      "Name": "bloodhound",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Compliance check framework"
    },
    {
      "Name": "bloodhound-k8s",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Compliance checks for Kubernetes"
    },
    {
      "Name": "bootstrap-commands",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Manages bootstrap-commands"
    },
    {
      "Name": "bootstrap-containers",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Manages bootstrap-containers"
    },
    {
      "Name": "bork",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Dynamic setting generator for updog"
    },
    {
      "Name": "certdog",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket certificates handler"
    },
    {
      "Name": "cfsignal",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket CloudFormation Stack signaler"
    },
    {
      "Name": "chrony",
      "Publisher": "Bottlerocket",
      "Version": "4.5",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://chrony.tuxfamily.org",
      "Summary": "A versatile implementation of the Network Time Protocol"
    },
    {
      "Name": "cni",
      "Publisher": "Bottlerocket",
      "Version": "1.2.3",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/containernetworking/cni",
      "Summary": "Plugins for container networking"
    },
    {
      "Name": "cni-plugins",
      "Publisher": "Bottlerocket",
      "Version": "1.5.1",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/containernetworking/plugins",
      "Summary": "Plugins for container networking"
    },
    {
      "Name": "cni-plugins-bin",
      "Publisher": "Bottlerocket",
      "Version": "1.5.1",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/containernetworking/plugins",
      "Summary": "Plugins for container networking binaries"
    },
    {
      "Name": "conntrack-tools",
      "Publisher": "Bottlerocket",
      "Version": "1.4.8",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://conntrack-tools.netfilter.org/",
      "Summary": "Tools for managing Linux kernel connection tracking"
    },
    {
      "Name": "containerd",
      "Publisher": "Bottlerocket",
      "Version": "1.7.22",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/containerd/containerd",
      "Summary": "An industry-standard container runtime"
    },
    {
      "Name": "containerd-bin",
      "Publisher": "Bottlerocket",
      "Version": "1.7.22",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/containerd/containerd",
      "Summary": "An industry-standard container runtime's binaries"
    },
    {
      "Name": "coreutils",
      "Publisher": "Bottlerocket",
      "Version": "9.5",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.gnu.org/software/coreutils/",
      "Summary": "A set of basic GNU tools"
    },
    {
      "Name": "corndog",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket sysctl helper"
    },
    {
      "Name": "dbus-broker",
      "Publisher": "Bottlerocket",
      "Version": "36",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bus1/dbus-broker",
      "Summary": "D-BUS message broker"
    },
    {
      "Name": "e2fsprogs",
      "Publisher": "Bottlerocket",
      "Version": "1.47.1",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://e2fsprogs.sourceforge.net/",
      "Summary": "Tools for managing ext2, ext3, and ext4 file systems"
    },
    {
      "Name": "e2fsprogs-libs",
      "Publisher": "Bottlerocket",
      "Version": "1.47.1",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://e2fsprogs.sourceforge.net/",
      "Summary": "Libraries for ext2, ext3, and ext4 file systems"
    },
    {
      "Name": "early-boot-config",
      "Publisher": "Bottlerocket",
      "Version": "0.1",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "early-boot-config"
    },
    {
      "Name": "early-boot-config-aws",
      "Publisher": "Bottlerocket",
      "Version": "0.1",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "early-boot-config package for AWS"
    },
    {
      "Name": "early-boot-config-local",
      "Publisher": "Bottlerocket",
      "Version": "0.1",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "local-provider"
    },
    {
      "Name": "ecr-credential-provider-1.29",
      "Publisher": "Bottlerocket",
      "Version": "1.29.6",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/kubernetes/cloud-provider-aws",
      "Summary": "Amazon ECR credential provider"
    },
    {
      "Name": "ecr-credential-provider-1.29-bin",
      "Publisher": "Bottlerocket",
      "Version": "1.29.6",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/kubernetes/cloud-provider-aws",
      "Summary": "Amazon ECR credential provider binaries"
    },
    {
      "Name": "ethtool",
      "Publisher": "Bottlerocket",
      "Version": "6.10",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.kernel.org/pub/software/network/ethtool/",
      "Summary": "Settings tool for Ethernet NICs"
    },
    {
      "Name": "filesystem",
      "Publisher": "Bottlerocket",
      "Version": "1.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "The basic directory layout"
    },
    {
      "Name": "findutils",
      "Publisher": "Bottlerocket",
      "Version": "4.10.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://www.gnu.org/software/findutils/",
      "Summary": "A set of GNU tools for finding"
    },
    {
      "Name": "ghostdog",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Tool to manage ephemeral disks"
    },
    {
      "Name": "glibc",
      "Publisher": "Bottlerocket",
      "Version": "2.38",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://www.gnu.org/software/glibc/",
      "Summary": "The GNU libc libraries"
    },
    {
      "Name": "grep",
      "Publisher": "Bottlerocket",
      "Version": "3.11",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.gnu.org/software/grep/",
      "Summary": "GNU grep utility"
    },
    {
      "Name": "grub",
      "Publisher": "Bottlerocket",
      "Version": "2.06",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.gnu.org/software/grub/",
      "Summary": "Bootloader with support for Linux and more"
    },
    {
      "Name": "host-containers",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Manages system- and user-defined host containers"
    },
    {
      "Name": "host-ctr",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket host container runner"
    },
    {
      "Name": "host-ctr-bin",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket host container runner binaries"
    },
    {
      "Name": "hostname-imds",
      "Publisher": "Bottlerocket",
      "Version": "0.1.1",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "IMDS Hostname detector"
    },
    {
      "Name": "hostname-reverse-dns",
      "Publisher": "Bottlerocket",
      "Version": "0.1.1",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Reverse DNS Hostname detector"
    },
    {
      "Name": "iproute",
      "Publisher": "Bottlerocket",
      "Version": "6.4.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://kernel.org/pub/linux/utils/net/iproute2/",
      "Summary": "Tools for advanced IP routing and network device configuration"
    },
    {
      "Name": "iptables",
      "Publisher": "Bottlerocket",
      "Version": "1.8.10",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://www.netfilter.org/",
      "Summary": "Tools for managing Linux kernel packet filtering capabilities"
    },
    {
      "Name": "kernel-6.1",
      "Publisher": "Bottlerocket",
      "Version": "6.1.109",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.kernel.org/",
      "Summary": "The Linux kernel"
    },
    {
      "Name": "kernel-6.1-bootconfig-aws",
      "Publisher": "Bottlerocket",
      "Version": "6.1.109",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.kernel.org/",
      "Summary": "Boot config snippet for the Linux kernel on AWS"
    },
    {
      "Name": "kernel-6.1-devel",
      "Publisher": "Bottlerocket",
      "Version": "6.1.109",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.kernel.org/",
      "Summary": "Configured Linux kernel source for module building"
    },
    {
      "Name": "kernel-6.1-devel-squashed",
      "Publisher": "Bottlerocket",
      "Version": "6.1.109",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.kernel.org/",
      "Summary": "Configured Linux kernel source for module building (squashed)"
    },
    {
      "Name": "kernel-6.1-modules",
      "Publisher": "Bottlerocket",
      "Version": "6.1.109",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.kernel.org/",
      "Summary": "Modules for the Linux kernel"
    },
    {
      "Name": "kexec-tools",
      "Publisher": "Bottlerocket",
      "Version": "2.0.29",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.kernel.org/doc/html/latest/admin-guide/kdump/kdump.html",
      "Summary": "Linux tool to load kernels from the running system"
    },
    {
      "Name": "keyutils",
      "Publisher": "Bottlerocket",
      "Version": "1.6.1",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://people.redhat.com/~dhowells/keyutils/",
      "Summary": "Linux key management utilities"
    },
    {
      "Name": "kmod",
      "Publisher": "Bottlerocket",
      "Version": "31",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://git.kernel.org/?p=utils/kernel/kmod/kmod.git;a=summary",
      "Summary": "Tools for kernel module loading and unloading"
    },
    {
      "Name": "kubelet-1.29",
      "Publisher": "Bottlerocket",
      "Version": "1.29.5",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/kubernetes/kubernetes",
      "Summary": "Container cluster node agent"
    },
    {
      "Name": "kubelet-1.29-bin",
      "Publisher": "Bottlerocket",
      "Version": "1.29.5",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/kubernetes/kubernetes",
      "Summary": "Container cluster node agent binaries"
    },
    {
      "Name": "libacl",
      "Publisher": "Bottlerocket",
      "Version": "2.3.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://savannah.nongnu.org/projects/acl",
      "Summary": "Library for access control list support"
    },
    {
      "Name": "libattr",
      "Publisher": "Bottlerocket",
      "Version": "2.5.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://savannah.nongnu.org/projects/attr",
      "Summary": "Library for extended attribute support"
    },
    {
      "Name": "libaudit",
      "Publisher": "Bottlerocket",
      "Version": "3.1.4",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/linux-audit/audit-userspace/",
      "Summary": "Library for the audit subsystem"
    },
    {
      "Name": "libblkid",
      "Publisher": "Bottlerocket",
      "Version": "2.40.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://en.wikipedia.org/wiki/Util-linux",
      "Summary": "Block device ID library"
    },
    {
      "Name": "libcap",
      "Publisher": "Bottlerocket",
      "Version": "2.70",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://sites.google.com/site/fullycapable/",
      "Summary": "Library for getting and setting POSIX.1e capabilities"
    },
    {
      "Name": "libelf",
      "Publisher": "Bottlerocket",
      "Version": "0.191",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://sourceware.org/elfutils/",
      "Summary": "Library for ELF files"
    },
    {
      "Name": "libexpat",
      "Publisher": "Bottlerocket",
      "Version": "2.6.3",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://libexpat.github.io/",
      "Summary": "Library for XML parsing"
    },
    {
      "Name": "libfdisk",
      "Publisher": "Bottlerocket",
      "Version": "2.40.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://en.wikipedia.org/wiki/Util-linux",
      "Summary": "Partition table library"
    },
    {
      "Name": "libgcc",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://gcc.gnu.org/",
      "Summary": "GCC runtime library"
    },
    {
      "Name": "libinih",
      "Publisher": "Bottlerocket",
      "Version": "58",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/benhoyt/inih",
      "Summary": "Simple INI file parser library"
    },
    {
      "Name": "libmnl",
      "Publisher": "Bottlerocket",
      "Version": "1.0.5",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://netfilter.org/projects/libmnl",
      "Summary": "Library for netlink"
    },
    {
      "Name": "libmount",
      "Publisher": "Bottlerocket",
      "Version": "2.40.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://en.wikipedia.org/wiki/Util-linux",
      "Summary": "Device mounting library"
    },
    {
      "Name": "libncurses",
      "Publisher": "Bottlerocket",
      "Version": "6.5",
      "Release": "20240831.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://invisible-island.net/ncurses/ncurses.html",
      "Summary": "Ncurses libraries"
    },
    {
      "Name": "libnetfilter_conntrack",
      "Publisher": "Bottlerocket",
      "Version": "1.0.9",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://netfilter.org",
      "Summary": "Library for netfilter conntrack"
    },
    {
      "Name": "libnetfilter_cthelper",
      "Publisher": "Bottlerocket",
      "Version": "1.0.1",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://netfilter.org",
      "Summary": "Library for netfilter cthelper"
    },
    {
      "Name": "libnetfilter_cttimeout",
      "Publisher": "Bottlerocket",
      "Version": "1.0.1",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://netfilter.org",
      "Summary": "Library for netfilter cttimeout"
    },
    {
      "Name": "libnetfilter_queue",
      "Publisher": "Bottlerocket",
      "Version": "1.0.5",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://netfilter.org",
      "Summary": "Library for netfilter queue"
    },
    {
      "Name": "libnfnetlink",
      "Publisher": "Bottlerocket",
      "Version": "1.0.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://netfilter.org",
      "Summary": "Library for netfilter netlink"
    },
    {
      "Name": "libnftnl",
      "Publisher": "Bottlerocket",
      "Version": "1.2.7",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://netfilter.org/projects/libnftnl/",
      "Summary": "Library for nftables netlink"
    },
    {
      "Name": "libnvme",
      "Publisher": "Bottlerocket",
      "Version": "1.10",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/linux-nvme/libnvme",
      "Summary": "Library for NVM Express"
    },
    {
      "Name": "libpcre",
      "Publisher": "Bottlerocket",
      "Version": "10.44",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.pcre.org/",
      "Summary": "Library for regular expressions"
    },
    {
      "Name": "libseccomp",
      "Publisher": "Bottlerocket",
      "Version": "2.5.5",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/seccomp/libseccomp",
      "Summary": "Library for enhanced seccomp"
    },
    {
      "Name": "libselinux",
      "Publisher": "Bottlerocket",
      "Version": "3.6",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/SELinuxProject/",
      "Summary": "Library for SELinux"
    },
    {
      "Name": "libselinux-utils",
      "Publisher": "Bottlerocket",
      "Version": "3.6",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/SELinuxProject/",
      "Summary": "A set of utilities for SELinux"
    },
    {
      "Name": "libsemanage",
      "Publisher": "Bottlerocket",
      "Version": "3.6",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/SELinuxProject/",
      "Summary": "Library for SELinux binary policy manipulation"
    },
    {
      "Name": "libsepol",
      "Publisher": "Bottlerocket",
      "Version": "3.6",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/SELinuxProject/",
      "Summary": "Library for SELinux policy manipulation"
    },
    {
      "Name": "libsmartcols",
      "Publisher": "Bottlerocket",
      "Version": "2.40.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://en.wikipedia.org/wiki/Util-linux",
      "Summary": "Formatting library for ls-like programs"
    },
    {
      "Name": "libstd-rust",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.rust-lang.org/",
      "Summary": "Rust standard library"
    },
    {
      "Name": "liburcu",
      "Publisher": "Bottlerocket",
      "Version": "0.14.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://liburcu.org",
      "Summary": "Library for userspace RCU"
    },
    {
      "Name": "libuuid",
      "Publisher": "Bottlerocket",
      "Version": "2.40.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://en.wikipedia.org/wiki/Util-linux",
      "Summary": "Universally unique ID library"
    },
    {
      "Name": "libxcrypt",
      "Publisher": "Bottlerocket",
      "Version": "4.4.36",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/besser82/libxcrypt",
      "Summary": "Extended crypt library for descrypt, md5crypt, bcrypt, and others"
    },
    {
      "Name": "libz",
      "Publisher": "Bottlerocket",
      "Version": "1.3.1",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.zlib.net/",
      "Summary": "Library for zlib compression"
    },
    {
      "Name": "libzstd",
      "Publisher": "Bottlerocket",
      "Version": "1.5.6",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/facebook/zstd/",
      "Summary": "Library for Zstandard compression"
    },
    {
      "Name": "logdog",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket log extractor"
    },
    {
      "Name": "makedumpfile",
      "Publisher": "Bottlerocket",
      "Version": "1.7.5",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/makedumpfile/makedumpfile",
      "Summary": "Tool to create dumps from kernel memory images"
    },
    {
      "Name": "mdadm",
      "Publisher": "Bottlerocket",
      "Version": "4.3",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://cdn.kernel.org/pub/linux/utils/raid/mdadm/",
      "Summary": "mdadm is used for controlling Linux md devices (aka RAID arrays)"
    },
    {
      "Name": "bottlerocket-metadata",
      "Publisher": "Bottlerocket",
      "Version": "1.0",
      "Release": "1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/twoliter",
      "Summary": "Bottlerocket metadata"
    },
    {
      "Name": "metricdog",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket health metrics sender"
    },
    {
      "Name": "migration",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Tools to migrate version formats"
    },
    {
      "Name": "netdog",
      "Publisher": "Bottlerocket",
      "Version": "0.1.1",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket network configuration helper"
    },
    {
      "Name": "netdog-systemd-networkd",
      "Publisher": "Bottlerocket",
      "Version": "0.1.1",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket network configuration helper"
    },
    {
      "Name": "nvme-cli",
      "Publisher": "Bottlerocket",
      "Version": "2.10.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/linux-nvme/nvme-cli",
      "Summary": "CLI to interact with NVMe devices"
    },
    {
      "Name": "oci-add-hooks",
      "Publisher": "Bottlerocket",
      "Version": "1.0.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/awslabs/oci-add-hooks",
      "Summary": "OCI runtime wrapper that injects OCI hooks"
    },
    {
      "Name": "os",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket's first-party code"
    },
    {
      "Name": "pciutils",
      "Publisher": "Bottlerocket",
      "Version": "3.13.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.kernel.org/pub/software/utils/pciutils/",
      "Summary": "PCI bus related utilities"
    },
    {
      "Name": "pigz",
      "Publisher": "Bottlerocket",
      "Version": "2.8",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://www.zlib.net/pigz",
      "Summary": "pigz is a parallel implementation of gzip which utilizes multiple cores"
    },
    {
      "Name": "pluto",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Dynamic setting generator for kubernetes"
    },
    {
      "Name": "policycoreutils",
      "Publisher": "Bottlerocket",
      "Version": "3.6",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/SELinuxProject/",
      "Summary": "A set of SELinux policy tools"
    },
    {
      "Name": "prairiedog",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Tools for kdump support"
    },
    {
      "Name": "procps",
      "Publisher": "Bottlerocket",
      "Version": "4.0.4",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://gitlab.com/procps-ng/procps",
      "Summary": "A set of process monitoring tools"
    },
    {
      "Name": "release",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket release"
    },
    {
      "Name": "runc",
      "Publisher": "Bottlerocket",
      "Version": "1.1.14",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/opencontainers/runc",
      "Summary": "CLI for running Open Containers"
    },
    {
      "Name": "runc-bin",
      "Publisher": "Bottlerocket",
      "Version": "1.1.14",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/opencontainers/runc",
      "Summary": "CLI for running Open Containers binaries"
    },
    {
      "Name": "schnauzer",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Setting generator for templated settings values."
    },
    {
      "Name": "selinux-policy",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "SELinux policy"
    },
    {
      "Name": "settings-committer",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Commits settings from user data, defaults, and generators at boot"
    },
    {
      "Name": "bottlerocket-settings-defaults",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727568863.800458c4.br1",
      "Epoch": "1",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Settings defaults"
    },
    {
      "Name": "bottlerocket-settings-defaults-aws-k8s-1.31",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727568863.800458c4.br1",
      "Epoch": "1",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Settings defaults for the aws-k8s 1.27 through 1.30 variants"
    },
    {
      "Name": "bottlerocket-settings-plugins",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727568863.800458c4.br1",
      "Epoch": "1",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Settings plugins"
    },
    {
      "Name": "bottlerocket-settings-plugins-aws-k8s",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727568863.800458c4.br1",
      "Epoch": "1",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Settings plugin for the aws-k8s variants"
    },
    {
      "Name": "shibaken",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Run tasks reliant on IMDS"
    },
    {
      "Name": "shim",
      "Publisher": "Bottlerocket",
      "Version": "15.8",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/rhboot/shim/",
      "Summary": "UEFI shim loader"
    },
    {
      "Name": "shimpei",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "OCI-compatible shim around oci-add-hooks"
    },
    {
      "Name": "signpost",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket GPT priority querier/switcher"
    },
    {
      "Name": "static-pods",
      "Publisher": "Bottlerocket",
      "Version": "0.1",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Manages user-defined K*S static pods"
    },
    {
      "Name": "storewolf",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Data store creator"
    },
    {
      "Name": "sundog",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Updates settings dynamically based on user-specified generators"
    },
    {
      "Name": "systemd",
      "Publisher": "Bottlerocket",
      "Version": "252.22",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.freedesktop.org/wiki/Software/systemd",
      "Summary": "System and Service Manager"
    },
    {
      "Name": "systemd-networkd",
      "Publisher": "Bottlerocket",
      "Version": "252.22",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.freedesktop.org/wiki/Software/systemd",
      "Summary": "Files for networkd"
    },
    {
      "Name": "systemd-resolved",
      "Publisher": "Bottlerocket",
      "Version": "252.22",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://www.freedesktop.org/wiki/Software/systemd",
      "Summary": "Files for resolved"
    },
    {
      "Name": "thar-be-settings",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Applies changed settings to a Bottlerocket system"
    },
    {
      "Name": "thar-be-updates",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Dispatches Bottlerocket update commands"
    },
    {
      "Name": "updog",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Bottlerocket updater CLI"
    },
    {
      "Name": "util-linux",
      "Publisher": "Bottlerocket",
      "Version": "2.40.2",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "http://en.wikipedia.org/wiki/Util-linux",
      "Summary": "A collection of basic system utilities"
    },
    {
      "Name": "warm-pool-wait",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Warm pool wait for aws k8s"
    },
    {
      "Name": "xfscli",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "0.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "XFS progs cli"
    },
    {
      "Name": "xfsprogs",
      "Publisher": "Bottlerocket",
      "Version": "6.9.0",
      "Release": "1.1727554942.ab18bc69.br1",
      "Epoch": "0",
      "InstalledTime": "2024-10-02T20:45:29Z",
      "ApplicationType": "Unspecified",
      "Architecture": "aarch64",
      "Url": "https://xfs.wiki.kernel.org",
      "Summary": "Utilities for managing the XFS filesystem"
    }
  ]
}
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
