### PR TITLE
pubsys: fix bug blocking publishing parameters in a new region

### DIFF
--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -14,7 +14,7 @@ use crate::aws::{
 use crate::Args;
 use aws_config::SdkConfig;
 use aws_sdk_ec2::{types::ArchitectureValues, Client as Ec2Client};
-use aws_sdk_ssm::{config::Region, Client as SsmClient};
+use aws_sdk_ssm::{config::Region, error::ProvideErrorMetadata, Client as SsmClient};
 use clap::{ArgGroup, Parser};
 use futures::stream::{StreamExt, TryStreamExt};
 use governor::{prelude::*, Quota, RateLimiter};
@@ -202,9 +202,20 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
     info!("Getting current SSM parameters");
     let new_parameter_names: Vec<&SsmKey> =
         new_parameters.iter().map(|param| &param.ssm_key).collect();
-    let current_parameters = ssm::get_parameters(&new_parameter_names, &ssm_clients)
-        .await
-        .context(error::FetchSsmSnafu)?;
+    let result = ssm::get_parameters(&new_parameter_names, &ssm_clients).await;
+
+    // Typically if a user calls GetParameters for a nonexistent parameter, the call will succeed
+    // and simply report the parameter as invalid. However, SSM has a special case error in
+    // GetParameters for keys under the `/aws/` namespace if the service prefix (e.g
+    // `/aws/service/bottlerocket`) does not contain any keys. This is an expected state when
+    // publishing parameters in a new region for the first time. We can assume when we see this
+    // error that there are no parameters under the prefix.
+    let current_parameters = if is_aws_service_access_denied_error(&result) {
+        HashMap::new()
+    } else {
+        result.context(error::FetchSsmSnafu)?
+    };
+
     trace!("Current SSM parameters: {:#?}", current_parameters);
 
     // Show the difference between source and target parameters in SSM.
@@ -239,6 +250,20 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
 
     info!("All parameters match requested values.");
     Ok(())
+}
+
+fn is_aws_service_access_denied_error(result: &ssm::Result<HashMap<SsmKey, String>>) -> bool {
+    if let Err(ssm::error::Error::GetParameters { source, .. }) = result {
+        if let Some(err) = source.as_service_error() {
+            return err.code() == Some("AccessDeniedException")
+                && err.message().is_some()
+                && err
+                    .message()
+                    .unwrap()
+                    .contains("No access to \"/aws/\" namespace");
+        }
+    }
+    false
 }
 
 /// Write rendered parameters to the file at `ssm_parameters_output`


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Handles a special case error that occurs when getting SSM parameters from the `/aws/` namespace under a prefix that doesn't exist yet. In this case, SSM returns an error like:

```
$ aws ssm get-parameters --names /aws/service/not-real-service/not-real-parameter

An error occurred (AccessDeniedException) when calling the GetParameters operation: No access to "/aws/" namespace: aws/service/not-real-service is not a valid namespace
```

With parameters under any other namespace, SSM succeeds and returns:

```bash
$ aws ssm get-parameters --names /sam-berning/test/not-real-parameter
{
    "Parameters": [],
    "InvalidParameters": [
        "/sam-berning/test/not-real-parameter"
    ]
}
```

In order to bring the special-case behavior in line with the standard behavior, we assume that hitting this error means that none of the parameters in the request exist, and so we return an empty HashMap.

This assumption works because Pubsys publishes all SSM parameters under the same prefix, defined in the `Infra.toml` file, and this error happens only if no parameters exist under the prefix. e.g. if I request an invalid parameter under the `/aws/service/bottlerocket/` prefix in `us-west-2`, which does contain parameters, I get:

```bash
$ aws ssm get-parameters --names /aws/service/bottlerocket/not-real-parameter
{
    "Parameters": [],
    "InvalidParameters": [
        "/aws/service/bottlerocket/not-real-parameter"
    ]
}
```

However, if a later version of Pubsys introduces the ability to publish parameters under multiple prefixes, this assumption could break.

**Testing done:**

Performed three tests here with `pubsys ssm` commands:

1. Tested publishing to a nonexistent `/aws/` path (`/aws/service/not-real-service`). On a previous version of pubsys, this failed while fetching parameters. With the new version, it failed while setting parameters as expected.
2. Published two parameters that did not exist to my own AWS account under a non-`/aws/` namespace. The two parameters were published successfully.
3. Re-ran the same publish command in my own account. Pubsys found the two parameters that already existed, and correctly identified that they did not need updating.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
