### PR TITLE
testsys: request gpu if nvidia

### DIFF
--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -101,6 +101,7 @@ pub(crate) fn workload_crd(test_input: TestInput) -> Result<Test> {
         "testsys/type".to_string() => test_input.test_type.to_string(),
         "testsys/cluster".to_string() => cluster_resource_name.to_string(),
     });
+    let gpu = test_input.crd_input.variant.variant_flavor() == Some("nvidia");
     let plugins: Vec<_> = test_input
         .crd_input
         .config
@@ -109,7 +110,7 @@ pub(crate) fn workload_crd(test_input: TestInput) -> Result<Test> {
         .map(|(name, image)| WorkloadTest {
             name: name.to_string(),
             image: image.to_string(),
-            ..Default::default()
+            gpu,
         })
         .collect();
     if plugins.is_empty() {


### PR DESCRIPTION
**Description of changes:**

Updated the k8s workload inputs to be consistent with the ECS workload inputs (https://github.com/bottlerocket-os/twoliter/commit/8ad9a13c93c4722be59fe1b6e7ff82682052c1c6) when it comes to GPUs.

**Testing done:**

Ran workloads using testsys on `aws-k8s-1.29-nvidia`. When outputting the value of `test.gpu` to a file the value was `false` before the change, `true` after the change. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
