### PR TITLE
fix migrations and shell checks

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -582,7 +582,7 @@ if [[ -z ${version} ]]; then
     exit 1
 fi
 
-migrations_root="sources/api/migration/migrations/v${version}"
+migrations_root="sources/settings-migrations/v${version}"
 
 # First pass: Check all migrations explicitly listed in Release.toml
 

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -563,6 +563,11 @@ done'''
 script_runner = "bash"
 script = [
 '''
+if [[ ! -s Release.toml ]]; then
+    echo "No Release.toml found, skipping checks for migrations."
+    exit 0
+fi
+
 # Collect all found problems and report in bulk; patterns become easier to see
 problems=()
 

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -517,7 +517,7 @@ if ! docker run --rm \
   bash -c \
     'flagged_scripts=0 && \
     cd /tmp/tools && \
-    for shell_script in $(grep -l --directories=skip --regexp="^#\!.*bash$" * ); do
+    for shell_script in $(grep -l --directories=skip --regexp='^#!.*bash$' * ); do
       if ! shellcheck \
         --external-sources \
         --source-path=SCRIPTDIR \


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/260

**Description of changes:**
Found while testing the overall `check` task as part of validating the `cargo-deny` update.


**Testing done:**
Fixes these errors:
```
[cargo-make] INFO - Running Task: check-migrations
grep: Release.toml: No such file or directory

[cargo-make][1] INFO - Running Task: check-migrations
Found 1 problem(s) with data store migrations:
    - Migration 'kubelet-device-plugins-mig-settings' does not exist

[cargo-make] INFO - Running Task: check-shell
grep: warning: stray \ before !
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
