### PR TITLE
pubsys: add --dry-run mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
       labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
-      - run: cargo install cargo-deny --locked
+      - run: cargo install cargo-deny@0.17.0 --locked
       - run: cargo install cargo-make --locked
       - uses: actions/setup-go@v5
         with:

--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -15,7 +15,7 @@ use crate::Args;
 use aws_config::SdkConfig;
 use aws_sdk_ec2::{types::ArchitectureValues, Client as Ec2Client};
 use aws_sdk_ssm::{config::Region, Client as SsmClient};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use futures::stream::{StreamExt, TryStreamExt};
 use governor::{prelude::*, Quota, RateLimiter};
 use log::{error, info, trace};
@@ -32,6 +32,11 @@ use std::{
 
 /// Sets SSM parameters based on current build information
 #[derive(Debug, Parser)]
+#[command(group(
+    ArgGroup::new("dry_run_requirements")
+        .arg("dry_run")
+        .requires("ssm_parameter_output")
+))]
 pub(crate) struct SsmArgs {
     // This is JSON output from `pubsys ami` like `{"us-west-2": "ami-123"}`
     /// Path to the JSON file containing regional AMI IDs to modify
@@ -69,6 +74,10 @@ pub(crate) struct SsmArgs {
     /// If set, writes the generated SSM parameters to this path
     #[arg(long)]
     ssm_parameter_output: Option<PathBuf>,
+
+    /// Enables dry-run mode (only generates parameter manifest, does not update SSM)
+    #[arg(long)]
+    dry_run: bool,
 }
 
 /// Wrapper struct over parameter update and AWS clients needed to execute on it.
@@ -141,6 +150,12 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
             ssm_parameter_output,
             &RenderedParametersMap::from(&new_parameters).rendered_parameters,
         )?;
+    }
+
+    // Exit early if `--dry-run` is enabled
+    if ssm_args.dry_run {
+        info!("Dry-run mode enabled: Exiting after writing parameter manifest.");
+        return Ok(());
     }
 
     // Generate AWS Clients to use for the updates.

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1473,7 +1473,8 @@ pubsys \
    --ssm-parameter-output "${ssm_parameter_output}" \
    \
    ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"} \
-   ${ALLOW_CLOBBER:+--allow-clobber}
+   ${ALLOW_CLOBBER:+--allow-clobber} \
+   ${PUBLISH_SSM_DRY_RUN:+--dry-run}
 '''
 ]
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #356

**Description of changes:**
Add `--dry-run` flag to `pubsys ssm` subcommand, allowing users to generate a manifest of SSM parameter updates without actually modifying AWS SSM parameters. 

**Testing done:**

- [x] Exit early when `--dry-run` and `-ssm-parameter-output` set.
```
00:20:03 [INFO] Wrote rendered SSM parameters to "/local/home/qianxj/bottlerocket/build/images/x86_64-aws-k8s-1.30/1.25.0-f56453df/bottlerocket-aws-k8s-1.30-x86_64-1.25.0-f56453df-ssm-params.json"
00:20:03 [INFO] Dry-run mode enabled: Exiting after writing parameter manifest.
[cargo-make][1] INFO - Build Done in 0.29 seconds.
```
- [x] Error when `--ssm-parameter-output` not set when `--dry-run` enabled.
```
error: the following required arguments were not provided:
  --ssm-parameter-output <SSM_PARAMETER_OUTPUT>

Usage: pubsys --infra-config-path <INFRA_CONFIG_PATH> ssm --ami-input <AMI_INPUT> --arch <ARCH> --variant <VARIANT> --version <VERSION> --template-path <TEMPLATE_PATH> --ssm-parameter-output <SSM_PARAMETER_OUTPUT> --dry-run

For more information, try '--help'.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
