### PR TITLE
fix: move vendoring of cargo dependencies to cargo vendor

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -354,10 +354,20 @@ dependencies = ["setup"]
 script_runner = "bash"
 script = [
 '''
+declare -a CARGO_MANIFESTS
+# We make sure there is an empty folder at least here
+# to make the docker mount happy later on
+mkdir -p .cargo/vendor
 for ws in sources variants .; do
-  [ -s "${BUILDSYS_ROOT_DIR}/${ws}/Cargo.toml" ] || continue
-  cargo fetch --locked --manifest-path "${BUILDSYS_ROOT_DIR}/${ws}/Cargo.toml"
+  [ -s "${BUILDSYS_ROOT_DIR}/${ws}/Cargo.lock" ] || continue
+  CARGO_MANIFESTS+=(--sync "${BUILDSYS_ROOT_DIR}/${ws}/Cargo.toml")
 done
+cargo vendor --locked --no-delete  --versioned-dirs --respect-source-config  ${CARGO_MANIFESTS[@]} .cargo/vendor > .cargo/config.toml 2> .cargo/vendor.log || {
+   echo "vendoring of cargo dependencies failed"
+   cat .cargo/vendor.log
+   exit 1
+}
+rm .cargo/vendor.log
 
 chmod -R o+r ${CARGO_HOME}
 '''

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -109,7 +109,11 @@ RUN --mount=target=/host \
     rm /bypass
 
 USER builder
-RUN --mount=source=.cargo,target=/home/builder/.cargo \
+    # We only mount the config.toml and the vendor directory instead of the whole .cargo directory
+    # because the .git and .registry directories are specific to the version of cargo and can cause
+    # incapatibility between the host cargo and the cargo in the sdk
+RUN --mount=source=.cargo/config.toml,target=/home/builder/rpmbuild/.cargo/config.toml \
+    --mount=source=.cargo/vendor,target=/home/builder/rpmbuild/.cargo/vendor \
     --mount=type=cache,target=/home/builder/.cache,from=cache,source=/cache \
     --mount=source=sources,target=/home/builder/rpmbuild/BUILD/sources \
     --mount=target=/host \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Migrates how we vendor cargo dependencies to use cargo vendor and ensure we do not sync cargo internal directories in .cargo where incompatibilities can occur such as the one we are fixing:

https://github.com/bottlerocket-os/bottlerocket/issues/4415 


**Testing done:**

Built bob with a host using cargo 1.85.0 and verified that it builds sucessfully


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
