### PR TITLE
ci: fix repository name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
     needs: [create-release, upload-artifacts]
     if: >-
       ${{ needs.create-release.outputs.has-releases == 'true'
-          && github.repository == 'bottlerocket-os/bottlerocket'
+          && github.repository == 'bottlerocket-os/twoliter'
       }}
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
**Description of changes:**
The `0.4.7-rc1` release workflow did not upload attributions due to a bug in the CI workflow.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
