### PR TITLE
cross: install golang in the cross container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,12 @@ jobs:
         # do agree on 'cat' and '$()' so we use that to marshal values between commands.
         run: |
           export PATH=$CARGO_HOME/bin:$PATH
+          # cargo-cross warns us that multiple cross configurations are present in our
+          # workspace (ie dependencies have configurations), but it picks the appropriate one from
+          # the twoliter workspace.
+          #
+          # These warnings cause the tool to fail, so we disable them.
+          export CROSS_NO_WARNINGS=0
           # Actually do builds and make zips and whatnot
           cargo dist build --tag="${GITHUB_REF_NAME}" --output-format=json ${MATRIX_DIST_ARGS} > dist-manifest.json
           echo "dist ran successfully"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.5.0-rc3"
+version = "0.5.0-rc4"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,16 @@ installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
 
+[workspace.metadata.cross.build]
+pre-build = [
+    # install golang for krane-bundle
+    "apt update && apt --assume-yes install golang-1.22",
+    "update-alternatives --install /usr/bin/go go /usr/lib/go-1.22/bin/go 10",
+    # give the builder access to the go build and module caches
+    "mkdir /.cache && chmod a+rw /.cache",
+    "mkdir /go && chmod a+rw /go",
+]
+
 [workspace.dependencies]
 bottlerocket-types = { version = "0.0.14", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.14" }
 bottlerocket-variant = { version = "0.1", path = "tools/bottlerocket-variant" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.14", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.14" }
-twoliter = { version = "0.5.0-rc3", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.5.0-rc4", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.5.0-rc3"
+version = "0.5.0-rc4"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
**Description of changes:**
Twoliter's release process has been failing, as the build of `krane` has been unable to locate the go compiler. This was because Twoliter's release build is done by `cargo-cross`, which takes advantage of a containerized build environment with the appropriate cross-compilation toolchain for each target.

This ensures the cross environment also contains a go compiler and configures it to be usable by the `krane-bundle` crate build.


**Testing done:**
* Performed a release in my fork of Twoliter [here](https://github.com/cbgbt/twoliter/actions/runs/11296593392/job/31421887346).


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
