### PR TITLE
rpm2kit: drop unnecessary "--all" argument

### DIFF
--- a/twoliter/embedded/rpm2kit
+++ b/twoliter/embedded/rpm2kit
@@ -40,7 +40,7 @@ for pkg in ${PACKAGES} ; do
 done
 
 createrepo_c "${KIT_DIR}"
-dnf --disablerepo '*' --repofrompath "kit,file:///${KIT_DIR}" repoquery --all
+dnf --disablerepo '*' --repofrompath "kit,file:///${KIT_DIR}" repoquery
 
 WORK_DIR="$(mktemp -d)"
 


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
In dnf4, "--all" is the long way of writing "*", which is also the default if no argument is specified.

It's no longer supported in dnf5, so just get rid of it.


**Testing done:**
Built kits with a newer SDK based on Fedora 41, which uses dnf5.

Verified that the list of RPMs in the kit is still logged:
```
  #6 7.983 Added kit repo from file:////output/x86_64
  #6 8.030 kit                                              65 MB/s | 131 kB     00:00····
  #6 8.102 bottlerocket-amazon-ecs-cni-plugins-1:2020.09.0-1.1734645357.036202ea8.br1.x86_64
  #6 8.102 bottlerocket-amazon-ecs-cni-plugins-bin-1:2020.09.0-1.1734645357.036202ea8.br1.x86_64
  #6 8.102 bottlerocket-amazon-ecs-cni-plugins-ecs-agent-extras-1:2020.09.0-1.1734645357.036202ea8.br1.x86_64
  #6 8.102 bottlerocket-amazon-ecs-cni-plugins-ecs-agent-fips-extras-1:2020.09.0-1.1734645357.036202ea8.br1.x86_64
  #6 8.102 bottlerocket-amazon-ecs-cni-plugins-fips-bin-1:2020.09.0-1.1734645357.036202ea8.br1.x86_64
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
