### PR TITLE
pubsys: override kit repo for multi-arch image as well

### DIFF
--- a/tools/pubsys/src/kit/publish_kit/mod.rs
+++ b/tools/pubsys/src/kit/publish_kit/mod.rs
@@ -110,7 +110,10 @@ async fn publish_kit(
         error::NoArchiveSnafu { path: kit_path }
     );
 
-    let target_uri = format!("{}/{}:{}", vendor_registry_uri, kit_name, kit_version);
+    let target_uri = format!(
+        "{}/{}:{}",
+        vendor_registry_uri, repository_target, kit_version
+    );
 
     info!("Pushing kit to {}", &target_uri);
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

We forgot to also override repository for the multi-arch image when using a repository override for `publish-kit`, so the single-arch images were being pushed to the overridden repo, but the multi-arch image is pushed to the regular repo. This fixes that.

**Testing done:**

Pushed a kit to an overridden repo, and verified that both the single-arch and multi-arch image were there.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
