### PR TITLE
chore: prepare for release 0.5.1-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.5.1...HEAD
+
+## [0.5.1] - 2024-11-11
+
+### Fixed
+
+- Allow projects to not have a `sources/` dir ([#404])
+- Write krane to a tempfile instead of a sealed anonymous file ([#405])
+
+[#404]: https://github.com/bottlerocket-os/twoliter/pull/404
+[#405]: https://github.com/bottlerocket-os/twoliter/pull/405
+
+[0.5.1]: https://github.com/bottlerocket-os/twoliter/compare/v0.5.0...v0.5.1
 
 ## [0.5.0] - 2024-10-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.5.0"
+version = "0.5.1-rc1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.14", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.14" }
-twoliter = { version = "0.5.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.5.1-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.5.0"
+version = "0.5.1-rc1"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
**Description of changes:**

Prepare changelog and bump version

**Testing done**

- Built core-kit and AMI with twoliter
- Tested AMI build on a system affected by https://github.com/bottlerocket-os/twoliter/issues/403

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
