### PR TITLE
ci: install golang in build and release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Install crane for testing
-        uses: ./.github/actions/install-crane
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "^1.18"
       - name: Install cargo-dist
         run: |
           cargo install --locked \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,4 +21,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo install cargo-deny --locked
       - run: cargo install cargo-make --locked
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "^1.18"
       - run: make build


### PR DESCRIPTION
**Description of changes:**
The release build for twoliter `0.5.0-rc1` failed because golang is missing from the build environment. This *should* install golang there.


**Testing done:**
😬


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
