### PR TITLE
VOLUME_TYPE: gp2 -> gp3

### DIFF
--- a/tools/pubsys/src/aws/ami/register.rs
+++ b/tools/pubsys/src/aws/ami/register.rs
@@ -15,7 +15,7 @@ const DATA_DEVICE_NAME: &str = "/dev/xvdb";
 
 // Features we assume/enable for the images.
 const VIRT_TYPE: &str = "hvm";
-const VOLUME_TYPE: &str = "gp2";
+const VOLUME_TYPE: &str = "gp3";
 const SRIOV: &str = "simple";
 const ENA: bool = true;
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** https://github.com/bottlerocket-os/bottlerocket/issues/4000#issuecomment-2342962331
It relates to this issue but I don't think this will change how Bottlerocket is released today, that seems to be closed sources ?


**Description of changes:** Set EBS disk type to gp3 instead of gp2

**Testing done:** on twoliter itself, just cargo test. On Bottlerocket, it's the setup I've been using for a while, benchmarks show no difference.


Note that gp3 was already used in other parts of the code.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
