### PR TITLE
Cross build golang in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,3 +21,30 @@ jobs:
         with:
           go-version: "^1.18"
       - run: make build
+
+  cross-build:
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_16-core
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+          - target: aarch64-unknown-linux-musl
+    env:
+      TARGET_TRIPLE: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Cross
+        # Pin cargo cross to a version that we know is working for us.
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross/ --rev 7b79041 --locked
+      - run: |
+          # cargo-cross warns us that multiple cross configurations are present in our
+          # workspace (ie dependencies have configurations), but it picks the appropriate one from
+          # the twoliter workspace.
+          #
+          # These warnings cause the tool to fail, so we disable them.
+          export CROSS_NO_WARNINGS=0
+
+          cross build --release --bin twoliter --target "${TARGET_TRIPLE}"

--- a/tools/krane/build.rs
+++ b/tools/krane/build.rs
@@ -3,6 +3,11 @@ use std::path::PathBuf;
 use std::process::Command;
 
 const REQUIRED_TOOLS: &[&str] = &["go"];
+const CFLAGS: &str = concat!(
+    "-O2 -g -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS ",
+    "-fexceptions -fstack-clash-protection -fno-omit-frame-pointer",
+);
+const LDFLAGS: &str = "-Wl,-z,relro -Wl,-z,now";
 
 fn main() {
     let script_dir = env::current_dir().unwrap();
@@ -16,10 +21,22 @@ fn main() {
     let build_output_loc = out_dir.join("libkrane.a");
     let mut build_command = Command::new("go");
 
+    let curr_cflags = env::var("CFLAGS").unwrap_or_default();
+    let desired_cflags = format!("{curr_cflags} {CFLAGS}");
+
+    let curr_ldflags = env::var("LDFLAGS").unwrap_or_default();
+    let desired_ldflags = format!("{curr_ldflags} {LDFLAGS}");
+
     build_command
         .env("GOOS", get_goos())
         .env("GOARCH", get_goarch())
         .env("CGO_ENABLED", "1")
+        .env("CFLAGS", &desired_cflags)
+        .env("CGO_CFLAGS", &desired_cflags)
+        .env("CXXFLAGS", &desired_cflags)
+        .env("CGO_CXXFLAGS", &desired_cflags)
+        .env("LDFLAGS", &desired_ldflags)
+        .env("CGO_LDFLAGS", &desired_ldflags)
         .arg("build")
         .arg("-buildmode=c-archive")
         .arg("-o")


### PR DESCRIPTION
**Description of changes:**
`cargo-cross` builds of `krane-static` were failing. This:
* Explicitly enables CGO when building golang sources
* Attempts to detect the cross build environment and configure the cross-compiler when building `krane-static`
* Runs `cargo-cross` for PRs to twoliter to catch such errors ahead of time in the future.

**Testing done:**
* Successfully cross-built twoliter for aarch64 on an x86_64 machine.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
