### PR TITLE
Drop k8s 1.24

### DIFF
--- a/tools/bottlerocket-variant/src/lib.rs
+++ b/tools/bottlerocket-variant/src/lib.rs
@@ -56,9 +56,9 @@ pub mod error {
 ///
 /// For example, here are some valid variant strings:
 /// - aws-ecs-1
-/// - vmware-k8s-1.23
+/// - vmware-k8s-1.32
 /// - metal-dev
-/// - aws-k8s-1.24-nvidia
+/// - aws-k8s-1.32-nvidia
 ///
 /// The `platform` and `runtime` values are required. `variant_version` and `variant_flavor` values
 /// are optional and will default to `"0"` and `"none"` respectively.
@@ -70,10 +70,10 @@ pub mod error {
 ///
 /// ```rust
 /// use bottlerocket_variant::{Variant, VARIANT_ENV};
-/// std::env::set_var(VARIANT_ENV, "metal-k8s-1.24");
+/// std::env::set_var(VARIANT_ENV, "vmware-k8s-1.32");
 /// let variant = Variant::from_env().unwrap();
 ///
-/// assert_eq!(variant.version().unwrap(), "1.24");
+/// assert_eq!(variant.version().unwrap(), "1.32");
 ///
 /// // In a `build.rs` file, you may want to emit cfgs that you can use for conditional compilation.
 /// variant.emit_cfgs();
@@ -96,9 +96,9 @@ impl Variant {
     /// # Valid Values
     ///
     /// - `aws-dev`
-    /// - `vmware-k8s-1.24`
-    /// - `aws-k8s-1.24-nvidia`
-    /// - `aws-k8s-1.24-nvidia-some-additional-ignored-tuple-positions`
+    /// - `vmware-k8s-1.32`
+    /// - `aws-k8s-1.32-nvidia`
+    /// - `aws-k8s-1.32-nvidia-some-additional-ignored-tuple-positions`
     ///
     /// # Invalid Values
     ///
@@ -130,13 +130,13 @@ impl Variant {
     }
 
     /// The variant's runtime. This is the second member of the tuple. For example, in
-    /// `metal-k8s-1.24`, `k8s` is the `runtime`.
+    /// `vmware-k8s-1.32`, `k8s` is the `runtime`.
     pub fn runtime(&self) -> &str {
         &self.runtime
     }
 
     /// The variant's family. This is the `platform` and `runtime` together. For example, in
-    /// `aws-k8s-1.24`, `aws-k8s` is the `family`.
+    /// `aws-k8s-1.32`, `aws-k8s` is the `family`.
     pub fn family(&self) -> &str {
         &self.family
     }
@@ -149,7 +149,7 @@ impl Variant {
     }
 
     /// The variant's flavor. This is the optional fourth value in the variant string tuple. For
-    /// example for `aws-k8s-1.24-nvidia` the `variant_flavor` is `nvidia`.
+    /// example for `aws-k8s-1.32-nvidia` the `variant_flavor` is `nvidia`.
     pub fn variant_flavor(&self) -> Option<&str> {
         self.variant_flavor.as_deref()
     }
@@ -166,14 +166,14 @@ impl Variant {
     ///
     /// # Example
     ///
-    /// Given a variant `aws-k8s-1.24`, if this function has been called in `build.rs`, then
+    /// Given a variant `aws-k8s-1.32`, if this function has been called in `build.rs`, then
     /// all of the following conditional complition checks would evaluate to `true`.
     ///
-    /// `#[cfg(variant = "aws-k8s-1.24")]`
+    /// `#[cfg(variant = "aws-k8s-1.32")]`
     /// `#[cfg(variant_platform = "aws")]`
     /// `#[cfg(variant_runtime = "k8s")]`
     /// `#[cfg(variant_family = "aws-k8s")]`
-    /// `#[cfg(variant_version = "1.24")]`
+    /// `#[cfg(variant_version = "1.32")]`
     /// `#[cfg(variant_flavor = "none")]`
     pub fn emit_cfgs(&self) {
         Self::rerun_if_changed();
@@ -407,11 +407,11 @@ fn parse_ok() {
             variant_flavor: None,
         },
         Test {
-            input: "aws-k8s-1.24-nvidia-some-additional-ignored-tuple-positions",
+            input: "aws-k8s-1.32-nvidia-some-additional-ignored-tuple-positions",
             platform: "aws",
             runtime: "k8s",
             variant_family: "aws-k8s",
-            variant_version: Some("1.24"),
+            variant_version: Some("1.32"),
             variant_flavor: Some("nvidia"),
         },
     ];
@@ -430,7 +430,7 @@ fn parse_ok() {
 
 #[test]
 fn parse_err() {
-    let tests = vec!["aws", "aws-", "aws-dev-", "aws-k8s-1.24-"];
+    let tests = vec!["aws", "aws-", "aws-dev-", "aws-k8s-1.32-"];
     for test in tests {
         let result = Variant::new(test);
         assert!(

--- a/tools/testsys/Test.toml.example
+++ b/tools/testsys/Test.toml.example
@@ -120,6 +120,6 @@ instance-type = "p3.2xlarge"
 [aws-ecs-nvidia.aarch64]
 instance-type = "g5g.2xlarge"
 
-# Configuration for only the `aws-k8s-1.24` variant (variant level configuration).
-["aws-k8s-1.24".aarch64]
+# Configuration for only the `aws-k8s-1.32` variant (variant level configuration).
+["aws-k8s-1.32".aarch64]
 conformance-image = "<KUBERNETES-CONFORMANCE-IMAGE-URI>"

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -33,7 +33,7 @@ BUILDSYS_VERSION_BUILD_TIMESTAMP = { script = ["git show -s --format=%ct HEAD ||
 # use a different Release.toml.
 BUILDSYS_RELEASE_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Release.toml"
 # This can be overridden with -e to build a different variant from the variants/ directory
-BUILDSYS_VARIANT = { script = ['echo "${BUILDSYS_VARIANT:-aws-k8s-1.24}"'] }
+BUILDSYS_VARIANT = { script = ['echo "${BUILDSYS_VARIANT:-aws-k8s-1.32}"'] }
 # Product name used for file and directory naming
 BUILDSYS_NAME = "bottlerocket"
 # "Pretty" name used to identify OS in os-release, bootloader, etc.


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/4359

**Description of changes:**

Amazon EKS will end extended support of [Kubernetes 1.24 on January 31, 2025](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar). Support for the `aws-k8s-1.24*` variants of Bottlerocket will end on the same date. 

As a result, we are dropping references to k8s 1.24 variants in twoliter.

**Testing done:**

Edited tests in `tools/bottlerocket-variant/src/lib.rs` pass with `cargo test`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
