### PR TITLE
Adjust use of cargo config file to not clash with host cargo operations

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -362,13 +362,31 @@ for ws in sources variants .; do
   [ -s "${BUILDSYS_ROOT_DIR}/${ws}/Cargo.lock" ] || continue
   CARGO_MANIFESTS+=(--sync "${BUILDSYS_ROOT_DIR}/${ws}/Cargo.toml")
 done
-cargo vendor --locked --no-delete  --versioned-dirs --respect-source-config  ${CARGO_MANIFESTS[@]} .cargo/vendor > .cargo/config.toml 2> .cargo/vendor.log || {
-   echo "vendoring of cargo dependencies failed"
-   cat .cargo/vendor.log
-   exit 1
-}
-rm .cargo/vendor.log
+exec 9<>.cargo/vendor.lock
+if ! flock -w 90 9; then
+    echo "failed to obtain lock" >&2
+    exit 1
+fi
 
+set +e
+cargo vendor \
+    --locked \
+    --no-delete \
+    --versioned-dirs \
+    --respect-source-config \
+    ${CARGO_MANIFESTS[@]} \
+    .cargo/vendor \
+    > .cargo/twoliter_cargo_config.toml \
+    2> .cargo/vendor.log
+
+if [ "${?}" -ne 0 ]; then
+   echo "vendoring of cargo dependencies failed" >&2
+   cat .cargo/vendor.log >&2
+   exit 1
+fi
+
+set -e
+rm .cargo/vendor.log
 chmod -R o+r ${CARGO_HOME}
 '''
 ]
@@ -459,7 +477,8 @@ done
 if ! docker run --rm \
    -u $(id -u):$(id -g) \
    -e CARGO_HOME="/tmp/.cargo" \
-   -v "${CARGO_HOME}":/tmp/.cargo \
+   -v "${CARGO_HOME}/twoliter_cargo_config.toml":/tmp/.cargo/config.toml \
+   -v "${CARGO_HOME}/vendor":/tmp/.cargo/vendor \
    -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
    "${TLPRIVATE_SDK_IMAGE}" \
    cargo fmt \
@@ -495,7 +514,8 @@ export VARIANT="${BUILDSYS_VARIANT}"
 if ! docker run --rm \
    -u $(id -u):$(id -g) \
    -e CARGO_HOME="/tmp/.cargo" \
-   -v "${CARGO_HOME}":/tmp/.cargo \
+   -v "${CARGO_HOME}/twoliter_cargo_config.toml":/tmp/.cargo/config.toml \
+   -v "${CARGO_HOME}/vendor":/tmp/.cargo/vendor \
    -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
    -e VARIANT \
    "${TLPRIVATE_SDK_IMAGE}" \
@@ -978,7 +998,8 @@ docker run --rm \
   --user "$(id -u):$(id -g)" \
   --security-opt="label=disable" \
   -e CARGO_HOME="/tmp/.cargo" \
-  -v "${CARGO_HOME}":/tmp/.cargo \
+  -v "${CARGO_HOME}/twoliter_cargo_config.toml":/tmp/.cargo/config.toml \
+  -v "${CARGO_HOME}/vendor":/tmp/.cargo/vendor \
   -v "${BUILDSYS_ROOT_DIR}/sources":/tmp/sources \
   "${TLPRIVATE_SDK_IMAGE}" \
   bash -c "${run_cargo_deny}"

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -112,7 +112,7 @@ USER builder
     # We only mount the config.toml and the vendor directory instead of the whole .cargo directory
     # because the .git and .registry directories are specific to the version of cargo and can cause
     # incapatibility between the host cargo and the cargo in the sdk
-RUN --mount=source=.cargo/config.toml,target=/home/builder/rpmbuild/.cargo/config.toml \
+RUN --mount=source=.cargo/twoliter_cargo_config.toml,target=/home/builder/rpmbuild/.cargo/config.toml \
     --mount=source=.cargo/vendor,target=/home/builder/rpmbuild/.cargo/vendor \
     --mount=type=cache,target=/home/builder/.cache,from=cache,source=/cache \
     --mount=source=sources,target=/home/builder/rpmbuild/BUILD/sources \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** 486

Closes #486 

**Description of changes:**

* Change our call to cargo vendor to store the config file to .cargo/twoliter_cargo_config.toml
* Checks if the user has their own .cargo/config.toml and if so will ensure it is taken into account
* Modify the bind mount in the build context to mount .cargo/twoliter_cargo_config.toml to .cargo/config.toml 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
