### PR TITLE
chore: prepare release 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.7.3...HEAD
 
-## [0.7.3-rc] - 2024-02-20
+## [0.7.3] - 2024-02-21
 
 ### Changed
 
 - Improve upstream source fallback logging ([#454])
 - Use a consistent length for project build ID ([#456])
-- Update kit metadata schema version to v3 due to changes in advisory generation ([#459])
+- Update kit metadata schema version to v3 due to changes in advisory generation ([#459], [#461])
 
 [#454]: https://github.com/bottlerocket-os/twoliter/pull/454
 [#456]: https://github.com/bottlerocket-os/twoliter/pull/456
 [#459]: https://github.com/bottlerocket-os/twoliter/pull/459
+[#461]: https://github.com/bottlerocket-os/twoliter/pull/461
 
 [0.7.3]: https://github.com/bottlerocket-os/twoliter/compare/v0.7.1...v0.7.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.7.3-rc2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.15", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.15" }
-twoliter = { version = "0.7.3-rc2", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.7.3", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.7.3-rc2"
+version = "0.7.3"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Release 0.7.3 including a bump to the kit metadata

**Testing done:**
* Build of a core kit
* Build of a kernel kit

* Tested that with build 0.7.3-rc2 that twoliter errors when trying to use older kits:

```
Error: kit appears to be built with metadata version 'v2', possibly by an older version of twoliter with unsupported incompatibilities. This version of twoliter supports metadata version 'v3'.
```

* Tested that older twoliter (0.7.2) errors when trying to use a newer kit:

```
[fedora@ip-172-31-15-80 bottlerocket]$ tools/twoliter/twoliter --version
twoliter 0.7.2
[fedora@ip-172-31-15-80 bottlerocket]$ tools/twoliter/twoliter update
[2025-02-21T23:39:56Z WARN  twoliter::project] A Release.toml file was found. Release.toml is deprecated. Please remove it from your project.
[2025-02-21T23:39:56Z INFO  twoliter::project::lock] Resolving project references to create lock file
[2025-02-21T23:39:56Z INFO  twoliter::project::lock::image] Resolving dependency image dependency 'bottlerocket-kernel-kit-1.1.2@247242824936.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-kernel-kit:v1.1.2'.
Error: kit appears to be built with metadata version 'v3', possibly by a newer version of twoliter with unsupported incompatibilities. This version of twoliter supports metadata version 'v2'.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
