### PR TITLE
twoliter: add check-advisories task to lint BRSAs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,9 +20,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "^1.18"
-      # Install `patch`, needed to build `krane-bundle`
-      - run: sudo apt-get install -y patch
-      - run: make build
+      # Install `patch`, needed to build `krane-bundle`, and tools for linking against musl
+      - run: sudo apt-get install -y patch musl-tools musl-dev
+      - run: rustup target add x86_64-unknown-linux-musl
+      - run: CARGO_BUILD_TARGET=x86_64-unknown-linux-musl make build
 
   cross-build:
     runs-on:

--- a/clarify.toml
+++ b/clarify.toml
@@ -5,7 +5,7 @@ license-files = [
     { path = "COPYING", hash = 0x278afbcf },
     { path = "LICENSE-APACHE", hash = 0x24b54f4b },
     { path = "LICENSE-MIT", hash = 0x462dee44 },
-    { path = "src/unicode/data/LICENSE-UNICODE", hash = 0x70f7339 },
+    { path = "src/unicode/data/LICENSE-UNICODE", hash = 0x70f7339  },
 ]
 
 [clarify.petgraph]
@@ -26,6 +26,23 @@ license-files = [
     { path = "LICENSE-MIT", hash = 0xb755395b },
     { path = "src/unicode_tables/LICENSE-UNICODE", hash = 0xa7f28b93 },
 ]
+
+[clarify.rust-fuzzy-search]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0xbde481e5 },
+    { path = "LICENSE-MIT", hash = 0xb5a90d39 },
+]
+skip-files = [
+    # these licenses apply to documentation
+    "target/doc/FiraSans-LICENSE.txt",
+    "target/doc/COPYRIGHT.txt",
+    "target/doc/LICENSE-APACHE.txt",
+    "target/doc/LICENSE-MIT.txt",
+    "target/doc/SourceCodePro-LICENSE.txt",
+    "target/doc/SourceSerif4-LICENSE.md",
+]
+
 
 [clarify.typenum]
 expression = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -78,8 +78,6 @@ skip = [
     { name = "tabled", version = "0.15.0" },
     # multiple deps are using an older version of tabled_derive
     { name = "tabled_derive", version = "0.7.0" },
-    # multiple deps are using an older version of zerocopy
-    { name = "zerocopy", version = "0.7.35" },
 ]
 
 skip-tree = [
@@ -90,9 +88,9 @@ skip-tree = [
     { name = "windows-sys" },
 ]
 
-[bans.workspace-dependencies]    
-duplicates = "deny"                                                                                                                                                                                                                                   
-include-path-dependencies = true    
+[bans.workspace-dependencies]
+duplicates = "deny"
+include-path-dependencies = true
 unused = "deny"
 
 [sources]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # particular date of the nightly compiler, but we want builds to be reproducable, so we lock to a
 # specific, recent instance of nightly.
 [toolchain]
-channel = "nightly-2024-07-11"
+channel = "nightly-2025-02-28"
 profile = "default"

--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -159,7 +159,7 @@ impl LookasideCache {
         let name = parsed
             .path_segments()
             .context(error::ExternalFileNameSnafu { path: url })?
-            .last()
+            .next_back()
             .context(error::ExternalFileNameSnafu { path: url })?;
         Ok(name.into())
     }

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -162,7 +162,7 @@ fn extract_file_name(url: &str) -> Result<PathBuf> {
     let name = parsed
         .path_segments()
         .context(error::InputFileBadSnafu { path: url })?
-        .last()
+        .next_back()
         .context(error::InputFileBadSnafu { path: url })?;
     Ok(name.into())
 }

--- a/tools/oci-cli-wrapper/src/lib.rs
+++ b/tools/oci-cli-wrapper/src/lib.rs
@@ -3,14 +3,14 @@
 //!
 //! Current two tools are supported:
 //! * crane, gcrane, krane
-//!     Crane provides a more direct interaction with the container registry,
-//!     allowing us to query image information in the registry without having to pull the full image to
-//!     disk. It also does not require a daemon to operate and has optimizations for pulling large images to disk
+//!   Crane provides a more direct interaction with the container registry,
+//!   allowing us to query image information in the registry without having to pull the full image to
+//!   disk. It also does not require a daemon to operate and has optimizations for pulling large images to disk
 //! * docker
-//!     Docker can perform all interactions we need with several caveats that make it less efficient than
-//!     crane. The image needs to be pulled locally in order for docker to inspect the manifest and extract
-//!     metadata. In addition, in order to operate with OCI image format, the containerd-snapshotter
-//!     feature has to be enabled in the docker daemon
+//!   Docker can perform all interactions we need with several caveats that make it less efficient than
+//!   crane. The image needs to be pulled locally in order for docker to inspect the manifest and extract
+//!   metadata. In addition, in order to operate with OCI image format, the containerd-snapshotter
+//!   feature has to be enabled in the docker daemon
 use std::fmt::{Display, Formatter};
 use std::{collections::HashMap, path::Path};
 

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -114,8 +114,8 @@ pub(crate) struct AmiImage {
 }
 
 /// Create a CRD to launch Bottlerocket instances on an EKS or ECS cluster.
-pub(crate) async fn ec2_crd<'a>(
-    bottlerocket_input: BottlerocketInput<'a>,
+pub(crate) async fn ec2_crd(
+    bottlerocket_input: BottlerocketInput<'_>,
     cluster_type: ClusterType,
     region: &str,
 ) -> Result<Resource> {
@@ -231,8 +231,8 @@ pub(crate) async fn ec2_crd<'a>(
 }
 
 /// Create a CRD to launch Bottlerocket instances on an EKS or ECS cluster.
-pub(crate) async fn ec2_karpenter_crd<'a>(
-    bottlerocket_input: BottlerocketInput<'a>,
+pub(crate) async fn ec2_karpenter_crd(
+    bottlerocket_input: BottlerocketInput<'_>,
     region: &str,
 ) -> Result<Resource> {
     let cluster_name = bottlerocket_input

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -36,7 +36,7 @@ pub struct CrdInput<'a> {
     pub images: TestsysImages,
 }
 
-impl<'a> CrdInput<'a> {
+impl CrdInput<'_> {
     /// Retrieve the TUF repo information from `Infra.toml`
     pub fn tuf_repo_config(&self) -> Option<TufRepoConfig> {
         if let (Some(metadata_base_url), Some(targets_url)) = (

--- a/tools/update-metadata/src/lib.rs
+++ b/tools/update-metadata/src/lib.rs
@@ -311,7 +311,7 @@ impl Update {
             .waves
             .range((Included(0), Excluded(seed)))
             .map(|(k, v)| (*k, *v))
-            .last();
+            .next_back();
         let end_wave = self
             .waves
             .range((Included(seed), Included(MAX_SEED)))

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -416,6 +416,7 @@ done
 [tasks.check]
 dependencies = [
    "check-cargo-version",
+   "check-advisories",
    "unit-tests",
    "check-fmt",
    "check-lints",
@@ -536,6 +537,61 @@ fi
 if [ "${rc}" -ne 0 ]; then
   echo "Found lint warnings. First-party shell code is checked with ShellCheck." >&2
   exit $rc
+fi
+'''
+]
+
+# Task to lint Bottlerocket Security Advisories by checking for valid CVE or GHSA IDs
+# and verifying that each versioned directory under "advisories" has a corresponding
+# tag on the Twoliter project this task runs against.
+[tasks.check-advisories]
+script_runner = "bash"
+script = [
+'''
+if find advisories -name '*.toml' -type f >/dev/null 2>&1 ; then
+
+  # Ensure each versioned advisories directory has a corresponding release tag.
+  for version in $(find advisories/* -type d -not -path advisories/staging); do
+    set +e; grep -q v$(basename ${version})$ <(PAGER= git tag); rc="$?"; set -e;
+    if [ "${rc}" -ne 0  ]; then
+      echo "error: no corresponding tag found for ${version} advisories directory" >&2
+      exit 1
+    fi
+  done
+
+
+  # Not all BRSAs might have a CVE; there can be cases where an advisory
+  # is for a GHSA, for example, but no corresponding CVE, and vice versa.
+  # Check separately for GHSA ID regex when a 'ghsa' is included and for
+  # CVE ID regex when a 'cve' is included.
+
+  # 1. If ghsa line exists and GHSA ID does not match regex, error
+
+  # Regex to strictly match a GHSA identifier in an advisory
+  # https://github.com/github/advisory-database?tab=readme-ov-file#ghsa-ids
+  ghsa_regex="^ghsa\s+=\s+\"GHSA(-[23456789cfghjmpqrvwx]{4}){3}\""
+
+  # Find all non-matching GHSA lines and report
+  ghsa_found="$(grep -L --include '*.toml' -R -P ${ghsa_regex} advisories | xargs awk '/ghsa/')"
+  if [ ! -z "${ghsa_found}"  ] ; then
+    echo "error: advisory GHSA ID did not match expression '${ghsa_regex}' and may contain non-ASCII characters" >&2
+    echo "${ghsa_found}" >&2
+    exit 1
+  fi
+
+  # 2. If cve line exists and CVE ID does not match regex, error
+
+  # Regex to strictly match CVE identifier in an advisory
+  # https://cve.mitre.org/cve/identifiers/tech-guidance.html#input_format
+  cve_regex="^cve\s+=\s+\"CVE-\d{4}-(0\d{3}|[1-9]\d{3,})\""
+
+  # Find all non-matching CVE lines and report
+  cve_found="$(grep -L --include '*.toml' -R -P ${cve_regex} advisories | xargs awk '/cve/')"
+  if [ ! -z "${cve_found}"  ] ; then
+    echo "error: advisory CVE ID did not match expression '${cve_regex}' and may contain non-ASCII characters" >&2
+    echo "${cve_found}" >&2
+    exit 1
+  fi
 fi
 '''
 ]

--- a/twoliter/src/project/lock/mod.rs
+++ b/twoliter/src/project/lock/mod.rs
@@ -1,7 +1,7 @@
-/// Covers the functionality and implementation of Twoliter.lock which is generated using
-/// `twoliter update`. It acts similarly to Cargo.lock as a flattened out representation of all kit
-/// and sdk image dependencies with associated digests so twoliter can validate that contents of a kit
-/// do not mutate unexpectedly.
+//! Covers the functionality and implementation of Twoliter.lock which is generated using
+//! `twoliter update`. It acts similarly to Cargo.lock as a flattened out representation of all kit
+//! and sdk image dependencies with associated digests so twoliter can validate that contents of a kit
+//! do not mutate unexpectedly.
 
 /// Contains operations for working with an OCI Archive
 mod archive;

--- a/twoliter/src/project/lock/verification.rs
+++ b/twoliter/src/project/lock/verification.rs
@@ -101,9 +101,6 @@ impl LockfileVerifier for Lock {
     }
 }
 
-/// A `LockfileVerifier` can return a set of `VerifyTag` structs, claiming that those artifacts
-/// have been resolved and verified against the lockfile.
-
 /// Writes marker files indicating which artifacts have been resolved and verified against the lock
 #[derive(Debug)]
 pub(crate) struct VerificationTagger {

--- a/twoliter/src/project/vendor.rs
+++ b/twoliter/src/project/vendor.rs
@@ -98,7 +98,7 @@ impl OverriddenVendor {
             .unwrap_or(&self.original_vendor.registry)
     }
 
-    pub(crate) fn repo_for<'a, V: VendedArtifact>(&'a self, image: &'a V) -> &str {
+    pub(crate) fn repo_for<'a, V: VendedArtifact>(&'a self, image: &'a V) -> &'a str {
         self.override_
             .name
             .as_deref()


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #466 

**Description of changes:**

Lint BRSAs for CVE / GHSA IDs in a new task, check-advisories. Also ensure that each directory under "advisories" in a project has an associated tag on the project.

Add this to the list in the meta task "check"

**Testing done:**

[x] Run against kernel-kit with bad CVE IDs

```
╭─fedora ~/kernel-kit  ‹v1.1.3*›
╰─➤  ./tools/twoliter/twoliter make check-advisories --cargo-home /home/fedora/kernel-kit/.cargo --arch $(uname -m)
[2025-02-28T20:20:24Z INFO  twoliter::project::lock] Resolving SDK project reference to check against lock file
[2025-02-28T20:20:25Z INFO  twoliter::project::lock::image] Resolving dependency image dependency 'bottlerocket-sdk-0.50.1@public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.50.1'.
[cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO -
[cargo-make] INFO - Build File: /home/fedora/kernel-kit/build/tools/Makefile.toml
[cargo-make] INFO - Task: check-advisories
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: check-advisories
error: advisory CVE ID did not match expression '^cve\s+=\s+"CVE-\d{4}-(0\d{3}|[1-9]\d{3,})"' and may contain non-ASCII characters
cve = "CVE‑2024‑53869"
cve = "CVE‑2024‑0150"
cve = "CVE‑2024‑0131"
cve = "CVE‑2024‑0149"
cve = "CVE‑2024‑0147"
Error while executing command, exit code: 1
Error: Command was unsuccessful, exit code 105
```

Fixed in https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/55

[x] Run against kernel-kit with bad GHSA ID (mocked advisory)

```
╰─➤  ./tools/twoliter/twoliter make check-advisories --cargo-home /home/fedora/kernel-kit/.cargo --arch $(uname -m)
[2025-02-28T20:22:47Z INFO  twoliter::project::lock] Resolving SDK project reference to check against lock file
[2025-02-28T20:22:47Z INFO  twoliter::project::lock::image] Resolving dependency image dependency 'bottlerocket-sdk-0.50.1@public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.50.1'.
[cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO -
[cargo-make] INFO - Build File: /home/fedora/kernel-kit/build/tools/Makefile.toml
[cargo-make] INFO - Task: check-advisories
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: check-advisories
error: advisory GHSA ID did not match expression '^ghsa\s+=\s+"GHSA(-[23456789cfghjmpqrvwx]{4}){3}"' and may contain non-ASCII characters
ghsa = "GHSA-0000-5224-cccc"
Error while executing command, exit code: 1
Error: Command was unsuccessful, exit code 105
```

[x] Run in a Twoliter project without an `advisories` subdirectory

After ASCII fixes, run against kernel-kit:

```
╭─fedora ~/kernel-kit  ‹develop*›
╰─➤  ./tools/twoliter/twoliter make check-advisories --cargo-home /home/fedora/kernel-kit/.cargo --arch $(uname -m)
[2025-02-25T22:57:43Z INFO  twoliter::project::lock] Resolving SDK project reference to check against lock file
[2025-02-25T22:57:43Z INFO  twoliter::project::lock::image] Resolving dependency image dependency 'bottlerocket-sdk-0.50.1@public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.50.1'.
[cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO -
[cargo-make] INFO - Build File: /home/fedora/kernel-kit/build/tools/Makefile.toml
[cargo-make] INFO - Task: check-advisories
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: check-advisories
[cargo-make] INFO - Build Done in 0.22 seconds.
```


Test case of unexpected directory under `advisories/`:

```
╭─fedora ~/kernel-kit  ‹develop*›
╰─➤  ls advisories
0  1.0.2  1.0.4  1.0.6  1.0.7  1.1.0  staging
╭─fedora ~/kernel-kit  ‹develop*›
╰─➤  ./tools/twoliter/twoliter make check-advisories --cargo-home /home/fedora/kernel-kit/.cargo --arch $(uname -m)
[2025-02-25T22:55:54Z INFO  twoliter::project::lock] Resolving SDK project reference to check against lock file
[2025-02-25T22:55:55Z INFO  twoliter::project::lock::image] Resolving dependency image dependency 'bottlerocket-sdk-0.50.1@public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.50.1'.
[cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO -
[cargo-make] INFO - Build File: /home/fedora/kernel-kit/build/tools/Makefile.toml
[cargo-make] INFO - Task: check-advisories
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: check-advisories
error: no corresponding tag found for advisories/0 directory
Error while executing command, exit code: 1
Error: Command was unsuccessful, exit code 105
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
