### PR TITLE
twoliter: do not exit early with docker not on path

### DIFF
--- a/twoliter/src/preflight.rs
+++ b/twoliter/src/preflight.rs
@@ -3,7 +3,7 @@
 use anyhow::{ensure, Result};
 use which::which_global;
 
-const REQUIRED_TOOLS: &[&str] = &["docker", "gzip", "lz4"];
+const REQUIRED_TOOLS: &[&str] = &["gzip", "lz4"];
 
 /// Runs all common setup required for twoliter.
 ///


### PR DESCRIPTION
**Description of changes:**
* #442 removed the `docker` binary version check, but we still mistakenly check for `docker` being a binary on the `PATH`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
