### PR TITLE
build: use consistent length for project build ID

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -24,7 +24,7 @@ BUILDSYS_CACERTS_BUNDLE_OVERRIDE = ""
 BUILDSYS_METADATA_DIR = "${BUILDSYS_BUILD_DIR}/metadata"
 BUILDSYS_CARGO_METADATA_PATH = "${BUILDSYS_METADATA_DIR}/cargo_metadata.json"
 BUILDSYS_SBKEYS_PROFILE = { script = ['echo "${BUILDSYS_SBKEYS_PROFILE:-local}"'] }
-BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*' || echo 00000000"] }
+BUILDSYS_VERSION_BUILD = { script = ["git describe --always --dirty --exclude '*' --abbrev=8 || echo 00000000"] }
 # The unix timestamp in ms of the latest commit of the project.
 # This is an input for setting the Release value of a package.
 BUILDSYS_VERSION_BUILD_TIMESTAMP = { script = ["git show -s --format=%ct HEAD || echo 0000000000"] }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

git describe returns a SHA1 of variable length depending on the number
of objects in a git repository
https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1

For example, at time of writing bottlerocket-kernel-kit returns a SHA1
with a length of 7, whereas the bottlerocket-core-kit returns a SHA1 of
length 8. This is due to the bottlerocket-kernel-kit having a much
smaller git history than the core-kit (or bottlerocket-os/bottlerocket)

the build ID is used in application inventory generation. Application
inventory is used by various software to evaluate vulnerability
applicability along with Bottlerocket's updateinfo.xml. The build ID
length being non-deterministic resulted in inconsistencies for
comparisons between the updateinfo.xml generated by Bottlerocket and the
application inventory embedded into Bottlerocket AMIs.

This commit sets a consistent length of 8 for commits returned by git
describe and used as project build ID. This is done for
historical purposes given advisories published to
https://advisories.bottlerocket.aws/updateinfo.xml.gz have been
referenced with their build ID.



**Testing done:**

`cargo test`

Run `git describe --always --dirty --exclude '*' --abbrev=8` in various git repos

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
