### PR TITLE
twoliter: add support for kmod kit feature flag

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -239,6 +239,14 @@ FIPS-compliant ciphers to be included in the image.
 fips = true
 ```
 
+`external-kmod-development` enables functionality for building custom kernel modules at runtime
+
+```ignore
+[package.metadata.build-variant.image-features]
+external-kmod-development = true
+```
+
+
 */
 
 mod error;
@@ -487,8 +495,11 @@ impl ManifestInfo {
     /// Convenience method to return the enabled image features for this variant.
     pub fn image_features(&self) -> Option<HashSet<ImageFeature>> {
         let variant = self.build_variant()?;
-        let mut features =
-            HashSet::from([ImageFeature::InPlaceUpdates, ImageFeature::HostContainers]);
+        let mut features = HashSet::from([
+            ImageFeature::InPlaceUpdates,
+            ImageFeature::HostContainers,
+            ImageFeature::ExternalKmodDevelopment,
+        ]);
         if let Some(image_features) = &variant.image_features {
             for (feature, enabled) in image_features.iter() {
                 if *enabled {
@@ -800,6 +811,7 @@ pub enum ImageFeature {
     Fips,
     InPlaceUpdates,
     HostContainers,
+    ExternalKmodDevelopment,
 }
 
 const EXPERIMENTAL_IMAGE_FEATURES: [&ImageFeature; 1] = [&ImageFeature::ErofsRootPartition];
@@ -816,6 +828,7 @@ impl TryFrom<String> for ImageFeature {
             "fips" => Ok(ImageFeature::Fips),
             "in-place-updates" => Ok(ImageFeature::InPlaceUpdates),
             "host-containers" => Ok(ImageFeature::HostContainers),
+            "external-kmod-development" => Ok(ImageFeature::ExternalKmodDevelopment),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -832,6 +845,7 @@ impl fmt::Display for ImageFeature {
             ImageFeature::Fips => write!(f, "FIPS"),
             ImageFeature::InPlaceUpdates => write!(f, "IN_PLACE_UPDATES"),
             ImageFeature::HostContainers => write!(f, "HOST_CONTAINERS"),
+            ImageFeature::ExternalKmodDevelopment => write!(f, "EXTERNAL_KMOD_DEVELOPMENT"),
         }
     }
 }

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -183,6 +183,8 @@ PUBLISH_AMI_NAME_DEFAULT = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH
 # The name of the kmod kit archive, used to ease building out-of-tree kernel modules.
 BUILDSYS_KMOD_KIT = "${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-kmod-kit-v${BUILDSYS_VERSION_IMAGE}.tar.xz"
 BUILDSYS_KMOD_KIT_PATH = "${BUILDSYS_VARIANT_DIR}/${BUILDSYS_KMOD_KIT}"
+BUILDSYS_NO_KMOD_KIT = ".no-kmod-kit"
+BUILDSYS_NO_KMOD_KIT_PATH = "${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NO_KMOD_KIT}"
 
 # The name of the OVA bundle that will be built if the current variant builds VMDK artifacts
 BUILDSYS_OVA = "${BUILDSYS_NAME_VARIANT}-v${BUILDSYS_VERSION_IMAGE}.ova"
@@ -1073,8 +1075,10 @@ for file in ${MIGRATIONS_DIR}/*; do
 done
 
 # Include the kmod kit in the repo so it's easier to build out-of-tree kernel
-# modules for a given release.
-LINK_REPO_TARGETS=("--link-target ${BUILDSYS_KMOD_KIT_PATH}")
+# modules for a given release if the marker file is not present.
+if [[ ! -e ${BUILDSYS_NO_KMOD_KIT_PATH} ]]; then
+   LINK_REPO_TARGETS=("--link-target ${BUILDSYS_KMOD_KIT_PATH}")
+fi
 
 # Include the os and data disk images in the repo both with and without a
 # friendly name if they exist.  Check for the existence of the image and not

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1066,13 +1066,17 @@ fi
 
 COPY_REPO_TARGETS=()
 
-# TODO: only add migrations from Release.toml, not all
 MIGRATIONS_DIR="$(mktemp -d)"
-tar xpf "${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-migrations.tar" -C "${MIGRATIONS_DIR}"
-for file in ${MIGRATIONS_DIR}/*; do
-   [ -e "${file}" ] || continue
-   COPY_REPO_TARGETS+=("--copy-target ${file}")
-done
+
+# Only try to unpack migrations if in place updates are turned on
+if [[ ! -e "${BUILDSYS_VARIANT_DIR}/.no-migrations" ]]; then
+   # TODO: only add migrations from Release.toml, not all
+   tar xpf "${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-migrations.tar" -C "${MIGRATIONS_DIR}"
+   for file in ${MIGRATIONS_DIR}/*; do
+       [ -e "${file}" ] || continue
+       COPY_REPO_TARGETS+=("--copy-target ${file}")
+   done
+fi
 
 # Include the kmod kit in the repo so it's easier to build out-of-tree kernel
 # modules for a given release if the marker file is not present.

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -212,6 +212,7 @@ ARG EROFS_ROOT_PARTITION
 ARG IN_PLACE_UPDATES
 ARG HOST_CONTAINERS
 ARG FIPS
+ARG EXTERNAL_KMOD_DEVELOPMENT
 
 USER builder
 WORKDIR /home/builder
@@ -235,7 +236,8 @@ RUN \
    && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${EROFS_ROOT_PARTITION:+%bcond_without erofs_root_partition\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${IN_PLACE_UPDATES:+%bcond_without in_place_updates\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${HOST_CONTAINERS:+%bcond_without host_containers\n}" >> "${RPM_BCONDS}"
+   && echo -e -n "${HOST_CONTAINERS:+%bcond_without host_containers\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${EXTERNAL_KMOD_DEVELOPMENT:+%bcond_without external_kmod_development\n}" >> "${RPM_BCONDS}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an RPM repository from packages created in Section 1 and kits from Section 2.
@@ -436,6 +438,7 @@ ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 ARG BYPASS_SOCKET
 ARG OUTPUT_SOCKET
 ARG BUILDER_UID
+ARG EXTERNAL_KMOD_DEVELOPMENT
 
 USER root
 
@@ -443,15 +446,20 @@ WORKDIR /tmp
 RUN --mount=target=/host \
     /host/build/tools/pipesys link --fd-socket "${BYPASS_SOCKET}" --target /bypass && \
     /host/build/tools/pipesys link --fd-socket "${OUTPUT_SOCKET}" --target /output && \
-    mkdir -p /local/archives && \
-    KERNEL="$(printf "%s\n" ${PACKAGES} | awk '/^kernel-/{print $1}')" && \
-    find /bypass/build/ -type f \
-        -name "bottlerocket-${KERNEL}-archive-*.${ARCH}.rpm" \
-        -exec cp '{}' '/local/archives/' ';' && \
-    /host/build/tools/rpm2kmodkit \
-        --archive-dir=/local/archives \
-        --toolchain-dir=/toolchain \
-        --output-dir=/output && \
+    mkdir -p /local/archives; \
+    if [[ -n "${EXTERNAL_KMOD_DEVELOPMENT}" ]]; then \
+        KERNEL="$(printf "%s\n" ${PACKAGES} | awk '/^kernel-/{print $1}')" && \
+        find /bypass/build/ -type f \
+            -name "bottlerocket-${KERNEL}-archive-*.${ARCH}.rpm" \
+            -exec cp '{}' '/local/archives/' ';' && \
+        /host/build/tools/rpm2kmodkit \
+            --archive-dir=/local/archives \
+            --toolchain-dir=/toolchain \
+            --output-dir=/output; \
+    else \
+        mkdir -p /output/${VERSION_ID}-${BUILD_ID} && \
+        touch /output/${VERSION_ID}-${BUILD_ID}/.no-kmod-kit; \
+    fi; \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm -rf /local/archives && \
     rm /output && \

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -403,6 +403,7 @@ ARG VARIANT
 ARG BYPASS_SOCKET
 ARG OUTPUT_SOCKET
 ARG BUILDER_UID
+ARG IN_PLACE_UPDATES
 ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 WORKDIR /root
 
@@ -410,14 +411,19 @@ USER root
 RUN --mount=target=/host \
     /host/build/tools/pipesys link --fd-socket "${BYPASS_SOCKET}" --target /bypass && \
     /host/build/tools/pipesys link --fd-socket "${OUTPUT_SOCKET}" --target /output && \
-    mkdir -p /local/migrations && \
-    find /bypass/build/rpms/ -maxdepth 2 -type f \
-        -name "bottlerocket-migrations-*.rpm" \
-        -not -iname '*debuginfo*' \
-        -exec cp '{}' '/local/migrations/' ';' && \
-    /host/build/tools/rpm2migrations \
-        --package-dir=/local/migrations \
-        --output-dir=/output && \
+    mkdir -p /local/migrations; \
+    if [[ -n "${IN_PLACE_UPDATES}" ]]; then \
+        find /bypass/build/rpms/ -maxdepth 2 -type f \
+            -name "bottlerocket-migrations-*.rpm" \
+            -not -iname '*debuginfo*' \
+            -exec cp '{}' '/local/migrations/' ';' && \
+        /host/build/tools/rpm2migrations \
+            --package-dir=/local/migrations \
+            --output-dir=/output; \
+    else \
+        mkdir -p /output/${VERSION_ID}-${BUILD_ID} && \
+        touch /output/${VERSION_ID}-${BUILD_ID}/.no-migrations; \
+    fi; \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output && \
     rm -rf /local/migrations && \
     rm /output && \

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -62,6 +62,11 @@ Provides: %{_cross_os}image-feature(fips)
 Provides: %{_cross_os}image-feature(no-fips)
 %endif
 
+%if %{with external_kmod_development}
+Provides: %{_cross_os}image-feature(external-kmod-development)
+%else
+Provides: %{_cross_os}image-feature(no-external-kmod-development)
+%endif
 %description
 %{summary}.
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/74

**Description of changes:**
Added a feature flag `kmod-kits` which is on by default. Turning this feature flag off, causes builds to not produce kmod kits.


**Testing done:**
Built `aws-ecs-2` variant using current variant definition, saw that kmod kits were created. Added `kmod-kits = false` to the variant definition, rebuilt, and saw that no kmod kits were created. When no kmod kits created, the `.no-kmod-kit` marker file was created. Tested that `cargo make repo` continued to work in this case.

Set `in-place-updates = false` saw that migrations files were not created. Additionally a `.no-migrations` marker is created in order to allow `cargo make repo` to continue to work.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
