### PR TITLE
krane: write krane binary to a tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,8 +1902,8 @@ dependencies = [
  "anyhow",
  "flate2",
  "lazy_static",
- "pentacle",
  "tar",
+ "tempfile",
 ]
 
 [[package]]
@@ -2301,16 +2301,6 @@ checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64 0.22.1",
  "serde",
-]
-
-[[package]]
-name = "pentacle"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e875807b4510e6847d4ef7674ab9b3efe30cc99b933f2e6e82f6ef38f7e5352"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ nix = "0.28"
 nonzero_ext = "0.3"
 num_cpus = "1"
 olpc-cjson = "0.1"
-pentacle = "1.1"
 rand = { version = "0.8", default-features = false }
 regex = "1"
 reqwest = { version = "0.11", default-features = false }

--- a/tools/krane/Cargo.toml
+++ b/tools/krane/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow.workspace = true
 flate2.workspace = true
 lazy_static.workspace = true
-pentacle.workspace = true
+tempfile.workspace = true
 
 [build-dependencies]
 flate2.workspace = true

--- a/tools/krane/README.md
+++ b/tools/krane/README.md
@@ -4,8 +4,7 @@ This crate packages the `krane` utility from [google/go-containerregistry].
 
 The utility is compiled by a build script, the output of which is compressed and stored in the Rust
 crate as via `include_bytes!`.
-At runtime, `krane-bundle` writes the decompressed binary to a [sealed anonymous file], passing the
+At runtime, `krane-bundle` writes the decompressed binary to a temp file, passing the
 filepath of that file to any caller.
 
 [google/go-containerregistry]: https://github.com/google/go-containerregistry
-[sealed anonymous file]: https://github.com/haha-business/pentacle

--- a/tools/oci-cli-wrapper/src/cli.rs
+++ b/tools/oci-cli-wrapper/src/cli.rs
@@ -27,7 +27,12 @@ impl CommandLine {
         ensure!(
             output.status.success(),
             error::OperationFailedSnafu {
-                message: String::from_utf8_lossy(&output.stderr),
+                message: format!(
+                    "status: {} stderr: {} stdout: {}",
+                    &output.status,
+                    String::from_utf8_lossy(&output.stderr),
+                    String::from_utf8_lossy(&output.stdout)
+                ),
                 program: self.path.clone(),
                 args: args.iter().map(|x| x.to_string()).collect::<Vec<_>>()
             }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #403 

**Description of changes:**

While looking into #403, I noticed that the `krane` binary produced in the build works as expected if I just copy the binary over to an affected system.

This PR changes the way that the `krane-bundle` lib installs krane. Instead of keeping the file in memory and sealing it, we create a temp directory and write the krane binary to that directory.

This PR also improves the error message when krane fails to run.

**Testing done:**

Built twoliter with

```bash
cross build --target=x86_64-unknown-linux-musl --release
```

and copied the produced binary over to a system that was affected by the bug in #403. I ran `twoliter update` in the bottlerocket repo without issue.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
