### PR TITLE
Add golang to additional CI workflows where it was missing, always use bottlerocket capacity for release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "^1.18"
       - name: Install cargo-dist
         run: ${{ matrix.install-dist }}
       - name: Install Cross
@@ -187,7 +190,9 @@ jobs:
           && (needs.upload-artifacts.result == 'skipped'
             || needs.upload-artifacts.result == 'success')
       }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_8-core
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -195,6 +200,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "^1.18"
       - name: mark release as non-draft
         run: |
           gh release edit "${GITHUB_REF_NAME}" --draft=false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.5.0-rc2"
+version = "0.5.0-rc3"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.14", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.14" }
-twoliter = { version = "0.5.0-rc2", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.5.0-rc3", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.5.0-rc2"
+version = "0.5.0-rc3"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
**Description of changes:**
[Release actions continue to fail due to inconsistent golang installations](https://github.com/bottlerocket-os/twoliter/actions/runs/11280513366/job/31373807955). Embarrassingly, this calls for another CI modification and version bump.




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
