### PR TITLE
Use Rust's front-end parallel compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,8 @@
 [unstable]
 bindeps = true
+
+[build]
+# This is the recommended configuration that yields the
+# best results:
+#  - https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
+rustflags = ["-Z", "threads=8"]


### PR DESCRIPTION
**Description of changes:**

Use the recommended configuration that enables the front-end parallel compilation for faster builds. In various runs, I observed that the compilation time went down by 30 seconds:

```
# Before
Finished `release` profile [optimized] target(s) in 8m 22s

# After
Finished `release` profile [optimized] target(s) in 7m 40s
```

**Testing done:**

- Build variant, and publish the AMI successfully


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
