### PR TITLE
testsys: add new field `assume_role` to VSphereK8sClusterConfig

### DIFF
--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -120,6 +120,7 @@ impl CrdCreator for VmwareK8sCreator {
             .vcenter_resource_pool(&self.datacenter.resource_pool)
             .vcenter_workload_folder(&self.datacenter.folder)
             .mgmt_cluster_kubeconfig_base64(&self.encoded_mgmt_cluster_kubeconfig)
+            .assume_role(cluster_input.crd_input.config.agent_role.clone())
             .eks_a_release_manifest_url(
                 cluster_input
                     .crd_input


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
```
testsys: add new field `assume_role` to VSphereK8sClusterConfig
```

At TestSys main repo, We need use `assume_role` to retrieve secret values from aws secret manager when we create vmware clusters. Adding new filed `assume_role` to VSphereK8sClusterConfig. 
Associated PR at TestSys: https://github.com/bottlerocket-os/bottlerocket-test-system/pull/975

**Testing done:**
***same as the TestSys PR Testing done. ***


Creating vmware clusters.

- [x] vmware-k8s-1.28 clusters
```
2025-03-06T06:20:29.091Z        V0      Writing cluster config file
2025-03-06T06:20:29.092Z        V0      🎉 Cluster created!
2025-03-06T06:20:29.092Z        V4      Task finished   {"task_name": "write-cluster-config", "duration": "1.723032ms"}
2025-03-06T06:20:29.092Z        V4      ----------------------------------
2025-03-06T06:20:29.092Z        V4      Tasks completed {"duration": "8m45.182380788s"}
2025-03-06T06:20:29.092Z        V3      Logging out from current govc session
2025-03-06T06:20:29.311Z        V3      Cleaning up long running container      {"name": "eksa_1741241493999798556"}
[2025-03-06T06:20:29Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Scaling default NodeGroup machinedeployments replicas to 0
machinedeployment.cluster.x-k8s.io/x86-64-vmware-k8s-128-md-0 scaled
[2025-03-06T06:20:29Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Cluster created
```

- [x] vmware-k8s-1.32 clusters
```
2025-03-06T06:20:29.091Z        V0      Writing cluster config file
2025-03-06T06:20:29.092Z        V0      🎉 Cluster created!
2025-03-06T06:20:29.092Z        V4      Task finished   {"task_name": "write-cluster-config", "duration": "1.732324ms"}
2025-03-06T06:20:29.092Z        V4      ----------------------------------
2025-03-06T06:20:29.092Z        V4      Tasks completed {"duration": "8m45.182380788s"}
2025-03-06T06:20:29.092Z        V3      Logging out from current govc session
2025-03-06T06:20:29.311Z        V3      Cleaning up long running container      {"name": "eksa_1741223423423424423"}
[2025-03-06T06:20:29Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Scaling default NodeGroup machinedeployments replicas to 0
machinedeployment.cluster.x-k8s.io/x86-64-vmware-k8s-132-md-0 scaled
[2025-03-06T06:20:29Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Cluster created
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
