### PR TITLE
twoliter: disallow std::path::Path::canonicalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3918,6 +3936,7 @@ dependencies = [
  "log",
  "oci-cli-wrapper",
  "olpc-cjson",
+ "path-absolutize",
  "pipesys",
  "pubsys",
  "pubsys-setup",
@@ -4242,7 +4261,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ buildsys-config = { version = "0.1", path = "tools/buildsys-config" }
 krane-static = { version = "0.1", path = "tools/krane" }
 oci-cli-wrapper = { version = "0.1", path = "tools/oci-cli-wrapper" }
 parse-datetime = { version = "0.1", path = "tools/parse-datetime" }
+path-absolutize = "3.1"
 pipesys = { version = "0.1", path = "tools/pipesys", lib = true, artifact = [ "bin:pipesys" ] }
 pubsys = { version = "0.1", path = "tools/pubsys", artifact = [ "bin:pubsys" ] }
 pubsys-config = { version = "0.1", path = "tools/pubsys-config" }
@@ -147,3 +148,6 @@ which = "6"
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[workspace.lints.clippy]
+disallowed-methods = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,12 @@
+[[disallowed-methods]]
+path = "std::path::Path::canonicalize"
+reason = "Twoliter usually does not want to resolve symlinks. Use path_absolutize instead"
+
+[[disallowed-methods]]
+path = "std::fs::canonicalize"
+reason = "Twoliter usually does not want to resolve symlinks. Use path_absolutize instead"
+
+[[disallowed-methods]]
+path = "tokio::fs::canonicalize"
+reason = "Twoliter usually does not want to resolve symlinks. Use path_absolutize instead"
+

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
+mod twoliter_build;
 mod twoliter_update;
 
 pub const TWOLITER_PATH: &'static str = env!("CARGO_BIN_FILE_TWOLITER");

--- a/tests/integration-tests/src/twoliter_build.rs
+++ b/tests/integration-tests/src/twoliter_build.rs
@@ -1,0 +1,75 @@
+use super::{run_command, test_projects_dir, TWOLITER_PATH};
+use std::path::Path;
+use tempfile::TempDir;
+
+#[test]
+#[ignore]
+fn test_workspace_symlinks_not_followed() {
+    // Ensure a symlinked `Twoliter.toml` does not trick us into putting our build directory into
+    // the symlink target's parent directory.
+
+    let target_kit = test_projects_dir().join("local-kit");
+    let work_dir = copy_project_to_temp_dir(&target_kit);
+
+    let work_dir_path = work_dir.path();
+
+    let working_twoliter_toml = work_dir_path.join("Twoliter.toml");
+
+    // Replace Twoliter.toml with a symlink
+    std::fs::remove_file(&working_twoliter_toml).unwrap();
+    std::os::unix::fs::symlink(
+        target_kit.join("Twoliter.toml"),
+        work_dir_path.join("Twoliter.toml"),
+    )
+    .unwrap();
+
+    assert!(!work_dir_path.join("build").is_dir());
+
+    run_command(
+        TWOLITER_PATH,
+        [
+            "update",
+            "--project-path",
+            working_twoliter_toml.to_str().unwrap(),
+        ],
+        [],
+    );
+    run_command(
+        TWOLITER_PATH,
+        [
+            "fetch",
+            "--project-path",
+            working_twoliter_toml.to_str().unwrap(),
+        ],
+        [],
+    );
+
+    assert!(work_dir_path.join("build").is_dir());
+}
+
+pub(crate) fn copy_project_to_temp_dir(project: impl AsRef<Path>) -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    copy_most_dirs_recursively(project, &temp_dir);
+    temp_dir
+}
+
+/// Copy dirs recursively except for some of the larger "ignoreable" dirs that may exist in the
+/// user's checkout.
+fn copy_most_dirs_recursively(src: impl AsRef<Path>, dst: impl AsRef<Path>) {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+    for entry in std::fs::read_dir(src).unwrap() {
+        std::fs::create_dir_all(&dst).unwrap();
+        let entry = entry.unwrap();
+        let file_type = entry.file_type().unwrap();
+        if file_type.is_dir() {
+            let name = entry.file_name().to_str().unwrap().to_string();
+            if matches!(name.as_ref(), "target" | "build" | ".gomodcache" | ".cargo") {
+                continue;
+            }
+            copy_most_dirs_recursively(&entry.path(), &dst.join(entry.file_name()));
+        } else {
+            std::fs::copy(entry.path(), dst.join(entry.file_name())).unwrap();
+        }
+    }
+}

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static.workspace = true
 log.workspace = true
 oci-cli-wrapper.workspace = true
 olpc-cjson.workspace = true
+path-absolutize.workspace = true
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -61,3 +62,6 @@ test-case.workspace = true
 default = ["integ-tests", "pubsys"]
 integ-tests = []
 pubsys = ["dep:pubsys"]
+
+[lints]
+workspace = true

--- a/twoliter/src/project/mod.rs
+++ b/twoliter/src/project/mod.rs
@@ -7,6 +7,7 @@ pub(crate) use self::image::{Image, ProjectImage, ValidIdentifier, VendedArtifac
 pub(crate) use self::vendor::ArtifactVendor;
 use lock::LockedImage;
 pub(crate) use lock::VerificationTagger;
+use path_absolutize::Absolutize;
 
 use self::lock::{Lock, LockedSDK, Override};
 use crate::common::fs::{self, read_to_string};
@@ -108,7 +109,7 @@ impl Project<Unlocked> {
             dir.display()
         );
         let dir = dir
-            .canonicalize()
+            .absolutize()
             .context(format!("Unable to canonicalize '{}'", dir.display()))?;
         let filepath = dir.join("Twoliter.toml");
         if filepath.is_file() {


### PR DESCRIPTION
**Issue number:**

Closes #427

**Description of changes:**
Twoliter uses the location of `Twoliter.toml` to locate the rest of the Twoliter workspace. Prior to this change, it [used `std::fs::canonicalize`](https://doc.rust-lang.org/std/fs/fn.canonicalize.html) to do so. This function resolves symlinks on the filesystem, which is a problem when you're building in the context of a symlink farm.

This change moves to using [path-absolutize](https://crates.io/crates/path-absolutize) for such canoncicalization, which uses unix separator and path traversal semantics to "canonicalize" a path without resolving symlinks or actually consulting with the host's filesystem.

The change also adds clippy lints to attempt to forbid future use of canonicalization functions that can cause this to regress.

See https://github.com/bottlerocket-os/twoliter/issues/427 for more details.


**Testing done:**
* New integration tests pass
* Created a twoliter workspace where `Twoliter.toml` was a symlink to another workspace. Issuing a build on the old version caused build artifacts to be placed in the `build` directory behind the symlink. With the new change, build artifacts were placed in the new workspace as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
