### PR TITLE
fix syntax warnings from newer versions of Docker

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -691,6 +691,15 @@ impl DockerBuild {
         args.build_arg("NOCACHE", &self.common_build_args.nocache);
         args.build_arg("TOKEN", &self.common_build_args.token);
         args.build_arg("OUTPUT_SOCKET", &self.common_build_args.output_socket);
+
+        // Skip some build checks:
+        // - InvalidDefaultArgInFrom warns about the SDK argument, which is always set
+        // - SecretsUsedInArgOrEnv warns about the TOKEN argument, which is not a secret
+        args.build_arg(
+            "BUILDKIT_DOCKERFILE_CHECK",
+            "skip=InvalidDefaultArgInFrom,SecretsUsedInArgOrEnv",
+        );
+
         args
     }
 }

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -16,7 +16,7 @@ ARG SDK
 ARG ARCH
 ARG GOARCH
 
-FROM ${SDK} as sdk
+FROM ${SDK} AS sdk
 
 ############################################################################################
 # Section 1: The following build stages are used to build rpm.spec packages
@@ -194,7 +194,7 @@ COPY --from=kitbuild /tmp/.${NOCACHE} /
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Generate the expected RPM macros and bconds.
-FROM sdk as rpm-macros-and-bconds
+FROM sdk AS rpm-macros-and-bconds
 ARG VARIANT
 ARG VARIANT_PLATFORM
 ARG VARIANT_RUNTIME
@@ -314,7 +314,7 @@ RUN --mount=target=/host \
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Builds a Bottlerocket image.
-FROM repobuild as imgbuild
+FROM repobuild AS imgbuild
 ARG ARCH
 ARG VERSION_ID
 ARG BUILD_ID
@@ -385,7 +385,7 @@ RUN --mount=target=/host \
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an archive of the datastore migrations.
-FROM repobuild as migrationbuild
+FROM repobuild AS migrationbuild
 ARG ARCH
 ARG VERSION_ID
 ARG BUILD_ID
@@ -417,7 +417,7 @@ RUN --mount=target=/host \
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an archive of kernel development sources and toolchain.
-FROM repobuild as kmodkitbuild
+FROM repobuild AS kmodkitbuild
 # The list of packages from the variant Cargo.toml package.metadata.build-variant.packages section.
 ARG PACKAGES
 ARG ARCH
@@ -461,7 +461,7 @@ COPY --from=kmodkitbuild /tmp/.${NOCACHE} /output/
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Repack an existing image.
-FROM sdk as imgrepack
+FROM sdk AS imgrepack
 ARG ARCH
 ARG VERSION_ID
 ARG BUILD_ID


### PR DESCRIPTION
**Issue number:**
Fixes #436

**Description of changes:**
Align case for `FROM` and `AS`, and suppress checks that don't apply.


**Testing done:**
Verified that the warnings are no longer logged.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
