### PR TITLE
imghelper: set AWS_CA_BUNDLE if cert is available

### DIFF
--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -430,6 +430,11 @@ sbsetup_wrapup() {
 }
 
 sbsetup_aws_profile() {
+  # Use the CA bundle override as the AWS CA cert bundle, if present.
+  if [[ -s "/root/certs/ca-bundle.crt" ]]; then
+    cp /root/certs/ca-bundle.crt /etc/pki/tls/cert.pem
+    export AWS_CA_BUNDLE=/etc/pki/tls/cert.pem
+  fi
   # Set AWS environment variables from build secrets, if present.
   local var val
   for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN; do


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

If a CA-Bundle is set using a secret mount and present, it will update the SDK to use these certs instead. Also sets the aws variable AWS_CA_BUNDLE if there is a secret mount. The secret mount is created when we pass a CABundle via override using the environment variable `BUILDSYS_CACERTS_BUNDLE_OVERRIDE`.

Note: I tried setting `SSL_CERT_FILE` variable instead but it causes the curl utility in [aws-kms-pkcs11](https://github.com/JackOfMostTrades/aws-kms-pkcs11) to fail.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
