### PR TITLE
release: prepare for release 0.5.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.4.7...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.5.0...HEAD
+
+## [0.5.0] - 2024-10-10
+
+### Added
+
+- Use bundled `krane` for OCI repository support ([#387])
+
+### Changed
+
+- Increment kit metadata version. This makes this version of Twoliter incompatible with kits built
+  from older versions of Twoliter, and older versions of Twoliter incompatible with kits built from
+  this version. ([#387])
+- Unconditionally use an RPMs NEVR in a variant's application inventory ([#384])
+
+### Fixed
+
+- Allow `find-debuginfo` to manage its own PATH ([#383])
+- Refrain from defining RPM macros twice ([#392])
+
+### Removed
+
+- Remove the ability to use `docker` or `crane` from system PATH ([#387])
+
+[#383]: https://github.com/bottlerocket-os/twoliter/pull/383
+[#384]: https://github.com/bottlerocket-os/twoliter/pull/384
+[#387]: https://github.com/bottlerocket-os/twoliter/pull/387
+[#392]: https://github.com/bottlerocket-os/twoliter/pull/392
+
+[0.5.0]: https://github.com/bottlerocket-os/twoliter/compare/v0.4.7...v0.5.0
 
 ## [0.4.7] - 2024-10-07
 
@@ -25,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#379]: https://github.com/bottlerocket-os/twoliter/pull/379
 [#381]: https://github.com/bottlerocket-os/twoliter/pull/381
 [#385]: https://github.com/bottlerocket-os/twoliter/pull/385
+
+[0.4.7]: https://github.com/bottlerocket-os/twoliter/compare/v0.4.6...v0.4.7
 
 ## [0.4.6] - 2024-09-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.4.7"
+version = "0.5.0-rc1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.14", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.14" }
-twoliter = { version = "0.4.7", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.5.0-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.4.7"
+version = "0.5.0-rc1"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
**Testing done:**
* Used to build core-kit and derivative bottlerocket AMIs
* The release-candidate will be tested against `bottlerocket-core-kit` CI

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
