### PR TITLE
chore: prep for release v0.10.0-beta0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.8.1...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.10.0-beta0...HEAD
+
+## [0.10.0-beta0] - 2025-04-18
+### Release Highlights
+We're working on releasing a system in Twoliter to make EBS block device mapping settings fully configurable for AWS variants. This beta release of Twoliter 0.10.0 changes the default EBS volume type from gp2 to gp3 so that we can run performance tests against gp3 in the meantime.
+
+### Changed
+* Update to use gp3 instead of gp2 for EBS volumes when registering AMIs.
+
+[0.10.0-beta0]: https://github.com/bottlerocket-os/twoliter/compare/v0.9.0..v0.10.0-beta0
 
 ## [0.9.0] - 2025-04-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.9.0"
+version = "0.10.0-beta0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
-twoliter = { version = "0.9.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.10.0-beta0", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/tools/pubsys/src/aws/ami/register.rs
+++ b/tools/pubsys/src/aws/ami/register.rs
@@ -15,7 +15,7 @@ const DATA_DEVICE_NAME: &str = "/dev/xvdb";
 
 // Features we assume/enable for the images.
 const VIRT_TYPE: &str = "hvm";
-const VOLUME_TYPE: &str = "gp2";
+const VOLUME_TYPE: &str = "gp3";
 const SRIOV: &str = "simple";
 const ENA: bool = true;
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.9.0"
+version = "0.10.0-beta0"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
* Update to use gp3 for EBS volumes when registering AMIs from gp2.
* Create CHANGELOG and bump version to prepare for v0.10.0-beta0

**Testing done:**
```
cargo build
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
