### PR TITLE
docs: add rust nightly requirement to Testing Binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ The process of testing changes to Twoliter in Bottlerocket is as follows:
 - Commit your changes. This can be either a local commit or a commit on a git fork.
 - In the Bottlerocket git repo
   - Remove the existing Twoliter binary if it exists.
+  - Ensure the [nightly rust toolchain] is installed and enabled.
   - Run any/all `cargo make` commands with the following environment
     variables.
+
+[nightly rust toolchain]: https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust
 
 ```sh
 # The URL to the Twoliter git repository. This can be anything that git remote add would accept.


### PR DESCRIPTION
**Issue number:**

Closes # N/a

**Description of changes:**

Faced the following build error when testing my custom Twoliter:
```
error: toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed
```

This was fixed by installing rust nightly, so adding this step to the Testing section.

**Testing done:**

N/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
