### PR TITLE
Use `krane` to fetch the project's SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.5.1...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.5.2...HEAD
+
+## [0.5.2] - 2024-12-03
+
+### Changed
+
+- Use `krane` to fetch the SDK during the build instead of `docker` ([#411])
+- Enable verbose `krane` logs when the log level is DEBUG or TRACE ([#411])
+- Update `ecr-login` to v0.9.0 ([#411])
+
+[#411]: https://github.com/bottlerocket-os/twoliter/pull/411
+
+[0.5.2]: https://github.com/bottlerocket-os/twoliter/compare/v0.5.1...v0.5.2
 
 ## [0.5.1] - 2024-11-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,6 +3871,7 @@ dependencies = [
  "filetime",
  "flate2",
  "futures",
+ "krane-bundle",
  "log",
  "oci-cli-wrapper",
  "olpc-cjson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.5.1"
+version = "0.5.2-rc1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,7 @@ dependencies = [
  "lazy_static",
  "tar",
  "tempfile",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.14", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.14" }
-twoliter = { version = "0.5.1", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.5.2-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
 
 [workspace.metadata.cross.build]
 pre-build = [
-    # install golang for krane-bundle
-    "apt update && apt --assume-yes install golang-1.22",
+    # install golang and patch for krane-bundle
+    "apt update && apt --assume-yes install golang-1.22 patch",
     "update-alternatives --install /usr/bin/go go /usr/lib/go-1.22/bin/go 10",
     # give the builder access to the go build and module caches
     "mkdir /.cache && chmod a+rw /.cache",

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOP := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
-BOTTLEROCKET_SDK_VERSION ?= v0.45.0
+BOTTLEROCKET_SDK_VERSION ?= v0.47.0
 BOTTLEROCKET_SDK_IMAGE ?= public.ecr.aws/bottlerocket/bottlerocket-sdk:$(BOTTLEROCKET_SDK_VERSION)
 
 .PHONY: design

--- a/tools/krane/Cargo.toml
+++ b/tools/krane/Cargo.toml
@@ -15,3 +15,4 @@ tempfile.workspace = true
 [build-dependencies]
 flate2.workspace = true
 tar.workspace = true
+which.workspace = true

--- a/tools/krane/patches/0001-krane-update-ecr-login-to-v0.9.0.patch
+++ b/tools/krane/patches/0001-krane-update-ecr-login-to-v0.9.0.patch
@@ -1,0 +1,233 @@
+From 179d47cd4a413e8da0f0c963f1d5cdc06704470b Mon Sep 17 00:00:00 2001
+From: "Sean P. Kelly" <seankell@amazon.com>
+Date: Tue, 3 Dec 2024 20:30:07 +0000
+Subject: [PATCH] krane: update ecr-login to v0.9.0
+
+---
+ cmd/krane/go.mod | 39 +++++++++++++-----------
+ cmd/krane/go.sum | 79 ++++++++++++++++++++++++------------------------
+ 2 files changed, 61 insertions(+), 57 deletions(-)
+
+diff --git a/cmd/krane/go.mod b/cmd/krane/go.mod
+index 3cc202b7..cf9c0204 100644
+--- a/cmd/krane/go.mod
++++ b/cmd/krane/go.mod
+@@ -1,11 +1,13 @@
+ module github.com/google/go-containerregistry/cmd/krane
+ 
+-go 1.18
++go 1.21
++
++toolchain go1.23.2
+ 
+ replace github.com/google/go-containerregistry => ../../
+ 
+ require (
+-	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230510185313-f5e39e5f34c7
++	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20240910181921-bef5bd9384b7
+ 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
+ 	github.com/google/go-containerregistry v0.15.2
+ )
+@@ -22,26 +24,27 @@ require (
+ 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+ 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+ 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+-	github.com/aws/aws-sdk-go-v2 v1.18.0 // indirect
+-	github.com/aws/aws-sdk-go-v2/config v1.18.25 // indirect
+-	github.com/aws/aws-sdk-go-v2/credentials v1.13.24 // indirect
+-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.34 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/ecr v1.18.11 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.16.2 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.27 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/sso v1.12.10 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/sts v1.19.0 // indirect
+-	github.com/aws/smithy-go v1.13.5 // indirect
++	github.com/aws/aws-sdk-go-v2 v1.30.5 // indirect
++	github.com/aws/aws-sdk-go-v2/config v1.27.33 // indirect
++	github.com/aws/aws-sdk-go-v2/credentials v1.17.32 // indirect
++	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.13 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.17 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.17 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 // indirect
++	github.com/aws/aws-sdk-go-v2/service/ecr v1.32.4 // indirect
++	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.25.6 // indirect
++	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.4 // indirect
++	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.19 // indirect
++	github.com/aws/aws-sdk-go-v2/service/sso v1.22.7 // indirect
++	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.7 // indirect
++	github.com/aws/aws-sdk-go-v2/service/sts v1.30.7 // indirect
++	github.com/aws/smithy-go v1.20.4 // indirect
+ 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
+ 	github.com/dimchansky/utfbom v1.1.1 // indirect
+ 	github.com/docker/cli v24.0.0+incompatible // indirect
+ 	github.com/docker/distribution v2.8.2+incompatible // indirect
+ 	github.com/docker/docker v24.0.0+incompatible // indirect
+-	github.com/docker/docker-credential-helpers v0.7.0 // indirect
++	github.com/docker/docker-credential-helpers v0.8.2 // indirect
+ 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+ 	github.com/golang/protobuf v1.5.3 // indirect
+ 	github.com/google/go-cmp v0.5.9 // indirect
+@@ -52,7 +55,7 @@ require (
+ 	github.com/opencontainers/go-digest v1.0.0 // indirect
+ 	github.com/opencontainers/image-spec v1.1.0-rc3 // indirect
+ 	github.com/pkg/errors v0.9.1 // indirect
+-	github.com/sirupsen/logrus v1.9.1 // indirect
++	github.com/sirupsen/logrus v1.9.3 // indirect
+ 	github.com/spf13/cobra v1.7.0 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+ 	github.com/vbatts/tar-split v0.11.3 // indirect
+diff --git a/cmd/krane/go.sum b/cmd/krane/go.sum
+index 45188955..a72be078 100644
+--- a/cmd/krane/go.sum
++++ b/cmd/krane/go.sum
+@@ -28,42 +28,43 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
+ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
+ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+-github.com/aws/aws-sdk-go-v2 v1.18.0 h1:882kkTpSFhdgYRKVZ/VCgf7sd0ru57p2JCxz4/oN5RY=
+-github.com/aws/aws-sdk-go-v2 v1.18.0/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+-github.com/aws/aws-sdk-go-v2/config v1.18.25 h1:JuYyZcnMPBiFqn87L2cRppo+rNwgah6YwD3VuyvaW6Q=
+-github.com/aws/aws-sdk-go-v2/config v1.18.25/go.mod h1:dZnYpD5wTW/dQF0rRNLVypB396zWCcPiBIvdvSWHEg4=
+-github.com/aws/aws-sdk-go-v2/credentials v1.13.24 h1:PjiYyls3QdCrzqUN35jMWtUK1vqVZ+zLfdOa/UPFDp0=
+-github.com/aws/aws-sdk-go-v2/credentials v1.13.24/go.mod h1:jYPYi99wUOPIFi0rhiOvXeSEReVOzBqFNOX5bXYoG2o=
+-github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3 h1:jJPgroehGvjrde3XufFIJUZVK5A2L9a3KwSFgKy9n8w=
+-github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3/go.mod h1:4Q0UFP0YJf0NrsEuEYHpM9fTSEVnD16Z3uyEF7J9JGM=
+-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33 h1:kG5eQilShqmJbv11XL1VpyDbaEJzWxd4zRiCG30GSn4=
+-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33/go.mod h1:7i0PF1ME/2eUPFcjkVIwq+DOygHEoK92t5cDqNgYbIw=
+-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27 h1:vFQlirhuM8lLlpI7imKOMsjdQLuN9CPi+k44F/OFVsk=
+-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27/go.mod h1:UrHnn3QV/d0pBZ6QBAEQcqFLf8FAzLmoUfPVIueOvoM=
+-github.com/aws/aws-sdk-go-v2/internal/ini v1.3.34 h1:gGLG7yKaXG02/jBlg210R7VgQIotiQntNhsCFejawx8=
+-github.com/aws/aws-sdk-go-v2/internal/ini v1.3.34/go.mod h1:Etz2dj6UHYuw+Xw830KfzCfWGMzqvUTCjUj5b76GVDc=
+-github.com/aws/aws-sdk-go-v2/service/ecr v1.18.11 h1:wlTgmb/sCmVRJrN5De3CiHj4v/bTCgL5+qpdEd0CPtw=
+-github.com/aws/aws-sdk-go-v2/service/ecr v1.18.11/go.mod h1:Ce1q2jlNm8BVpjLaOnwnm5v2RClAbK6txwPljFzyW6c=
+-github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.16.2 h1:yflJrGmi1pXtP9lOpOeaNZyc0vXnJTuP2sor3nJcGGo=
+-github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.16.2/go.mod h1:uHtRE7aqXNmpeYL+7Ec7LacH5zC9+w2T5MBOeEKDdu0=
+-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.27 h1:0iKliEXAcCa2qVtRs7Ot5hItA2MsufrphbRFlz1Owxo=
+-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.27/go.mod h1:EOwBD4J4S5qYszS5/3DpkejfuK+Z5/1uzICfPaZLtqw=
+-github.com/aws/aws-sdk-go-v2/service/sso v1.12.10 h1:UBQjaMTCKwyUYwiVnUt6toEJwGXsLBI6al083tpjJzY=
+-github.com/aws/aws-sdk-go-v2/service/sso v1.12.10/go.mod h1:ouy2P4z6sJN70fR3ka3wD3Ro3KezSxU6eKGQI2+2fjI=
+-github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10 h1:PkHIIJs8qvq0e5QybnZoG1K/9QTrLr9OsqCIo59jOBA=
+-github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10/go.mod h1:AFvkxc8xfBe8XA+5St5XIHHrQQtkxqrRincx4hmMHOk=
+-github.com/aws/aws-sdk-go-v2/service/sts v1.19.0 h1:2DQLAKDteoEDI8zpCzqBMaZlJuoE9iTYD0gFmXVax9E=
+-github.com/aws/aws-sdk-go-v2/service/sts v1.19.0/go.mod h1:BgQOMsg8av8jset59jelyPW7NoZcZXLVpDsXunGDrk8=
+-github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
+-github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+-github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230510185313-f5e39e5f34c7 h1:G5IT+PEpFY0CDb3oITDP9tkmLrHkVD8Ny+elUmBqVYI=
+-github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230510185313-f5e39e5f34c7/go.mod h1:VVALgT1UESBh91dY0GprHnT1Z7mKd96VDk8qVy+bmu0=
++github.com/aws/aws-sdk-go-v2 v1.30.5 h1:mWSRTwQAb0aLE17dSzztCVJWI9+cRMgqebndjwDyK0g=
++github.com/aws/aws-sdk-go-v2 v1.30.5/go.mod h1:CT+ZPWXbYrci8chcARI3OmI/qgd+f6WtuLOoaIA8PR0=
++github.com/aws/aws-sdk-go-v2/config v1.27.33 h1:Nof9o/MsmH4oa0s2q9a0k7tMz5x/Yj5k06lDODWz3BU=
++github.com/aws/aws-sdk-go-v2/config v1.27.33/go.mod h1:kEqdYzRb8dd8Sy2pOdEbExTTF5v7ozEXX0McgPE7xks=
++github.com/aws/aws-sdk-go-v2/credentials v1.17.32 h1:7Cxhp/BnT2RcGy4VisJ9miUPecY+lyE9I8JvcZofn9I=
++github.com/aws/aws-sdk-go-v2/credentials v1.17.32/go.mod h1:P5/QMF3/DCHbXGEGkdbilXHsyTBX5D3HSwcrSc9p20I=
++github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.13 h1:pfQ2sqNpMVK6xz2RbqLEL0GH87JOwSxPV2rzm8Zsb74=
++github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.13/go.mod h1:NG7RXPUlqfsCLLFfi0+IpKN4sCB9D9fw/qTaSB+xRoU=
++github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.17 h1:pI7Bzt0BJtYA0N/JEC6B8fJ4RBrEMi1LBrkMdFYNSnQ=
++github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.17/go.mod h1:Dh5zzJYMtxfIjYW+/evjQ8uj2OyR/ve2KROHGHlSFqE=
++github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.17 h1:Mqr/V5gvrhA2gvgnF42Zh5iMiQNcOYthFYwCyrnuWlc=
++github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.17/go.mod h1:aLJpZlCmjE+V+KtN1q1uyZkfnUWpQGpbsn89XPKyzfU=
++github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvKgqdiXoTxAF4HQcQ=
++github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
++github.com/aws/aws-sdk-go-v2/service/ecr v1.32.4 h1:nQAU2Yr+afkAvIV39mg7LrNYFNQP7ShwbmiJqx2fUKA=
++github.com/aws/aws-sdk-go-v2/service/ecr v1.32.4/go.mod h1:keOS9j4fv5ASh7dV29lIpGw2QgoJwGFAyMU0uPvfax4=
++github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.25.6 h1:D9C5XIIciGM6mRZTi7zDdFsBsPsgzbsPwwN0wLCymnc=
++github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.25.6/go.mod h1:Mrlicf7xXyuelm+q8XVMblDxJq2pKpKGXiWx/3uqjqs=
++github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.4 h1:KypMCbLPPHEmf9DgMGw51jMj77VfGPAN2Kv4cfhlfgI=
++github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.4/go.mod h1:Vz1JQXliGcQktFTN/LN6uGppAIRoLBR2bMvIMP0gOjc=
++github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.19 h1:rfprUlsdzgl7ZL2KlXiUAoJnI/VxfHCvDFr2QDFj6u4=
++github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.19/go.mod h1:SCWkEdRq8/7EK60NcvvQ6NXKuTcchAD4ROAsC37VEZE=
++github.com/aws/aws-sdk-go-v2/service/sso v1.22.7 h1:pIaGg+08llrP7Q5aiz9ICWbY8cqhTkyy+0SHvfzQpTc=
++github.com/aws/aws-sdk-go-v2/service/sso v1.22.7/go.mod h1:eEygMHnTKH/3kNp9Jr1n3PdejuSNcgwLe1dWgQtO0VQ=
++github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.7 h1:/Cfdu0XV3mONYKaOt1Gr0k1KvQzkzPyiKUdlWJqy+J4=
++github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.7/go.mod h1:bCbAxKDqNvkHxRaIMnyVPXPo+OaPRwvmgzMxbz1VKSA=
++github.com/aws/aws-sdk-go-v2/service/sts v1.30.7 h1:NKTa1eqZYw8tiHSRGpP0VtTdub/8KNk8sDkNPFaOKDE=
++github.com/aws/aws-sdk-go-v2/service/sts v1.30.7/go.mod h1:NXi1dIAGteSaRLqYgarlhP/Ij0cFT+qmCwiJqWh/U5o=
++github.com/aws/smithy-go v1.20.4 h1:2HK1zBdPgRbjFOHlfeQZfpC4r72MOb9bZkiFwggKO+4=
++github.com/aws/smithy-go v1.20.4/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
++github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20240910181921-bef5bd9384b7 h1:wPoMm1zbH1k1D2+sYx19AYMnmBOGPoJB5A022oTwURs=
++github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20240910181921-bef5bd9384b7/go.mod h1:skPUtbWfzU/dVg+S37iSI415qioEEeAR6Ez72cOHR+M=
+ github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589 h1:krfRl01rzPzxSxyLyrChD+U+MzsBXbm0OwYYB67uF+4=
+ github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589/go.mod h1:OuDyvmLnMCwa2ep4Jkm6nyA0ocJuZlGyk2gGseVzERM=
+ github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
+ github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
+ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+-github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
+ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+@@ -75,8 +76,8 @@ github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m3
+ github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docker/docker v24.0.0+incompatible h1:z4bf8HvONXX9Tde5lGBMQ7yCJgNahmJumdrStZAbeY4=
+ github.com/docker/docker v24.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+-github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
+-github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
++github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
++github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
+ github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+ github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+ github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+@@ -86,7 +87,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
+ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+@@ -109,8 +109,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
+ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+ github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+-github.com/sirupsen/logrus v1.9.1 h1:Ou41VVR3nMWWmTiEUnj0OlsgOSCUFgsPAOl6jRIcVtQ=
+-github.com/sirupsen/logrus v1.9.1/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
++github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
++github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+ github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+ github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+@@ -123,8 +123,9 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
+ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
++github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
++github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+ github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
+ github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
+ github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=
+@@ -142,6 +143,7 @@ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq
+ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+ golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
++golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+@@ -166,11 +168,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220906165534-d0df966e6959/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+@@ -189,6 +189,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
+ golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+ golang.org/x/tools v0.9.1 h1:8WMNJAz3zrtPmnYC7ISf5dEn3MT0gY7jBJfw27yrrLo=
++golang.org/x/tools v0.9.1/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+-- 
+2.40.1
+

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -21,6 +21,7 @@ env_logger.workspace = true
 filetime.workspace = true
 flate2.workspace = true
 futures.workspace = true
+krane-bundle.workspace = true
 log.workspace = true
 oci-cli-wrapper.workspace = true
 olpc-cjson.workspace = true

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.5.1"
+version = "0.5.2-rc1"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -315,13 +315,23 @@ dependencies = ["setup-build"]
 script_runner = "bash"
 script = [
 '''
+SDK_PLATFORM="$(docker version --format '{{.Server.Os}}/{{.Server.Arch}}')"
+KRANE="${TWOLITER_TOOLS_DIR}/krane"
+
 if [ ! -s "${BUILDSYS_EXTERNAL_KITS_DIR}/.sdk-verified" ]; then
    echo "Twoliter could not validate '${TLPRIVATE_SDK_IMAGE}', refusing to continue" >&2
    exit 1
 fi
 if ! docker image inspect "${TLPRIVATE_SDK_IMAGE}" >/dev/null 2>&1 ; then
-  if ! docker pull "${TLPRIVATE_SDK_IMAGE}" ; then
+  echo "Pulling SDK '${TLPRIVATE_SDK_IMAGE}'"
+  ${KRANE} pull "${TLPRIVATE_SDK_IMAGE}" /dev/stdout --platform "${SDK_PLATFORM}" \
+    | docker load
+  if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
     echo "failed to pull '${TLPRIVATE_SDK_IMAGE}'" >&2
+    exit 1
+  fi
+  if [[ ${PIPESTATUS[1]} -ne 0 ]]; then
+    echo "failed to load '${TLPRIVATE_SDK_IMAGE}' into docker daemon" >&2
     exit 1
   fi
 fi

--- a/twoliter/src/cargo_make.rs
+++ b/twoliter/src/cargo_make.rs
@@ -154,7 +154,7 @@ fn build_system_env_vars() -> Result<Vec<String>> {
 
 /// A list of environment variables that don't conform to naming conventions but need to be passed
 /// through to the `cargo make` invocation.
-const ENV_VARS: [&str; 23] = [
+const ENV_VARS: &[&str] = &[
     "ALLOW_MISSING_KEY",
     "AMI_DATA_FILE_SUFFIX",
     "CARGO_MAKE_CARGO_ARGS",
@@ -180,7 +180,7 @@ const ENV_VARS: [&str; 23] = [
     "no_proxy",
 ];
 
-const DISALLOWED_ENV_VARS: [&str; 4] = [
+const DISALLOWED_ENV_VARS: &[&str] = &[
     "BUILDSYS_SDK_NAME",
     "BUILDSYS_SDK_VERSION",
     "BUILDSYS_REGISTRY",

--- a/twoliter/src/cmd/mod.rs
+++ b/twoliter/src/cmd/mod.rs
@@ -75,8 +75,10 @@ pub(super) fn init_logger(level: Option<LevelFilter>) {
             Builder::from_default_env().init();
         }
         _ => {
+            // Use RUST_LOG if it exists for dependencies.
             // use provided log level or default for this crate only.
             Builder::new()
+                .parse_default_env()
                 .filter(
                     Some(env!("CARGO_CRATE_NAME")),
                     level.unwrap_or(DEFAULT_LEVEL_FILTER),

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -2,6 +2,7 @@ use crate::common::fs;
 use anyhow::{Context, Result};
 use filetime::{set_file_handle_times, set_file_mtime, FileTime};
 use flate2::read::ZlibDecoder;
+use krane_bundle::KRANE;
 use std::path::Path;
 use tar::Archive;
 use tokio::fs::OpenOptions;
@@ -49,6 +50,7 @@ pub(crate) async fn install_tools(tools_dir: impl AsRef<Path>) -> Result<()> {
     write_bin("testsys", TESTSYS, &dir, mtime).await?;
     write_bin("tuftool", TUFTOOL, &dir, mtime).await?;
     write_bin("unplug", UNPLUG, &dir, mtime).await?;
+    fs::copy(KRANE.path(), dir.join("krane")).await?;
 
     // Apply the mtime to the directory now that the writes are done.
     set_file_mtime(dir, mtime).context(format!("Unable to set mtime for '{}'", dir.display()))?;


### PR DESCRIPTION
**Description of changes:**
This PR resolves two issues:
* The `fetch-sdk` task used `docker pull` to pull the SDK image. We use `krane` for authenticated OCI registry interactions elsewhere in twoliter, so using it for `fetch-sdk` allows us to avoid needing to configure additional credentials for the docker daemon.
* `krane` uses a dated version of the `ecr-login` package from [awslabs/amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper). This pulls in the latest version, which should have support for the latest AWS endpoints.

**Testing done:**
These tests were conducted on an EC2 instance with a role that allows pulling from the given private ECR repository.

Using the old twoliter, I removed all docker credential configurations and then attempted to use a build with an SDK overridden to a private ECR repository:

```
[cargo-make] INFO - Running Task: fetch-sdk
Error response from daemon: Head "https://109276217309.dkr.ecr.us-west-2.amazonaws.com/v2/bottlerocket/bottlerocket-sdk/manifests/v0.47.0": no basic auth credentials
failed to pull '$ACCOUNT.dkr.ecr.us-west-2.amazonaws.com/bottlerocket/bottlerocket-sdk:v0.47.0'
[cargo-make] ERROR - Error while executing command, exit code: 1
```

Using the new twoliter:

```
[cargo-make] INFO - Running Task: fetch-sdk
Pulling SDK '109276217309.dkr.ecr.us-west-2.amazonaws.com/bottlerocket/bottlerocket-sdk:v0.47.0'
Loaded image: 109276217309.dkr.ecr.us-west-2.amazonaws.com/bottlerocket/bottlerocket-sdk:v0.47.0
[cargo-make] INFO - Running Task: fetch-sources
```

Logs from `krane` are also verbose with debug logs enabled:

```
[2024-12-03T21:35:24Z DEBUG oci_cli_wrapper::cli] [/tmp/.tmpEW7xjl/krane,
'-v', 'manifest', '109276217309.dkr.ecr.us-west-2.amazonaws.com/bottlerocket/bottlerocket-sdk:v0.47.0'] stderr: 2024/12/03 21:35:24 --> GET https://109276217309.dkr.ecr.us-west-2.amazonaws.com/v2/
    2024/12/03 21:35:24 GET /v2/ HTTP/1.1
    Host: 109276217309.dkr.ecr.us-west-2.amazonaws.com
    User-Agent: krane/(devel) go-containerregistry/v0.15.2
    Accept-Encoding: gzip

...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
