### PR TITLE
chore: prepare for release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.8.1...HEAD
 
-## [0.9.0-rc1] - 2025-04-16
+## [0.9.0] - 2025-04-16
 
 ### Added
 * Add `external-kmod-development` image feature to control when to build kmod kits ([#512])
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#515]: https://github.com/bottlerocket-os/twoliter/pull/515
 [#517]: https://github.com/bottlerocket-os/twoliter/pull/517
 
-[0.9.0-rc1]: https://github.com/bottlerocket-os/twoliter/compare/v0.8.1..v0.9.0-rc1
+[0.9.0]: https://github.com/bottlerocket-os/twoliter/compare/v0.8.1..v0.9.0
 
 ## [0.8.1] - 2025-03-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.9.0-rc1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
-twoliter = { version = "0.9.0-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.9.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.9.0-rc1"
+version = "0.9.0"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
Release 0.9.0

**Testing done:**

- [x] Built bottlerocket-kernel-kit for both arcs
- [x] Built bottlerocket-core-kit for both arches 
- [x] Built bottlerocket-bob for both arches
- [x] Ran and checked validate-ami the ami.json of 0.8.1 v 0.9.1 are identical
- [x] Ran and checked validate-ssm the ssm.json contents are the same but ordering was swapped 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
