### PR TITLE
rpm2img: set VENDOR_NAME to "Bottlerocket"

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -371,6 +371,7 @@ PRETTY_NAME="${PRETTY_NAME} ${VERSION}"
 VARIANT_ID=${VARIANT}
 VERSION_ID=${VERSION_ID}
 BUILD_ID=${BUILD_ID}
+VENDOR_NAME="Bottlerocket"
 HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
 SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
 BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: #513 

**Description of changes:**

Set `VENDOR_NAME="Bottlerocket"` in `/etc/os-release`

#513 tracks the larger effort to make the value for this field configurable via project Twoliter.toml

**Testing done:**

Build a dev variant and inspect `/etc/os-bottlerocket-release` in the control container (mounted from `/etc/os-release` on the host):

```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "e5cd08cf",
    "pretty_name": "Bottlerocket OS 1.36.0 (aws-k8s-1.30)",
    "variant_id": "aws-k8s-1.30",
    "version_id": "1.36.0"
  }
}
[ssm-user@control]$ cat /etc/bottlerocket-release
NAME=Bottlerocket
ID=bottlerocket
VERSION="1.36.0 (aws-k8s-1.30)"
PRETTY_NAME="Bottlerocket OS 1.36.0 (aws-k8s-1.30)"
VARIANT_ID=aws-k8s-1.30
VERSION_ID=1.36.0
BUILD_ID=e5cd08cf
VENDOR_NAME="Bottlerocket"
HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
DOCUMENTATION_URL="https://bottlerocket.dev"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
