### PR TITLE
Update rust toolchain to nightly-2025-02-28

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,9 +20,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "^1.18"
-      # Install `patch`, needed to build `krane-bundle`
-      - run: sudo apt-get install -y patch
-      - run: make build
+      # Install `patch`, needed to build `krane-bundle`, and tools for linking against musl
+      - run: sudo apt-get install -y patch musl-tools musl-dev
+      - run: rustup target add x86_64-unknown-linux-musl
+      - run: CARGO_BUILD_TARGET=x86_64-unknown-linux-musl make build
 
   cross-build:
     runs-on:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
       labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
-      - run: cargo install cargo-deny@0.17.0 --locked
+      - run: cargo install cargo-deny --locked
       - run: cargo install cargo-make --locked
       - uses: actions/setup-go@v5
         with:

--- a/clarify.toml
+++ b/clarify.toml
@@ -27,6 +27,23 @@ license-files = [
     { path = "src/unicode_tables/LICENSE-UNICODE", hash = 0xa7f28b93 },
 ]
 
+[clarify.rust-fuzzy-search]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE-APACHE", hash = 0xbde481e5 },
+    { path = "LICENSE-MIT", hash = 0xb5a90d39 },
+]
+skip-files = [
+    # these licenses apply to documentation
+    "target/doc/FiraSans-LICENSE.txt",
+    "target/doc/COPYRIGHT.txt",
+    "target/doc/LICENSE-APACHE.txt",
+    "target/doc/LICENSE-MIT.txt",
+    "target/doc/SourceCodePro-LICENSE.txt",
+    "target/doc/SourceSerif4-LICENSE.md",
+]
+
+
 [clarify.typenum]
 expression = "MIT OR Apache-2.0"
 license-files = [

--- a/deny.toml
+++ b/deny.toml
@@ -78,8 +78,6 @@ skip = [
     { name = "tabled", version = "0.15.0" },
     # multiple deps are using an older version of tabled_derive
     { name = "tabled_derive", version = "0.7.0" },
-    # multiple deps are using an older version of zerocopy
-    { name = "zerocopy", version = "0.7.35" },
 ]
 
 skip-tree = [
@@ -90,9 +88,9 @@ skip-tree = [
     { name = "windows-sys" },
 ]
 
-[bans.workspace-dependencies]    
-duplicates = "deny"                                                                                                                                                                                                                                   
-include-path-dependencies = true    
+[bans.workspace-dependencies]
+duplicates = "deny"
+include-path-dependencies = true
 unused = "deny"
 
 [sources]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # particular date of the nightly compiler, but we want builds to be reproducable, so we lock to a
 # specific, recent instance of nightly.
 [toolchain]
-channel = "nightly-2024-07-11"
+channel = "nightly-2025-02-28"
 profile = "default"

--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -159,7 +159,7 @@ impl LookasideCache {
         let name = parsed
             .path_segments()
             .context(error::ExternalFileNameSnafu { path: url })?
-            .last()
+            .next_back()
             .context(error::ExternalFileNameSnafu { path: url })?;
         Ok(name.into())
     }

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -162,7 +162,7 @@ fn extract_file_name(url: &str) -> Result<PathBuf> {
     let name = parsed
         .path_segments()
         .context(error::InputFileBadSnafu { path: url })?
-        .last()
+        .next_back()
         .context(error::InputFileBadSnafu { path: url })?;
     Ok(name.into())
 }

--- a/tools/oci-cli-wrapper/src/lib.rs
+++ b/tools/oci-cli-wrapper/src/lib.rs
@@ -3,14 +3,14 @@
 //!
 //! Current two tools are supported:
 //! * crane, gcrane, krane
-//!     Crane provides a more direct interaction with the container registry,
-//!     allowing us to query image information in the registry without having to pull the full image to
-//!     disk. It also does not require a daemon to operate and has optimizations for pulling large images to disk
+//!   Crane provides a more direct interaction with the container registry,
+//!   allowing us to query image information in the registry without having to pull the full image to
+//!   disk. It also does not require a daemon to operate and has optimizations for pulling large images to disk
 //! * docker
-//!     Docker can perform all interactions we need with several caveats that make it less efficient than
-//!     crane. The image needs to be pulled locally in order for docker to inspect the manifest and extract
-//!     metadata. In addition, in order to operate with OCI image format, the containerd-snapshotter
-//!     feature has to be enabled in the docker daemon
+//!   Docker can perform all interactions we need with several caveats that make it less efficient than
+//!   crane. The image needs to be pulled locally in order for docker to inspect the manifest and extract
+//!   metadata. In addition, in order to operate with OCI image format, the containerd-snapshotter
+//!   feature has to be enabled in the docker daemon
 use std::fmt::{Display, Formatter};
 use std::{collections::HashMap, path::Path};
 

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -114,8 +114,8 @@ pub(crate) struct AmiImage {
 }
 
 /// Create a CRD to launch Bottlerocket instances on an EKS or ECS cluster.
-pub(crate) async fn ec2_crd<'a>(
-    bottlerocket_input: BottlerocketInput<'a>,
+pub(crate) async fn ec2_crd(
+    bottlerocket_input: BottlerocketInput<'_>,
     cluster_type: ClusterType,
     region: &str,
 ) -> Result<Resource> {
@@ -231,8 +231,8 @@ pub(crate) async fn ec2_crd<'a>(
 }
 
 /// Create a CRD to launch Bottlerocket instances on an EKS or ECS cluster.
-pub(crate) async fn ec2_karpenter_crd<'a>(
-    bottlerocket_input: BottlerocketInput<'a>,
+pub(crate) async fn ec2_karpenter_crd(
+    bottlerocket_input: BottlerocketInput<'_>,
     region: &str,
 ) -> Result<Resource> {
     let cluster_name = bottlerocket_input

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -36,7 +36,7 @@ pub struct CrdInput<'a> {
     pub images: TestsysImages,
 }
 
-impl<'a> CrdInput<'a> {
+impl CrdInput<'_> {
     /// Retrieve the TUF repo information from `Infra.toml`
     pub fn tuf_repo_config(&self) -> Option<TufRepoConfig> {
         if let (Some(metadata_base_url), Some(targets_url)) = (

--- a/tools/update-metadata/src/lib.rs
+++ b/tools/update-metadata/src/lib.rs
@@ -311,7 +311,7 @@ impl Update {
             .waves
             .range((Included(0), Excluded(seed)))
             .map(|(k, v)| (*k, *v))
-            .last();
+            .next_back();
         let end_wave = self
             .waves
             .range((Included(seed), Included(MAX_SEED)))

--- a/twoliter/src/project/lock/mod.rs
+++ b/twoliter/src/project/lock/mod.rs
@@ -1,7 +1,7 @@
-/// Covers the functionality and implementation of Twoliter.lock which is generated using
-/// `twoliter update`. It acts similarly to Cargo.lock as a flattened out representation of all kit
-/// and sdk image dependencies with associated digests so twoliter can validate that contents of a kit
-/// do not mutate unexpectedly.
+//! Covers the functionality and implementation of Twoliter.lock which is generated using
+//! `twoliter update`. It acts similarly to Cargo.lock as a flattened out representation of all kit
+//! and sdk image dependencies with associated digests so twoliter can validate that contents of a kit
+//! do not mutate unexpectedly.
 
 /// Contains operations for working with an OCI Archive
 mod archive;

--- a/twoliter/src/project/lock/verification.rs
+++ b/twoliter/src/project/lock/verification.rs
@@ -101,9 +101,6 @@ impl LockfileVerifier for Lock {
     }
 }
 
-/// A `LockfileVerifier` can return a set of `VerifyTag` structs, claiming that those artifacts
-/// have been resolved and verified against the lockfile.
-
 /// Writes marker files indicating which artifacts have been resolved and verified against the lock
 #[derive(Debug)]
 pub(crate) struct VerificationTagger {

--- a/twoliter/src/project/vendor.rs
+++ b/twoliter/src/project/vendor.rs
@@ -98,7 +98,7 @@ impl OverriddenVendor {
             .unwrap_or(&self.original_vendor.registry)
     }
 
-    pub(crate) fn repo_for<'a, V: VendedArtifact>(&'a self, image: &'a V) -> &str {
+    pub(crate) fn repo_for<'a, V: VendedArtifact>(&'a self, image: &'a V) -> &'a str {
         self.override_
             .name
             .as_deref()


### PR DESCRIPTION
**Description of changes:**
* Upgrade Rust's nightly compiler. This allows us to build against the latest `cargo-deny`.
* Modify CI to link against `musl` to avoid ABI incompatibilities with Bottlerocket's SDK

**Testing done:**
* CI on this commit.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
