### PR TITLE
twoliter: avoid duplicate macro declaration

### DIFF
--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -75,7 +75,7 @@ RUN --mount=target=/host \
       -x '*-debugsource-*.rpm' \
       --no-database \
       ./rpmbuild/RPMS && \
-    cp .rpmmacros /etc/rpm/macros && \
+    cp .rpmmacros /root/.rpmmacros && \
     declare -a KIT_REPOS && \
     for kit in ${KIT_DEPENDENCIES} ; do \
       KIT_REPOS+=("--repofrompath=${kit},/bypass/build/kits/${kit}/${ARCH}" --enablerepo "${kit}") ; \


### PR DESCRIPTION
**Issue number:**

Closes #388

**Description of changes:**
Processes that run as root need the target's macros in order to parse spec files. Copy the macros to root's home directory rather than to the system-wide `/etc/rpm` location, to avoid defining macros twice for other users, such as the unprivileged builder user. Otherwise, the redundant definition forces macros to be undefined twice to clear them from the per-user and the system-level scopes.


**Testing done:**
Built core kits for both targets.

Verified that I could `%undefine cross_check_fips` just once - [as intended](https://github.com/bottlerocket-os/bottlerocket-sdk/blob/1e0fc9d0c464abd9980f2da09dc7aa1dbf62ed7a/macros/shared#L268) - to suppress the FIPS check:
```
diff --git a/packages/runc/runc.spec b/packages/runc/runc.spec
index 8c695be6..adad32ae 100644
--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -1,3 +1,5 @@
+%undefine cross_check_fips
+
 %global goproject github.com/opencontainers
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
@@ -65,7 +67,7 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 bin/runc %{buildroot}%{_cross_bindir}

 install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/bin/runc %{buildroot}%{_cross_fips_bindir}
+%dnl install -p -m 0755 fips/bin/runc %{buildroot}%{_cross_fips_bindir}

 %cross_scan_attribution go-vendor vendor

@@ -78,6 +80,6 @@ install -p -m 0755 fips/bin/runc %{buildroot}%{_cross_fips_bindir}
 %{_cross_bindir}/runc

 %files fips-bin
-%{_cross_fips_bindir}/runc
+%dnl %{_cross_fips_bindir}/runc
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
