### PR TITLE
chore: bump version to v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.5.1-rc1"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.14", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.14" }
-twoliter = { version = "0.5.1-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.5.1", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.5.1-rc1"
+version = "0.5.1"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Testing passed for v0.5.1-rc1 in the [core-kit](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/259) and [b-o/b](https://github.com/bottlerocket-os/bottlerocket/pull/4296), so moving ahead with the release.

**Testing done:**

Built core-kit and and AMI manually, and submitted draft pull requests to both core-kit and b-o/b to bump the version, and the workflows passed on both.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
