### PR TITLE
feat: add single zone configuration

### DIFF
--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -250,6 +250,8 @@ pub struct GenericVariantConfig {
     pub cluster_names: Vec<String>,
     /// The instance type that instances should be launched with
     pub instance_type: Option<String>,
+    /// The zones that instances should be launched to
+    pub zones: Option<Vec<String>>,
     /// Specify how Bottlerocket instances should be launched (ec2, karpenter)
     pub resource_agent_type: Option<ResourceAgentType>,
     /// Launch instances with the following Block Device Mapping
@@ -313,6 +315,7 @@ impl GenericVariantConfig {
         Self {
             cluster_names,
             instance_type: self.instance_type.or(other.instance_type),
+            zones: self.zones.or(other.zones),
             resource_agent_type: self.resource_agent_type.or(other.resource_agent_type),
             block_device_mapping,
             secrets,

--- a/tools/testsys/src/aws_k8s.rs
+++ b/tools/testsys/src/aws_k8s.rs
@@ -80,7 +80,7 @@ impl CrdCreator for AwsK8sCreator {
                 EksctlConfig::Args {
                     cluster_name: cluster_input.cluster_name.to_string(),
                     region: Some(self.region.clone()),
-                    zones: None,
+                    zones: cluster_input.crd_input.config.zones.clone(),
                     version: Some(cluster_version),
                 },
             ),

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -220,6 +220,7 @@ impl CrdInput<'_> {
             "version".to_string() => some_or_null(&self.variant.version().map(str::to_string)),
             "cluster-name".to_string() => cluster_name.to_string(),
             "instance-type".to_string() => some_or_null(&self.config.instance_type),
+            "zones".to_string() => some_or_null(&self.config.zones.clone().map(|vec| vec.join(" "))),
             "agent-role".to_string() => some_or_null(&self.config.agent_role),
             "conformance-image".to_string() => some_or_null(&self.config.conformance_image),
             "conformance-registry".to_string() => some_or_null(&self.config.conformance_registry),

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -151,6 +151,11 @@ struct CliConfig {
     #[arg(long, env = "TESTSYS_INSTANCE_TYPE")]
     instance_type: Option<String>,
 
+    /// Specify the zone that should be used. This is only applicable for aws-* variants.
+    /// It can be omitted for non-aws variants and can be omitted to use default instance types.
+    #[arg(long, env = "TESTSYS_ZONES")]
+    zones: Option<Vec<String>>,
+
     /// Add secrets to the testsys agents (`--secret awsCredentials=my-secret`)
     #[arg(long, short, value_parser = parse_key_val, number_of_values = 1)]
     secret: Vec<(String, SecretName)>,
@@ -187,6 +192,7 @@ impl From<CliConfig> for GenericVariantConfig {
         GenericVariantConfig {
             cluster_names: val.target_cluster_name.into_iter().collect(),
             instance_type: val.instance_type,
+            zones: val.zones,
             resource_agent_type: val.resource_agent_type,
             block_device_mapping: Default::default(),
             secrets: val.secret.into_iter().collect(),
@@ -223,6 +229,7 @@ impl Run {
             Some(self.config.into()),
             &self.test_flavor.to_string(),
         );
+
         let resolved_test_type = TestType::from_str(&test_type)
             .expect("All unrecognized test type become `TestType::Custom`");
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
Added feature allows configuring a specific zone in Test.toml, so that EC2 instance(s) can be launched in this specific zone. Usually, two zones must specified, but this feature allows one specific single zone for EC2 instance to launch into.


**Testing done:**
See testing at: https://github.com/bottlerocket-os/bottlerocket-test-system/pull/984


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
