### PR TITLE
fixes for dnf5 compatibility

### DIFF
--- a/twoliter/embedded/rpm2kmodkit
+++ b/twoliter/embedded/rpm2kmodkit
@@ -45,8 +45,7 @@ popd >/dev/null
 
 # Merge them together into a unified archive.
 pushd "${KIT_DIR}" >/dev/null
-tar cf "${OUTPUT_DIR}/${KMOD_KIT_FULL}.tar" "${KMOD_KIT}"
-xz -T0 "${OUTPUT_DIR}/${KMOD_KIT_FULL}.tar"
+XZ_OPT='-T0' tar cfJ "${OUTPUT_DIR}/${KMOD_KIT_FULL}.tar.xz" "${KMOD_KIT}"
 popd >/dev/null
 
 # Create friendly symlinks.


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/244

**Description of changes:**
Adjust the `dnf` invocation prior to `rpm2img` so that it can download RPMs with both `dnf4` and `dnf5`.

Fix a weird `xz` failure by compressing during archive creation, which is more efficient in any case.


**Testing done:**
Kits built fine with the new SDK before this change, but variants did not. I tested variant builds with and without the SDK update and verified that they worked both ways.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
