### PR TITLE
twoliter: bump to 0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.4.7-rc1"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.14", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.14" }
-twoliter = { version = "0.4.7-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.4.7", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.4.7-rc1"
+version = "0.4.7"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
**Description of changes:**
Prepare twoliter 0.4.7 after release-candidate testing has succeeded.

**Testing done:**
CI passes against 0.4.7-rc1:
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/183
* https://github.com/bottlerocket-os/bottlerocket/pull/4236

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
