### PR TITLE
buildsys: improve upstream source fallback logging

### DIFF
--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -93,8 +93,7 @@ impl LookasideCache {
                 Err(e) => {
                     // next check with upstream, if permitted
                     if f.force_upstream.unwrap_or(false) || self.upstream_fallback {
-                        println!("Error fetching from lookaside cache: {}", e);
-                        println!("Fetching {:?} from upstream source", url_file_name);
+                        println!("Source not found in lookaside-cache. Fetching {:?} from upstream source", url_file_name);
                         self.fetch_file(&f.url, &tmp, hash)?;
                         fs::rename(&tmp, path)
                             .context(error::ExternalFileRenameSnafu { path: &tmp })?;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #453 

**Description of changes:**

Adjust logging when upstream sources are used directly for building a package.

**Testing done:**

`cargo build`

`cargo test`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
