### PR TITLE
fix: add minutes to parse-datetime for waves

### DIFF
--- a/tools/parse-datetime/src/lib.rs
+++ b/tools/parse-datetime/src/lib.rs
@@ -97,6 +97,10 @@ pub fn parse_offset(input: &str) -> Result<Duration> {
         .context(error::DateArgCountSnafu { input })?;
 
     let duration = match unit_str {
+        "minute" | "minutes" => Duration::try_minutes(i64::from(count)).context(error::DateIntSnafu {
+            integer: count,
+            unit: "minutes",
+        })?,
         "hour" | "hours" => Duration::try_hours(i64::from(count)).context(error::DateIntSnafu {
             integer: count,
             unit: "hours",
@@ -112,7 +116,7 @@ pub fn parse_offset(input: &str) -> Result<Duration> {
         _ => {
             return error::DateArgInvalidSnafu {
                 input,
-                msg: "date argument's unit must be hours/days/weeks",
+                msg: "date argument's unit must be minutes/hours/days/weeks",
             }
             .fail();
         }

--- a/tools/parse-datetime/src/lib.rs
+++ b/tools/parse-datetime/src/lib.rs
@@ -97,10 +97,12 @@ pub fn parse_offset(input: &str) -> Result<Duration> {
         .context(error::DateArgCountSnafu { input })?;
 
     let duration = match unit_str {
-        "minute" | "minutes" => Duration::try_minutes(i64::from(count)).context(error::DateIntSnafu {
-            integer: count,
-            unit: "minutes",
-        })?,
+        "minute" | "minutes" => {
+            Duration::try_minutes(i64::from(count)).context(error::DateIntSnafu {
+                integer: count,
+                unit: "minutes",
+            })?
+        }
         "hour" | "hours" => Duration::try_hours(i64::from(count)).context(error::DateIntSnafu {
             integer: count,
             unit: "hours",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #472

**Description of changes:**
Introduces minutes also to parse-datetime to allow for the `ohno.toml` to work.


**Testing done:**
Tried building a repository using the ohno.toml wave configuration.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
