### PR TITLE
bump kit metadata version to coincide with advisory generation changes

### DIFF
--- a/twoliter/src/compatibility.rs
+++ b/twoliter/src/compatibility.rs
@@ -8,4 +8,4 @@ pub const SUPPORTED_TWOLITER_PROJECT_SCHEMA_VERSION: u32 = 1;
 ///
 /// The kit metadata version is embeddeded in a label within the OCI image's configuration blob,
 /// with the value stored at that label including the kit metadata itself.
-pub const SUPPORTED_KIT_METADATA_VERSION: &str = "v2";
+pub const SUPPORTED_KIT_METADATA_VERSION: &str = "v3";


### PR DESCRIPTION
* Bumps the kit metadata version to ensure incompatibility check with kit versions due to changes in advisory generation

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
