### PR TITLE
pubsys: integrate with amispec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,6 +2776,7 @@ dependencies = [
 name = "pubsys"
 version = "0.1.0"
 dependencies = [
+ "amispec",
  "async-stream",
  "aws-config",
  "aws-credential-types",
@@ -2797,6 +2798,7 @@ dependencies = [
  "indicatif",
  "lazy_static",
  "log",
+ "maplit",
  "nonzero_ext",
  "num_cpus",
  "oci-cli-wrapper",
@@ -2810,6 +2812,7 @@ dependencies = [
  "snafu",
  "tabled",
  "tempfile",
+ "test-case",
  "tinytemplate",
  "tokio",
  "tokio-retry",

--- a/tools/amispec/src/ebs.rs
+++ b/tools/amispec/src/ebs.rs
@@ -67,7 +67,10 @@ macro_rules! impl_block_device_types {
 
             properties {
                 volume_size: $size_ty:ty,
-                $($extra_attr:ident: $extra_ty:ty,)*
+                $(
+                    $(#[$extra_attr_meta:meta])*
+                    $extra_attr:ident: $extra_ty:ty,
+                )*
             }
 
             fn build(&$self:ident, $builder:ident) {
@@ -75,7 +78,6 @@ macro_rules! impl_block_device_types {
             }
         }
     )*) => {
-
         #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
         #[serde(rename_all = "kebab-case", tag = "volume-type")]
         pub enum EbsBlockDevice {
@@ -145,7 +147,10 @@ macro_rules! impl_block_device_types {
                     bounded_from_u64(size, $device::volume_type(), "volume-size")
                 })]
                 pub volume_size: $size_ty,
-                $(pub $extra_attr: $extra_ty,)*
+                $(
+                    $(#[$extra_attr_meta])*
+                    $extra_attr: $extra_ty,
+                )*
 
                 // Common EBS attributes
                 pub delete_on_termination: Option<bool>,
@@ -266,6 +271,9 @@ impl_block_device_types! {
 
         properties {
             volume_size: Option<BoundedU64<4, 16_384>>,
+            #[builder(with = |size: u64| -> Result<_, InvalidValueError> {
+                bounded_from_u64(size, "io1", "iops")
+            })]
             iops: BoundedU64<100, 64_000>,
         }
 
@@ -281,6 +289,9 @@ impl_block_device_types! {
 
         properties {
             volume_size: Option<BoundedU64<4, 65_536>>,
+            #[builder(with = |size: u64| -> Result<_, InvalidValueError> {
+                bounded_from_u64(size, "io2", "iops")
+            })]
             iops: BoundedU64<100, 256_000>,
         }
 
@@ -336,7 +347,13 @@ impl_block_device_types! {
 
         properties {
             volume_size: Option<BoundedU64<1, 16_384>>,
+            #[builder(with = |size: u64| -> Result<_, InvalidValueError> {
+                bounded_from_u64(size, "gp3", "iops")
+            })]
             iops: Option<BoundedU64<3_000, 16_000>>,
+            #[builder(with = |size: u64| -> Result<_, InvalidValueError> {
+                bounded_from_u64(size, "gp3", "throughput")
+            })]
             throughput: Option<BoundedU64<125, 1_000>>,
         }
 

--- a/tools/amispec/src/lib.rs
+++ b/tools/amispec/src/lib.rs
@@ -196,6 +196,7 @@ pub enum Architecture {
     Arm64Mac,
 }
 serde_plain::derive_fromstr_from_deserialize!(Architecture);
+serde_plain::derive_display_from_serialize!(Architecture);
 
 impl From<Architecture> for aws_sdk_ec2::types::ArchitectureValues {
     fn from(value: Architecture) -> Self {
@@ -217,6 +218,7 @@ pub enum BootMode {
     UefiPreferred,
 }
 serde_plain::derive_fromstr_from_deserialize!(BootMode);
+serde_plain::derive_display_from_serialize!(BootMode);
 
 impl From<BootMode> for aws_sdk_ec2::types::BootModeValues {
     fn from(value: BootMode) -> Self {
@@ -234,6 +236,7 @@ pub enum ImdsSupport {
     V2_0,
 }
 serde_plain::derive_fromstr_from_deserialize!(ImdsSupport);
+serde_plain::derive_display_from_serialize!(ImdsSupport);
 
 impl From<ImdsSupport> for aws_sdk_ec2::types::ImdsSupportValues {
     fn from(value: ImdsSupport) -> Self {
@@ -249,6 +252,7 @@ pub enum TpmSupport {
     V2_0,
 }
 serde_plain::derive_fromstr_from_deserialize!(TpmSupport);
+serde_plain::derive_display_from_serialize!(TpmSupport);
 
 impl From<TpmSupport> for aws_sdk_ec2::types::TpmSupportValues {
     fn from(value: TpmSupport) -> Self {
@@ -264,15 +268,7 @@ pub enum SriovNetSupport {
     Simple,
 }
 serde_plain::derive_fromstr_from_deserialize!(SriovNetSupport);
-
-impl std::fmt::Display for SriovNetSupport {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let repr = match self {
-            SriovNetSupport::Simple => "simple",
-        };
-        write!(f, "{}", repr)
-    }
-}
+serde_plain::derive_display_from_serialize!(SriovNetSupport);
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -281,15 +277,7 @@ pub enum VirtualizationType {
     // Paravirtual is not supported
 }
 serde_plain::derive_fromstr_from_deserialize!(VirtualizationType);
-
-impl std::fmt::Display for VirtualizationType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let repr = match self {
-            VirtualizationType::Hvm => "hvm",
-        };
-        write!(f, "{}", repr)
-    }
-}
+serde_plain::derive_display_from_serialize!(VirtualizationType);
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default, Builder, Templated)]
 #[templated(

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -392,7 +392,7 @@ struct ImageView {
 
 /// The nested structures here are somewhat complex, but they make it trivial
 /// to deserialize the structure we expect to find in the manifest.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct ManifestInfo {
     package: Package,
@@ -618,14 +618,14 @@ fn get_buildsys_package_name(pkg_metadata: &PackageMetadata) -> String {
         .to_string()
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 struct Package {
     name: String,
     metadata: Option<Metadata>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 struct Metadata {
     build_package: Option<BuildPackage>,
@@ -633,7 +633,7 @@ struct Metadata {
     build_variant: Option<BuildVariant>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 #[allow(dead_code)]
 pub struct BuildPackage {
@@ -645,7 +645,7 @@ pub struct BuildPackage {
     pub package_features: Option<Vec<ImageFeature>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 #[allow(dead_code)]
 pub struct BuildKit {
@@ -653,7 +653,7 @@ pub struct BuildKit {
     pub vendor: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 #[serde(untagged)]
 pub enum VariantSensitivity {
@@ -661,7 +661,7 @@ pub enum VariantSensitivity {
     Specific(SensitivityType),
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum SensitivityType {
     Platform,
@@ -670,7 +670,7 @@ pub enum SensitivityType {
     Flavor,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct BuildVariant {
     pub included_packages: Option<Vec<String>>,
@@ -682,7 +682,7 @@ pub struct BuildVariant {
     pub image_features: Option<HashMap<ImageFeature, bool>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum ImageFormat {
     Qcow2,
@@ -850,13 +850,13 @@ impl fmt::Display for ImageFeature {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum BundleModule {
     Go,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct ExternalFile {
     pub path: Option<PathBuf>,

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+amispec.workspace = true
 async-stream.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true
@@ -51,3 +52,7 @@ tough-kms.workspace = true
 tough-ssm.workspace = true
 update-metadata.workspace = true
 url = { workspace = true, features = ["serde"] }
+
+[dev-dependencies]
+maplit.workspace = true
+test-case.workspace = true

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -7,20 +7,23 @@ mod register;
 mod snapshot;
 pub(crate) mod wait;
 
+use self::register::mk_amispec;
 use crate::aws::ami::launch_permissions::get_launch_permissions;
 use crate::aws::ami::public::ami_is_public;
 use crate::aws::publish_ami::{get_snapshots, modify_image, modify_snapshots, ModifyOptions};
-use crate::aws::{client::build_client_config, parse_arch, region_from_string};
+use crate::aws::{client::build_client_config, region_from_string};
+use crate::frompath::FromPath;
 use crate::Args;
 use aws_sdk_ebs::Client as EbsClient;
 use aws_sdk_ec2::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_ec2::operation::copy_image::{CopyImageError, CopyImageOutput};
-use aws_sdk_ec2::types::{ArchitectureValues, OperationType};
+use aws_sdk_ec2::types::OperationType;
 use aws_sdk_ec2::{config::Region, Client as Ec2Client};
 use aws_sdk_sts::operation::get_caller_identity::{
     GetCallerIdentityError, GetCallerIdentityOutput,
 };
 use aws_sdk_sts::Client as StsClient;
+use buildsys::manifest::ManifestInfo;
 use clap::Parser;
 use futures::future::{join, lazy, ready, FutureExt};
 use futures::stream::{self, StreamExt};
@@ -47,16 +50,16 @@ pub(crate) struct AmiArgs {
     data_image: Option<PathBuf>,
 
     /// Path to the variant manifest
-    #[arg(short = 'v', long)]
-    variant_manifest: PathBuf,
+    #[arg(short = 'v', long, value_parser = parse_variant_manifest)]
+    variant_manifest: VariantManifest,
 
     /// Path to the UEFI data
-    #[arg(short = 'e', long)]
-    uefi_data: PathBuf,
+    #[arg(short = 'e', long, value_parser = parse_uefi_data)]
+    uefi_data: FromPath<String>,
 
     /// The architecture of the machine image
-    #[arg(short = 'a', long, value_parser = parse_arch)]
-    arch: ArchitectureValues,
+    #[arg(short = 'a', long)]
+    arch: String,
 
     /// The desired AMI name
     #[arg(short = 'n', long)]
@@ -73,6 +76,10 @@ pub(crate) struct AmiArgs {
     /// Regions where you want the AMI, the first will be used as the base for copying
     #[arg(long, value_delimiter = ',')]
     regions: Vec<String>,
+
+    /// amispec file containing AMI registration options.
+    #[arg(long, value_parser = parse_toml_file::<toml::Table>)]
+    amispec_file: Option<FromPath<toml::Table>>,
 
     /// If specified, save created regional AMI IDs in JSON at this path.
     #[arg(long)]
@@ -132,18 +139,31 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
 
     let base_ec2_client = Ec2Client::new(&client_config);
 
+    // Render an amispec without any defined snapshots.
+    //
+    // This is used to determine the desired name and architecture, so that we can see if our AMI
+    // already exists.
+    let tentative_amispec =
+        mk_amispec::create_amispec(ami_args, None).context(error::AmispecSnafu)?;
+
+    let arch = tentative_amispec
+        .architecture
+        .as_ref()
+        .map(ToString::to_string)
+        .context(error::MissingArchitectureSnafu)?;
+
     // Check if the AMI already exists, in which case we can use the existing ID, otherwise we
     // register a new one.
     let maybe_id = get_ami_id(
-        &ami_args.name,
-        &ami_args.arch,
+        &tentative_amispec.name,
+        &arch,
         &base_region,
         &base_ec2_client,
     )
     .await
     .context(error::GetAmiIdSnafu {
-        name: &ami_args.name,
-        arch: ami_args.arch.as_ref(),
+        arch: &arch,
+        name: &tentative_amispec.name,
         region: base_region.as_ref(),
     })?;
 
@@ -154,7 +174,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     let (ids_of_image, already_registered) = if let Some(found_id) = maybe_id {
         warn!(
             "\n{}\n\nFound '{}' already registered in {}: {}\n\n{0}",
-            WARN_SEPARATOR, ami_args.name, base_region, found_id
+            WARN_SEPARATOR, tentative_amispec.name, base_region, found_id
         );
         let snapshot_ids = get_snapshots(&found_id, &base_region, &base_ec2_client)
             .await
@@ -184,25 +204,34 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
 
         (found_ids, true)
     } else {
+        info!(
+            "Registering '{}' in {}",
+            tentative_amispec.name, base_region
+        );
         let new_ids = register_image(ami_args, &base_region, base_ebs_client, &base_ec2_client)
             .await
             .context(error::RegisterImageSnafu {
-                name: &ami_args.name,
-                arch: ami_args.arch.as_ref(),
+                name: &tentative_amispec.name,
+                arch: &arch,
                 region: base_region.as_ref(),
             })?;
         info!(
             "Registered AMI '{}' in {}: {}",
-            ami_args.name, base_region, new_ids.image_id
+            tentative_amispec.name, base_region, new_ids.image_id
         );
         (new_ids, false)
     };
+
+    // Eliminate our reference to `ami_args` to force the use of `tentative_amispec` to determine
+    // AMI properties.
+    #[expect(unused_variables)]
+    let ami_args = ();
 
     amis.insert(
         base_region.as_ref().to_string(),
         Image::new(
             &ids_of_image.image_id,
-            &ami_args.name,
+            &tentative_amispec.name,
             Some(public),
             Some(launch_permissions),
         ),
@@ -304,7 +333,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     let mut get_requests = Vec::with_capacity(regions.len());
     for region in regions.iter() {
         let ec2_client = &ec2_clients[region];
-        let get_request = get_ami_id(&ami_args.name, &ami_args.arch, region, ec2_client);
+        let get_request = get_ami_id(&tentative_amispec.name, &arch, region, ec2_client);
         let info_future = ready(region.clone());
         get_requests.push(join(info_future, get_request));
     }
@@ -316,14 +345,14 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     let mut copy_requests = Vec::with_capacity(regions.len());
     for (region, get_response) in get_responses {
         let get_response = get_response.context(error::GetAmiIdSnafu {
-            name: &ami_args.name,
-            arch: ami_args.arch.as_ref(),
+            name: &tentative_amispec.name,
+            arch: &arch,
             region: region.as_ref(),
         })?;
         if let Some(id) = get_response {
             info!(
                 "Found '{}' already registered in {}: {}",
-                ami_args.name, region, id
+                tentative_amispec.name, region, id
             );
             let public = ami_is_public(&ec2_clients[&region], region.as_ref(), &id)
                 .await
@@ -342,7 +371,12 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
 
             amis.insert(
                 region.as_ref().to_string(),
-                Image::new(&id, &ami_args.name, Some(public), Some(launch_permissions)),
+                Image::new(
+                    &id,
+                    &tentative_amispec.name,
+                    Some(public),
+                    Some(launch_permissions),
+                ),
             );
             continue;
         }
@@ -351,8 +385,8 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         let base_region = base_region.to_owned();
         let copy_future = ec2_client
             .copy_image()
-            .set_description(ami_args.description.clone())
-            .set_name(Some(ami_args.name.clone()))
+            .set_description(tentative_amispec.description.clone())
+            .set_name(Some(tentative_amispec.name.clone()))
             .set_source_image_id(Some(ids_of_image.image_id.clone()))
             .set_source_region(Some(base_region.as_ref().to_string()))
             .send();
@@ -391,17 +425,22 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
                 if let Some(image_id) = success.image_id {
                     info!(
                         "Registered AMI '{}' in {}: {}",
-                        ami_args.name, region, image_id,
+                        tentative_amispec.name, region, image_id,
                     );
                     amis.insert(
                         region.as_ref().to_string(),
-                        Image::new(&image_id, &ami_args.name, Some(false), Some(vec![])),
+                        Image::new(
+                            &image_id,
+                            &tentative_amispec.name,
+                            Some(false),
+                            Some(vec![]),
+                        ),
                     );
                 } else {
                     saw_error = true;
                     error!(
                         "Registered AMI '{}' in {} but didn't receive an AMI ID!",
-                        ami_args.name, region,
+                        tentative_amispec.name, region,
                     );
                 }
             }
@@ -497,11 +536,39 @@ async fn get_account_ids(
     Ok(grant_accounts)
 }
 
+/// Parses a toml file, returning a `FromPath<T>`.
+pub(crate) fn parse_toml_file<'de, T: Deserialize<'de>>(filepath: &str) -> Result<FromPath<T>> {
+    let toml_str = std::fs::read_to_string(filepath).context(error::ReadFileSnafu { filepath })?;
+    let toml_deserializer = toml::Deserializer::new(&toml_str);
+    FromPath::deserialize_from_path(filepath, toml_deserializer)
+        .context(error::ParseTomlSnafu { filepath })
+}
+
+/// Helper type that wraps buildsys::manifest::ManifestInfo but includes the filepath from which
+/// it was loaded.
+///
+/// This allows us to emit more helpful error messages when an error occurs due to a variant
+/// definition.
+pub(crate) type VariantManifest = FromPath<ManifestInfo>;
+
+pub(crate) fn parse_variant_manifest(filepath: &str) -> Result<VariantManifest> {
+    let manifest =
+        ManifestInfo::new(filepath).context(error::LoadVariantManifestSnafu { filepath })?;
+    Ok(FromPath::new_from_path(manifest, filepath))
+}
+
+pub(crate) fn parse_uefi_data(filepath: &str) -> Result<FromPath<String>> {
+    let uefi_data = std::fs::read_to_string(filepath).context(error::ReadFileSnafu { filepath })?;
+    Ok(FromPath::new_from_path(uefi_data, filepath))
+}
+
 mod error {
+    use super::register::mk_amispec;
     use crate::aws::{ami, publish_ami};
     use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::modify_image_attribute::ModifyImageAttributeError;
     use aws_sdk_sts::operation::get_caller_identity::GetCallerIdentityError;
+    use buildsys::manifest;
     use snafu::Snafu;
     use std::path::PathBuf;
 
@@ -512,6 +579,9 @@ mod error {
     pub(crate) enum Error {
         #[snafu(display("Some AMIs failed to copy, see above"))]
         AmiCopy,
+
+        #[snafu(display("Failed to create an amispec from publication inputs: {}", source))]
+        Amispec { source: mk_amispec::AmispecError },
 
         #[snafu(display("Error reading config: {}", source))]
         Config { source: pubsys_config::Error },
@@ -580,6 +650,18 @@ mod error {
             source: public::Error,
         },
 
+        #[snafu(display("Failed to load variant manifest from {}: {}", filepath.display(), source))]
+        LoadVariantManifest {
+            filepath: PathBuf,
+            #[snafu(source(from(manifest::Error, Box::new)))]
+            source: Box<manifest::Error>,
+        },
+
+        #[snafu(display(
+            "amispec rendered from pubsys inputs is missing a machine architecture."
+        ))]
+        MissingArchitecture,
+
         #[snafu(display("Infra.toml is missing {}", missing))]
         MissingConfig { missing: String },
 
@@ -587,6 +669,18 @@ mod error {
         MissingInResponse {
             request_type: String,
             missing: String,
+        },
+
+        #[snafu(display("Failed to parse file {} as toml: {}", filepath.display(), source))]
+        ParseToml {
+            filepath: PathBuf,
+            source: toml::de::Error,
+        },
+
+        #[snafu(display("Failed to read file {}: {}", filepath.display(), source))]
+        ReadFile {
+            filepath: PathBuf,
+            source: std::io::Error,
         },
 
         #[snafu(display("Error registering {} {} in {}: {}", arch, name, region, source))]

--- a/tools/pubsys/src/aws/ami/register/merge_toml.rs
+++ b/tools/pubsys/src/aws/ami/register/merge_toml.rs
@@ -1,0 +1,99 @@
+//! Provides a utility for merging toml tables
+
+/// Represents a type that can be "merged" with another version of itself.
+///
+/// This is primarily intended to be used with Map-like types, where keys can be recursively
+/// upserted into `self` from `other`.
+pub(crate) trait Merge {
+    fn merge(&mut self, other: &Self);
+}
+
+impl Merge for toml::Value {
+    fn merge(&mut self, other: &Self) {
+        match (self, other) {
+            (toml::Value::Table(a), toml::Value::Table(b)) => a.merge(b),
+            (a, b) => {
+                *a = b.clone();
+            }
+        }
+    }
+}
+
+impl Merge for toml::Table {
+    fn merge(&mut self, other: &Self) {
+        for (k, v) in other {
+            if let Some(a_val) = self.get_mut(k) {
+                a_val.merge(v);
+            } else {
+                self.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Merge;
+    use toml::toml;
+
+    #[test]
+    fn test_flat_merge() {
+        let mut a = toml! {
+            a = 1
+            b = 2
+            c = 3
+        };
+
+        let b = toml! {
+            b = 4
+            c = 5
+            d = 6
+        };
+
+        let expected = toml! {
+            a = 1
+            b = 4
+            c = 5
+            d = 6
+        };
+
+        a.merge(&b);
+
+        assert_eq!(a, expected);
+    }
+
+    #[test]
+    fn test_nested_merge() {
+        let mut a = toml! {
+            a = 1
+            b = { c = 2, d = 3 }
+        };
+
+        let b = toml! {
+            b = { d = { g = 6 }, e = 4 }
+            f = 5
+        };
+
+        let expected = toml! {
+            a = 1
+            b = { c = 2, d = { g = 6 }, e = 4 }
+            f = 5
+        };
+
+        a.merge(&b);
+
+        assert_eq!(a, expected);
+    }
+
+    #[test]
+    fn test_empty_merge() {
+        let mut a = toml! {
+            a = 1
+            b = 2
+        };
+        let expected = a.clone();
+
+        a.merge(&toml::map::Map::new());
+        assert_eq!(a, expected);
+    }
+}

--- a/tools/pubsys/src/aws/ami/register/mk_amispec.rs
+++ b/tools/pubsys/src/aws/ami/register/mk_amispec.rs
@@ -1,0 +1,966 @@
+//! This module generates an `amispec` to be used during the AMI registration process.
+//!
+//! An `amispec` defines the arguments that are passed to the EC2 RegisterImage call, including the
+//! EBS block device mappings which control EBS volumes and their properties.
+//!
+//! `amispec`s can be defined using handlebars-templated values for any field, allowing pubsys to
+//! inject AMI registration settings into the user-provided template.
+//!
+//! The `amispec` used to register an AMI is created using the following process:
+//! * A default `amispec` template is defined as a TOML table within pubsys
+//! * The default TOML table is modified to support features of the variant that is being registered
+//!     * Default EBS block device mappings are created for each snapshot
+//!     * If the variant supports secure boot, then the template has uefi-data updated, and sets
+//!       the default `boot-mode` to `uefi-preferred`
+//! * The default TOML template is merged with the user-provided TOML document, using a recursive
+//!   "upsert" procedure.
+//! * The resulting TOML document is parsed as a `TemplatedAmiSpec`
+//! * The `TemplatedAmiSpec` is finally rendered into the final `AmiSpec`.
+//!
+//! The handlebars render context is defined in [`AmispecRenderContext`] and includes basic
+//! AMI properties like the desired architecture and name, as well as information regarding
+//! EBS block devices required for the volumes based on the variant definition.
+use super::merge_toml::Merge;
+use super::BottlerocketSnapshots;
+use crate::aws::ami::VariantManifest;
+use amispec::{
+    ebs::{EbsBlockDeviceKind, InvalidValueError},
+    AmiSpec, TemplateOf, TemplatedAmiSpec,
+};
+use buildsys::manifest::{ImageFeature, PartitionPlan};
+use log::{debug, info, warn};
+use serde::Serialize;
+use snafu::{OptionExt, ResultExt, Snafu};
+use std::collections::HashMap;
+
+use crate::aws::ami::AmiArgs;
+
+type Result<T, E = AmispecError> = std::result::Result<T, E>;
+
+const ROOT_DEVICE_NAME: &str = "/dev/xvda";
+const DATA_DEVICE_NAME: &str = "/dev/xvdb";
+pub(crate) const VIRT_TYPE: &str = "hvm";
+
+lazy_static::lazy_static! {
+    /// The default amispec template.
+    ///
+    /// pubsys modifies this structure based on attributes of the variant being registered:
+    /// * If the variant has Secure Boot enabled,
+    ///     * The boot-mode is set to uefi-preferred
+    ///     * uefi-data is added to the template
+    static ref DEFAULT_AMISPEC_TEMPLATE: toml::Table = toml::toml! {
+        name = "{{ ami.unique_name }}"
+        description = "{{ ami.description }}"
+        architecture = "{{ ami.arch }}"
+        root-device-name = "/dev/xvda"
+        sriov-net-support = "simple"
+        virtualization-type = VIRT_TYPE
+        ena-support = true
+    };
+
+    static ref DEFAULT_ROOT_DEVICE_TEMPLATE: toml::Table = toml::toml! {
+        ["/dev/xvda".ebs]
+        volume-type = "gp2"
+        volume-size = "{{ block_devices.root.volume_size }}"
+        snapshot-id = "{{ block_devices.root.snapshot_id }}"
+        delete-on-termination = true
+    };
+
+    static ref DEFAULT_DATA_DEVICE_TEMPLATE: toml::Table = toml::toml! {
+        ["/dev/xvdb".ebs]
+        volume-type = "gp2"
+        volume-size = "{{ block_devices.data.volume_size }}"
+        snapshot-id = "{{ block_devices.data.snapshot_id }}"
+        delete-on-termination = true
+    };
+}
+
+/// Creates an `amispec` that defines the parameters that are used when registering an AMI.
+pub(crate) fn create_amispec(
+    ami_args: &AmiArgs,
+    bottlerocket_snapshots: Option<&BottlerocketSnapshots>,
+) -> Result<AmiSpec> {
+    use amispec_error::*;
+
+    let mut amispec_template_toml = default_amispec_template(
+        &ami_args.variant_manifest,
+        bottlerocket_snapshots,
+        &ami_args.uefi_data,
+    )?;
+
+    if let Some(user_amispec_template) = &ami_args.amispec_file {
+        info!("Merging user-defined amispec template for AMI properties");
+        amispec_template_toml.merge(user_amispec_template);
+    } else {
+        info!("Using default amispec for AMI properties");
+    }
+
+    debug!("Creating amispec with template:\n{amispec_template_toml}");
+    let amispec_template: TemplatedAmiSpec = amispec_template_toml
+        .try_into()
+        .context(ParseAmiSpecTemplateSnafu)?;
+
+    let render_context = AmispecRenderContext::from_ami_args(ami_args, bottlerocket_snapshots)?;
+    debug!("Creating amispec with render context:\n{render_context:#?}",);
+
+    let mut amispec = amispec_template
+        .render(&render_context)
+        .context(RenderAmiSpecSnafu)?;
+
+    ensure_amispec_volume_sizes(&mut amispec, &render_context.block_devices)?;
+
+    Ok(amispec)
+}
+
+/// Configure's the volume sizes for an AmiSpec based on a desired block device layout.
+///
+/// Only devices referred to by the `block_devices` map are altered.
+///
+/// If the `AmiSpec` already specifies a volume size, they are only altered if the specified size is
+/// less than the sizes specified in the given `block_devices` map. In this case, a warning message
+/// is logged.
+fn ensure_amispec_volume_sizes(
+    amispec: &mut AmiSpec,
+    block_devices: &HashMap<String, BlockDeviceRenderContext>,
+) -> Result<()> {
+    use amispec_error::*;
+
+    let bdms = match amispec.block_device_mappings.as_mut() {
+        Some(bdms) => bdms,
+        None => return Ok(()),
+    };
+
+    let mut ebs_volumes_with_size_hints = bdms
+        .values_mut()
+        // Keep block device mappings for EBS volumes that have them
+        .filter_map(|bdm| bdm.ebs.as_mut())
+        // Keep EBS volumes and their size hints if the volume has a size hint associated with the
+        // amispec's snapshot ID.
+        .filter_map(|ebs_volume| {
+            ebs_volume
+                .snapshot_id()
+                .map(str::to_string)
+                .and_then(|snapshot_id| {
+                    block_devices
+                        .values()
+                        .find(|device| device.snapshot_id == snapshot_id)
+                        .map(|device| (ebs_volume, device))
+                })
+        });
+
+    ebs_volumes_with_size_hints.try_for_each(|(ebs_volume, device_settings)| {
+        let size_hint = device_settings.volume_size;
+
+        debug!("Ensuring device '{}' requested with sufficient size", device_settings.device_name);
+        if let Some(curr_size) = ebs_volume.volume_size() {
+            if size_hint > curr_size {
+                warn!(
+                    "EBS volume '{ebs_volume:?}' was configured with size \
+                                    '{curr_size}', but size hints dictate that it should be \
+                                    larger. Using volume size '{size_hint}'"
+                );
+                ebs_volume
+                    .set_volume_size(Some(size_hint))
+                    .context(InvalidEbsVolumeSizeSnafu)?;
+            } else {
+                debug!("Volume for '{}' has sufficient size (requires '{size_hint}', has '{curr_size}'", device_settings.device_name)
+            }
+        } else {
+            debug!("No volume size requested for '{}'. Using '{size_hint}'", device_settings.device_name);
+            ebs_volume
+                .set_volume_size(Some(size_hint))
+                .context(InvalidEbsVolumeSizeSnafu)?;
+        }
+        Ok(())
+    })
+}
+
+/// Returns the default amispec template for a given variant.
+///
+/// This should be `DEFAULT_AMISPEC_TEMPLATE`, with some changes based on the variant:
+/// * The block device mappings contain a data device if one is specified
+/// * If the variant has secure boot enabled:
+///     * `boot-mode` is set to `uefi-preferred`
+///     * `uefi-data` is set to the input string
+fn default_amispec_template(
+    variant_manifest: &VariantManifest,
+    bottlerocket_snapshots: Option<&BottlerocketSnapshots>,
+    uefi_data: &str,
+) -> Result<toml::Table> {
+    let mut amispec_template = DEFAULT_AMISPEC_TEMPLATE.clone();
+    let mut block_device_mappings = toml::Table::new();
+
+    // Ensure the creation of new snapshots results in a compile error so that this is updated.
+    if let Some(snapshots) = bottlerocket_snapshots {
+        let BottlerocketSnapshots {
+            os_snapshot: _os_snapshot,
+            data_snapshot,
+        } = snapshots;
+
+        block_device_mappings.extend(DEFAULT_ROOT_DEVICE_TEMPLATE.clone());
+
+        if data_snapshot.is_some() {
+            block_device_mappings.extend(DEFAULT_DATA_DEVICE_TEMPLATE.clone());
+        }
+        amispec_template.insert("block-device-mappings".into(), block_device_mappings.into());
+    }
+
+    // Setup UEFI properties if secureboot is enabled
+    if variant_manifest
+        .image_features()
+        .iter()
+        .flatten()
+        .any(|f| *f == ImageFeature::UefiSecureBoot)
+    {
+        amispec_template.insert("boot-mode".into(), "uefi-preferred".into());
+        amispec_template.insert("uefi-data".into(), uefi_data.into());
+    }
+
+    Ok(amispec_template)
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct AmispecRenderContext {
+    pub ami: AmiRenderContext,
+    pub block_devices: HashMap<String, BlockDeviceRenderContext>,
+}
+
+impl AmispecRenderContext {
+    /// Create the handlebars render context that is used to render the amispec template
+    fn from_ami_args(
+        ami_args: &AmiArgs,
+        bottlerocket_snapshots: Option<&BottlerocketSnapshots>,
+    ) -> Result<Self> {
+        let block_device_render_context = bottlerocket_snapshots
+            .map(|bottlerocket_snapshots| {
+                bottlerocket_snapshots.block_device_render_context(&ami_args.variant_manifest)
+            })
+            .transpose()?;
+
+        Ok(AmispecRenderContext {
+            ami: AmiRenderContext {
+                unique_name: ami_args.name.clone(),
+                arch: ami_args.arch.clone(),
+                description: ami_args.description.clone(),
+            },
+            block_devices: block_device_render_context.unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct AmiRenderContext {
+    pub unique_name: String,
+    pub arch: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct BlockDeviceRenderContext {
+    pub device_name: String,
+    pub snapshot_id: String,
+    pub volume_size: u64,
+}
+
+impl BottlerocketSnapshots {
+    /// Creates the block device handlebars render context from a set of created EBS snapshots
+    fn block_device_render_context(
+        &self,
+        variant_manifest: &VariantManifest,
+    ) -> Result<HashMap<String, BlockDeviceRenderContext>> {
+        let image_layout =
+            variant_manifest
+                .image_layout()
+                .context(amispec_error::MissingImageLayoutSnafu {
+                    variant_manifest: Box::new(variant_manifest.clone()),
+                })?;
+
+        let (expects_data_volume, err_msg) = match image_layout.partition_plan {
+            PartitionPlan::Split => (true, "expects data volume, but none provided"),
+            PartitionPlan::Unified => (false, "does not expect data volume, but one provided"),
+        };
+        snafu::ensure!(
+            expects_data_volume == self.data_snapshot.is_some(),
+            amispec_error::ImageLayoutSnafu {
+                variant_manifest: Box::new(variant_manifest.clone()),
+                message: err_msg,
+            }
+        );
+
+        let (os_volume_size, data_volume_size) = image_layout.publish_image_sizes_gib();
+
+        let mut render_ctx = HashMap::new();
+        render_ctx.insert(
+            "root".into(),
+            BlockDeviceRenderContext {
+                device_name: ROOT_DEVICE_NAME.into(),
+                snapshot_id: self.os_snapshot.clone(),
+                volume_size: os_volume_size as u64,
+            },
+        );
+
+        if let Some(data_snapshot) = &self.data_snapshot {
+            render_ctx.insert(
+                "data".into(),
+                BlockDeviceRenderContext {
+                    device_name: DATA_DEVICE_NAME.into(),
+                    snapshot_id: data_snapshot.clone(),
+                    volume_size: data_volume_size as u64,
+                },
+            );
+        }
+
+        Ok(render_ctx)
+    }
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub(crate) enum AmispecError {
+    #[snafu(display("Failed to create amispec for image layout from {}: {}", variant_manifest.display_path(), message))]
+    ImageLayout {
+        variant_manifest: Box<VariantManifest>,
+        message: String,
+    },
+
+    #[snafu(display("Attempted to configure EBS volume with invalid size: {}", source))]
+    InvalidEbsVolumeSize { source: InvalidValueError },
+
+    #[snafu(display("Could not find image layout for '{}'", variant_manifest.display_path()))]
+    MissingImageLayout {
+        variant_manifest: Box<VariantManifest>,
+    },
+
+    #[snafu(display("Failed to parse AMI spec template: {}", source))]
+    ParseAmiSpecTemplate { source: toml::de::Error },
+
+    #[snafu(display("Failed to render amispec for RegisterImages call: {}", source))]
+    RenderAmiSpec { source: amispec::TemplatedError },
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::aws::ami::register::AmiArgs;
+    use crate::aws::ami::VariantManifest;
+    use amispec::{
+        ebs, Architecture, BlockDeviceMapping, BootMode, ImdsSupport, SriovNetSupport, TpmSupport,
+        VirtualizationType,
+    };
+    use buildsys::manifest::ManifestInfo;
+    use maplit::hashmap;
+    use std::path::PathBuf;
+
+    use test_case::test_case;
+
+    const ROOT_SNAP_ID: &str = "os-snapshot";
+    const DATA_SNAP_ID: &str = "data-snapshot";
+    const DEFAULT_ROOT_VOLUME_SIZE: u64 = 2;
+    const DEFAULT_DATA_VOLUME_SIZE: u64 = 20;
+
+    lazy_static::lazy_static! {
+        static ref SPLIT_LAYOUT_SNAPSHOTS: BottlerocketSnapshots = BottlerocketSnapshots {
+            os_snapshot: ROOT_SNAP_ID.into(),
+            data_snapshot: Some(DATA_SNAP_ID.into()),
+        };
+
+        static ref UNIFIED_LAYOUT_SNAPSHOTS: BottlerocketSnapshots = BottlerocketSnapshots {
+            os_snapshot: ROOT_SNAP_ID.into(),
+            data_snapshot: None,
+        };
+    }
+
+    #[test_case(
+        AmiArgs {
+            os_image: PathBuf::new(),
+            data_image: None,
+            variant_manifest: VariantManifest::new(
+                toml::toml! {
+                    [package]
+                    name = "test-variant"
+
+                    [package.metadata.build-variant.image-layout]
+                    partition-plan = "unified"
+                    os-image-size-gib = 100
+                }.try_into().unwrap(),
+            ),
+            uefi_data: Default::default(),
+            arch: "x86_64".into(),
+            name: "test-ami".into(),
+            description: Some("test description".into()),
+            no_progress: true,
+            regions: Vec::new(),
+            amispec_file: None,
+            ami_output: None,
+        },
+        UNIFIED_LAYOUT_SNAPSHOTS.clone(),
+        AmiSpec::builder()
+            .name("test-ami")
+            .architecture(Architecture::X86_64)
+            .ena_support(true)
+            .description("test description")
+            .root_device_name("/dev/xvda")
+            .sriov_net_support(SriovNetSupport::Simple)
+            .virtualization_type(VirtualizationType::Hvm)
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp2::builder()
+                        .snapshot_id(ROOT_SNAP_ID)
+                        .volume_size(101).unwrap()
+                        .delete_on_termination(true)
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+            .build();
+        "default amispec template, no data snapshot"
+    )]
+    #[test_case(
+        AmiArgs {
+            os_image: PathBuf::new(),
+            data_image: None,
+            variant_manifest: VariantManifest::new(
+                toml::toml! {
+                    [package]
+                    name = "test-variant"
+
+                    [package.metadata.build-variant]
+                }.try_into().unwrap(),
+            ),
+            uefi_data: Default::default(),
+            arch: "x86_64".into(),
+            name: "test-ami".into(),
+            description: Some("test description".into()),
+            no_progress: true,
+            regions: Vec::new(),
+            amispec_file: None,
+            ami_output: None,
+        },
+        SPLIT_LAYOUT_SNAPSHOTS.clone(),
+        AmiSpec::builder()
+            .name("test-ami")
+            .architecture(Architecture::X86_64)
+            .ena_support(true)
+            .description("test description")
+            .root_device_name("/dev/xvda")
+            .sriov_net_support(SriovNetSupport::Simple)
+            .virtualization_type(VirtualizationType::Hvm)
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp2::builder()
+                        .snapshot_id(ROOT_SNAP_ID)
+                        .volume_size(DEFAULT_ROOT_VOLUME_SIZE).unwrap()
+                        .delete_on_termination(true)
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+           .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp2::builder()
+                        .snapshot_id(DATA_SNAP_ID)
+                        .volume_size(DEFAULT_DATA_VOLUME_SIZE).unwrap()
+                        .delete_on_termination(true)
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvdb"))
+            .build();
+        "default amispec template, with data snapshot"
+    )]
+    #[test_case(
+        AmiArgs {
+            os_image: PathBuf::new(),
+            data_image: None,
+            variant_manifest: VariantManifest::new(
+                toml::toml! {
+                    [package]
+                    name = "test-variant"
+
+                    [package.metadata.build-variant.image-features]
+                    uefi-secure-boot = true
+                }.try_into().unwrap(),
+            ),
+            uefi_data: "uefi-data!".to_string().into(),
+            arch: "x86_64".into(),
+            name: "test-ami".into(),
+            description: Some("test description".into()),
+            no_progress: true,
+            regions: Vec::new(),
+            amispec_file: Some(toml::toml! {
+                name = "hello {{ ami.unique_name }}"
+                description = "expand the default {{ ami.description }} with more"
+
+                [block-device-mappings."/dev/xvda".ebs]
+                volume-type = "gp3"
+
+                [block-device-mappings."/dev/xvdb".ebs]
+                volume-type = "io1"
+                volume-size = 100
+                iops = 500
+            }.into()),
+            ami_output: None,
+        },
+        SPLIT_LAYOUT_SNAPSHOTS.clone(),
+        AmiSpec::builder()
+            .name("hello test-ami")
+            .description("expand the default test description with more")
+            .architecture(Architecture::X86_64)
+            .ena_support(true)
+            .boot_mode(BootMode::UefiPreferred)
+            .uefi_data("uefi-data!")
+            .root_device_name("/dev/xvda")
+            .sriov_net_support(SriovNetSupport::Simple)
+            .virtualization_type(VirtualizationType::Hvm)
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp3::builder()
+                        .snapshot_id(ROOT_SNAP_ID)
+                        .volume_size(DEFAULT_ROOT_VOLUME_SIZE).unwrap()
+                        .delete_on_termination(true)
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+           .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Io1::builder()
+                        .snapshot_id(DATA_SNAP_ID)
+                        .volume_size(100).unwrap()
+                        .iops(500).unwrap()
+                        .delete_on_termination(true)
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvdb"))
+            .build();
+        "override volume type for both volumes, use secure-boot"
+    )]
+    #[test_case(
+        AmiArgs {
+            os_image: PathBuf::new(),
+            data_image: None,
+            variant_manifest: VariantManifest::new(
+                toml::toml! {
+                    [package]
+                    name = "test-variant"
+
+                    [package.metadata.build-variant.image-features]
+                    uefi-secure-boot = true
+
+                    [package.metadata.build-variant.image-layout]
+                    partition-plan = "unified"
+                }.try_into().unwrap(),
+            ),
+            uefi_data: "uefi-data!".to_string().into(),
+            arch: "x86_64".into(),
+            name: "test-ami".into(),
+            description: Some("test description".into()),
+            no_progress: true,
+            regions: Vec::new(),
+            amispec_file: Some(toml::toml! {
+                boot-mode = "uefi"
+                tpm-support = "v2.0"
+                imds-support = "v2.0"
+            }.into()),
+            ami_output: None,
+        },
+        UNIFIED_LAYOUT_SNAPSHOTS.clone(),
+        AmiSpec::builder()
+            .name("test-ami")
+            .architecture(Architecture::X86_64)
+            .ena_support(true)
+            .description("test description")
+            .root_device_name("/dev/xvda")
+            .sriov_net_support(SriovNetSupport::Simple)
+            .virtualization_type(VirtualizationType::Hvm)
+            .tpm_support(TpmSupport::V2_0)
+            .imds_support(ImdsSupport::V2_0)
+            .boot_mode(BootMode::Uefi)
+            .uefi_data("uefi-data!")
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp2::builder()
+                        .snapshot_id(ROOT_SNAP_ID)
+                        .volume_size(22).unwrap()
+                        .delete_on_termination(true)
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+            .build();
+        "allow boot-mode overrides"
+    )]
+    fn test_create_amispec(ami_args: AmiArgs, snapshots: BottlerocketSnapshots, expected: AmiSpec) {
+        let actual = create_amispec(&ami_args, Some(&snapshots)).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test_case(
+        AmiSpec::builder()
+            .name("test")
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp3::builder()
+                        .snapshot_id("snap-12345678")
+                        .volume_size(4).unwrap()
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+            .build(),
+        hashmap! {
+            "friendly-volume-name".into() => BlockDeviceRenderContext {
+                device_name: "doesn't matter, only snap ID does".into(),
+                snapshot_id: "snap-12345678".into(),
+                volume_size: 10
+            },
+        },
+        AmiSpec::builder()
+            .name("test")
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp3::builder()
+                        .snapshot_id("snap-12345678")
+                        .volume_size(10).unwrap()
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+
+            .build()
+        ; "block device mapping smaller than image"
+    )]
+    #[test_case(
+        AmiSpec::builder()
+            .name("test-bdm-bigger-than-snapshot")
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp3::builder()
+                        .snapshot_id("snapshot!")
+                        .volume_size(10).unwrap()
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+            .build(),
+        hashmap! {
+            "friendly-volume-name".into() => BlockDeviceRenderContext {
+                device_name: "doesn't matter, only snap ID does".into(),
+                snapshot_id: "snapshot!".into(),
+                volume_size: 2
+            },
+            "unrelated-volume-name".into() => BlockDeviceRenderContext {
+                device_name: "doesn't matter, only snap ID does".into(),
+                snapshot_id: "different-snapshot!".into(),
+                volume_size: 20
+            },
+        },
+        AmiSpec::builder()
+            .name("test-bdm-bigger-than-snapshot")
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp3::builder()
+                        .snapshot_id("snapshot!")
+                        .volume_size(10).unwrap()
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+
+            .build()
+        ; "block device mapping larger than image"
+    )]
+    #[test_case(
+        AmiSpec::builder()
+            .name("test-bdm-snapshot-unrelated")
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp3::builder()
+                        .snapshot_id("some-random-snapshot")
+                        .volume_size(1).unwrap()
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+            .build(),
+        hashmap! {
+            "friendly-volume-name".into() => BlockDeviceRenderContext {
+                device_name: "doesn't matter, only snap ID does".into(),
+                snapshot_id: "snapshot!".into(),
+                volume_size: 2
+            },
+            "unrelated-volume-name".into() => BlockDeviceRenderContext {
+                device_name: "doesn't matter, only snap ID does".into(),
+                snapshot_id: "different-snapshot!".into(),
+                volume_size: 20
+            },
+        },
+        AmiSpec::builder()
+            .name("test-bdm-snapshot-unrelated")
+            .block_device_mapping(BlockDeviceMapping::builder()
+                .ebs(
+                    ebs::Gp3::builder()
+                        .snapshot_id("some-random-snapshot")
+                        .volume_size(1).unwrap()
+                        .build()
+                )
+                .build()
+                .with_device_name("/dev/xvda"))
+
+            .build()
+        ; "snapshots with no hints are ignored"
+    )]
+    fn test_ensure_amispec_volume_sizes(
+        mut amispec: AmiSpec,
+        block_devices: HashMap<String, BlockDeviceRenderContext>,
+        expected: AmiSpec,
+    ) {
+        ensure_amispec_volume_sizes(&mut amispec, &block_devices).unwrap();
+        assert_eq!(amispec, expected);
+    }
+
+    #[test_case(
+        toml::toml! {
+            [package]
+            name = "test-variant"
+
+        }.try_into().unwrap(),
+        BottlerocketSnapshots {
+            os_snapshot: "os-snapshot".to_string(),
+            data_snapshot: Some("data-snapshot".to_string())
+
+        },
+        "uefi-data",
+        toml::toml! {
+            name = "{{ ami.unique_name }}"
+            description = "{{ ami.description }}"
+            architecture = "{{ ami.arch }}"
+            root-device-name = "/dev/xvda"
+            sriov-net-support = "simple"
+            virtualization-type = VIRT_TYPE
+            ena-support = true
+
+            [block-device-mappings."/dev/xvda".ebs]
+            volume-type = "gp2"
+            volume-size = "{{ block_devices.root.volume_size }}"
+            snapshot-id = "{{ block_devices.root.snapshot_id }}"
+            delete-on-termination = true
+
+            [block-device-mappings."/dev/xvdb".ebs]
+            volume-type = "gp2"
+            volume-size = "{{ block_devices.data.volume_size }}"
+            snapshot-id = "{{ block_devices.data.snapshot_id }}"
+            delete-on-termination = true
+        };
+        "no secure boot, two snapshots"
+    )]
+    #[test_case(
+        toml::toml! {
+            [package]
+            name = "test-variant"
+
+            [package.metadata.build-variant.image-features]
+            uefi-secure-boot = true
+
+            [package.metadata.build-variant.image-layout]
+            partition-plan = "unified"
+
+        }.try_into().unwrap(),
+        BottlerocketSnapshots {
+            os_snapshot: "os-snapshot".to_string(),
+            data_snapshot: None
+
+        },
+        "uefi-data",
+        toml::toml! {
+            name = "{{ ami.unique_name }}"
+            description = "{{ ami.description }}"
+            architecture = "{{ ami.arch }}"
+            root-device-name = "/dev/xvda"
+            sriov-net-support = "simple"
+            virtualization-type = VIRT_TYPE
+            ena-support = true
+            uefi-data = "uefi-data"
+            boot-mode = "uefi-preferred"
+
+            [block-device-mappings."/dev/xvda".ebs]
+            volume-type = "gp2"
+            volume-size = "{{ block_devices.root.volume_size }}"
+            snapshot-id = "{{ block_devices.root.snapshot_id }}"
+            delete-on-termination = true
+        };
+        "secure boot, one snapshot"
+    )]
+    fn test_default_amispec_template(
+        variant_manifest: ManifestInfo,
+        bottlerocket_snapshots: BottlerocketSnapshots,
+        uefi_data: &str,
+        expected_template: toml::Table,
+    ) {
+        let actual_template = default_amispec_template(
+            &VariantManifest::new(variant_manifest),
+            Some(&bottlerocket_snapshots),
+            uefi_data,
+        )
+        .unwrap();
+
+        assert_eq!(actual_template, expected_template);
+    }
+
+    #[test_case(
+        AmiArgs {
+            os_image: PathBuf::new(),
+            data_image: None,
+            variant_manifest: VariantManifest::new(
+                toml::toml! {
+                    [package]
+                    name = "test-variant"
+
+                    [package.metadata.build-variant.image-layout]
+                    os-image-size-gib = 100
+                    partition-plan = "unified"
+                }.try_into().unwrap(),
+            ),
+            uefi_data: Default::default(),
+            arch: "x86_64".into(),
+            name: "test-ami".into(),
+            description: Some("test description".into()),
+            no_progress: true,
+            regions: Vec::new(),
+            amispec_file: None,
+            ami_output: None,
+        },
+        BottlerocketSnapshots {
+            os_snapshot: "os-snapshot".to_string(),
+            data_snapshot: None
+        },
+        AmispecRenderContext {
+            ami: AmiRenderContext {
+                unique_name: "test-ami".into(),
+                arch: "x86_64".into(),
+                description: Some("test description".into()),
+            },
+            block_devices: hashmap! {
+                "root".into() => BlockDeviceRenderContext {
+                    device_name: "/dev/xvda".into(),
+                    snapshot_id: "os-snapshot".into(),
+                    volume_size: 101
+                }
+            },
+        };
+        "one snapshot, specified image size"
+    )]
+    #[test_case(
+        AmiArgs {
+            os_image: PathBuf::new(),
+            data_image: None,
+            variant_manifest: VariantManifest::new(
+                toml::toml! {
+                    [package]
+                    name = "test-variant"
+
+                    [package.metadata.build-variant.image-layout]
+                    partition-plan = "split"
+                }.try_into().unwrap(),
+            ),
+            uefi_data: Default::default(),
+            arch: "aarch64".into(),
+            name: "has-data-volume".into(),
+            description: Some("render with two snapshots".into()),
+            no_progress: true,
+            regions: Vec::new(),
+            amispec_file: None,
+            ami_output: None,
+        },
+        BottlerocketSnapshots {
+            os_snapshot: "os-snapshot".to_string(),
+            data_snapshot: Some("data-snapshot".to_string())
+        },
+        AmispecRenderContext {
+            ami: AmiRenderContext {
+                unique_name: "has-data-volume".into(),
+                arch: "aarch64".into(),
+                description: Some("render with two snapshots".into()),
+            },
+            block_devices: hashmap! {
+                "root".into() => BlockDeviceRenderContext {
+                    device_name: "/dev/xvda".into(),
+                    snapshot_id: "os-snapshot".into(),
+                    volume_size: 2,
+                },
+                "data".into() => BlockDeviceRenderContext {
+                    device_name: "/dev/xvdb".into(),
+                    snapshot_id: "data-snapshot".into(),
+                    volume_size: 20,
+                }
+            },
+        };
+        "two snapshots"
+    )]
+    fn test_create_ami_render_context(
+        ami_args: AmiArgs,
+        snapshots: BottlerocketSnapshots,
+        expected: AmispecRenderContext,
+    ) {
+        assert_eq!(
+            AmispecRenderContext::from_ami_args(&ami_args, Some(&snapshots)).unwrap(),
+            expected,
+        )
+    }
+    #[test_case(
+        AmiArgs {
+            os_image: Default::default(),
+            data_image: None,
+            variant_manifest: VariantManifest::new(
+                toml::toml! {
+                    [package]
+                    name = "test-variant"
+
+                    [package.metadata.build-variant.image-layout]
+                    partition-plan = "split"
+                }.try_into().unwrap(),
+            ),
+            uefi_data: Default::default(),
+            arch: "aarch64".into(),
+            name: "test-ami".into(),
+            description: Some("test description".into()),
+            no_progress: true,
+            regions: Vec::new(),
+            amispec_file: None,
+            ami_output: None,
+        },
+        UNIFIED_LAYOUT_SNAPSHOTS.clone();
+        "split layout, one snaphot provided"
+    )]
+    #[test_case(
+        AmiArgs {
+            os_image: Default::default(),
+            data_image: Default::default(),
+            variant_manifest: VariantManifest::new(
+                toml::toml! {
+                    [package]
+                    name = "test-variant"
+
+                    [package.metadata.build-variant.image-layout]
+                    partition-plan = "unified"
+                }.try_into().unwrap(),
+            ),
+            uefi_data: Default::default(),
+            arch: "aarch64".into(),
+            name: "test-ami".into(),
+            description: Some("test description".into()),
+            no_progress: true,
+            regions: Vec::new(),
+            amispec_file: None,
+            ami_output: None,
+        },
+        SPLIT_LAYOUT_SNAPSHOTS.clone();
+        "unified layout, two snaphots provided"
+    )]
+    fn test_image_layout_respected(ami_args: AmiArgs, snapshots: BottlerocketSnapshots) {
+        let amispec = create_amispec(&ami_args, Some(&snapshots));
+        assert!(matches!(amispec, Err(AmispecError::ImageLayout { .. })));
+    }
+}

--- a/tools/pubsys/src/aws/ami/register/mod.rs
+++ b/tools/pubsys/src/aws/ami/register/mod.rs
@@ -1,23 +1,13 @@
 use super::{snapshot::snapshot_from_image, AmiArgs};
 use aws_sdk_ebs::Client as EbsClient;
-use aws_sdk_ec2::types::{
-    ArchitectureValues, BlockDeviceMapping, EbsBlockDevice, Filter, VolumeType,
-};
+use aws_sdk_ec2::types::Filter;
 use aws_sdk_ec2::{config::Region, Client as Ec2Client};
-use buildsys::manifest::{self, ImageFeature};
 use coldsnap::{SnapshotUploader, SnapshotWaiter};
 use log::{debug, info, warn};
 use snafu::{ensure, OptionExt, ResultExt};
-use tokio::fs;
 
-const ROOT_DEVICE_NAME: &str = "/dev/xvda";
-const DATA_DEVICE_NAME: &str = "/dev/xvdb";
-
-// Features we assume/enable for the images.
-const VIRT_TYPE: &str = "hvm";
-const VOLUME_TYPE: &str = "gp2";
-const SRIOV: &str = "simple";
-const ENA: bool = true;
+mod merge_toml;
+pub(crate) mod mk_amispec;
 
 #[derive(Debug)]
 pub(crate) struct RegisteredIds {
@@ -34,123 +24,24 @@ async fn _register_image(
     ec2_client: &Ec2Client,
     cleanup_snapshot_ids: &mut Vec<String>,
 ) -> Result<RegisteredIds> {
-    let variant_manifest = manifest::ManifestInfo::new(&ami_args.variant_manifest).context(
-        error::LoadVariantManifestSnafu {
-            path: &ami_args.variant_manifest,
-        },
-    )?;
+    let bottlerocket_snapshots = BottlerocketSnapshots::create_snapshots(
+        ami_args,
+        region,
+        ebs_client,
+        ec2_client,
+        cleanup_snapshot_ids,
+    )
+    .await?;
 
-    let image_layout = variant_manifest
-        .image_layout()
-        .context(error::MissingImageLayoutSnafu {
-            path: &ami_args.variant_manifest,
-        })?;
+    debug!("Creating AMI spec from variant definition and pubsys args");
+    let amispec = mk_amispec::create_amispec(ami_args, Some(&bottlerocket_snapshots))
+        .context(error::AmispecSnafu)?;
 
-    let (os_volume_size, data_volume_size) = image_layout.publish_image_sizes_gib();
-
-    let uefi_data =
-        fs::read_to_string(&ami_args.uefi_data)
-            .await
-            .context(error::LoadUefiDataSnafu {
-                path: &ami_args.uefi_data,
-            })?;
-
-    debug!("Uploading images into EBS snapshots in {}", region);
-    let uploader = SnapshotUploader::new(ebs_client);
-    let os_snapshot =
-        snapshot_from_image(&ami_args.os_image, &uploader, None, ami_args.no_progress)
-            .await
-            .context(error::SnapshotSnafu {
-                path: &ami_args.os_image,
-                region: region.as_ref(),
-            })?;
-    cleanup_snapshot_ids.push(os_snapshot.clone());
-
-    let mut data_snapshot = None;
-    if let Some(data_image) = &ami_args.data_image {
-        let snapshot = snapshot_from_image(data_image, &uploader, None, ami_args.no_progress)
-            .await
-            .context(error::SnapshotSnafu {
-                path: &ami_args.os_image,
-                region: region.as_ref(),
-            })?;
-        cleanup_snapshot_ids.push(snapshot.clone());
-        data_snapshot = Some(snapshot);
-    }
-
-    info!("Waiting for snapshots to become available in {}", region);
-    let waiter = SnapshotWaiter::new(ec2_client.clone());
-    waiter
-        .wait(&os_snapshot, Default::default())
-        .await
-        .context(error::WaitSnapshotSnafu {
-            snapshot_type: "root",
-        })?;
-
-    if let Some(ref data_snapshot) = data_snapshot {
-        waiter
-            .wait(&data_snapshot, Default::default())
-            .await
-            .context(error::WaitSnapshotSnafu {
-                snapshot_type: "data",
-            })?;
-    }
-
-    // Prepare parameters for AMI registration request
-    let os_bdm = BlockDeviceMapping::builder()
-        .set_device_name(Some(ROOT_DEVICE_NAME.to_string()))
-        .set_ebs(Some(
-            EbsBlockDevice::builder()
-                .set_delete_on_termination(Some(true))
-                .set_snapshot_id(Some(os_snapshot.clone()))
-                .set_volume_type(Some(VolumeType::from(VOLUME_TYPE)))
-                .set_volume_size(Some(os_volume_size))
-                .build(),
-        ))
-        .build();
-
-    let mut data_bdm = None;
-    if let Some(ref data_snapshot) = data_snapshot {
-        let mut bdm = os_bdm.clone();
-        bdm.device_name = Some(DATA_DEVICE_NAME.to_string());
-        if let Some(ebs) = bdm.ebs.as_mut() {
-            ebs.snapshot_id = Some(data_snapshot.clone());
-            ebs.volume_size = Some(data_volume_size);
-        }
-        data_bdm = Some(bdm);
-    }
-
-    let mut block_device_mappings = vec![os_bdm];
-    if let Some(data_bdm) = data_bdm {
-        block_device_mappings.push(data_bdm);
-    }
-
-    let uefi_secure_boot_enabled = variant_manifest
-        .image_features()
-        .iter()
-        .flatten()
-        .any(|f| *f == ImageFeature::UefiSecureBoot);
-
-    let (boot_mode, uefi_data) = if uefi_secure_boot_enabled {
-        (Some("uefi-preferred".into()), Some(uefi_data))
-    } else {
-        (None, None)
-    };
-
+    debug!("Registering AMI with amispec '{:?}'", amispec);
     info!("Making register image call in {}", region);
-    let register_response = ec2_client
-        .register_image()
-        .set_architecture(Some(ami_args.arch.clone()))
-        .set_block_device_mappings(Some(block_device_mappings))
-        .set_boot_mode(boot_mode)
-        .set_uefi_data(uefi_data)
-        .set_description(ami_args.description.clone())
-        .set_ena_support(Some(ENA))
-        .set_name(Some(ami_args.name.clone()))
-        .set_root_device_name(Some(ROOT_DEVICE_NAME.to_string()))
-        .set_sriov_net_support(Some(SRIOV.to_string()))
-        .set_virtualization_type(Some(VIRT_TYPE.to_string()))
-        .send()
+    let register_response = amispec
+        .as_register_image_call()
+        .send_with(ec2_client)
         .await
         .context(error::RegisterImageSnafu {
             region: region.as_ref(),
@@ -162,15 +53,83 @@ async fn _register_image(
             region: region.as_ref(),
         })?;
 
-    let mut snapshot_ids = vec![os_snapshot];
-    if let Some(data_snapshot) = data_snapshot {
-        snapshot_ids.push(data_snapshot);
-    }
-
     Ok(RegisteredIds {
         image_id,
-        snapshot_ids,
+        snapshot_ids: bottlerocket_snapshots.snapshot_ids(),
     })
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BottlerocketSnapshots {
+    pub(crate) os_snapshot: String,
+    pub(crate) data_snapshot: Option<String>,
+}
+
+impl BottlerocketSnapshots {
+    fn snapshot_ids(&self) -> Vec<String> {
+        let mut snapshot_ids = vec![self.os_snapshot.clone()];
+        if let Some(ref data_snapshot) = self.data_snapshot {
+            snapshot_ids.push(data_snapshot.clone());
+        }
+        snapshot_ids
+    }
+
+    /// Creates the EBS snapshots for the OS and (optional) data volume
+    ///
+    /// Snapshot IDs are added to `cleanup_snapshot_ids` so that they can be deleted on cleanup.
+    async fn create_snapshots(
+        ami_args: &AmiArgs,
+        region: &Region,
+        ebs_client: EbsClient,
+        ec2_client: &Ec2Client,
+        cleanup_snapshot_ids: &mut Vec<String>,
+    ) -> Result<BottlerocketSnapshots> {
+        debug!("Uploading images into EBS snapshots in {}", region);
+        let uploader = SnapshotUploader::new(ebs_client);
+        let os_snapshot =
+            snapshot_from_image(&ami_args.os_image, &uploader, None, ami_args.no_progress)
+                .await
+                .context(error::SnapshotSnafu {
+                    path: &ami_args.os_image,
+                    region: region.as_ref(),
+                })?;
+        cleanup_snapshot_ids.push(os_snapshot.clone());
+
+        let mut data_snapshot = None;
+        if let Some(data_image) = &ami_args.data_image {
+            let snapshot = snapshot_from_image(data_image, &uploader, None, ami_args.no_progress)
+                .await
+                .context(error::SnapshotSnafu {
+                    path: &ami_args.os_image,
+                    region: region.as_ref(),
+                })?;
+            cleanup_snapshot_ids.push(snapshot.clone());
+            data_snapshot = Some(snapshot);
+        }
+
+        info!("Waiting for snapshots to become available in {}", region);
+        let waiter = SnapshotWaiter::new(ec2_client.clone());
+        waiter
+            .wait(&os_snapshot, Default::default())
+            .await
+            .context(error::WaitSnapshotSnafu {
+                snapshot_type: "root",
+            })?;
+
+        if let Some(ref data_snapshot) = data_snapshot {
+            waiter
+                .wait(&data_snapshot, Default::default())
+                .await
+                .context(error::WaitSnapshotSnafu {
+                    snapshot_type: "data",
+                })?;
+        }
+
+        Ok(BottlerocketSnapshots {
+            os_snapshot,
+            data_snapshot,
+        })
+    }
 }
 
 /// Uploads the given images into snapshots and registers an AMI using them as its block device
@@ -181,7 +140,6 @@ pub(crate) async fn register_image(
     ebs_client: EbsClient,
     ec2_client: &Ec2Client,
 ) -> Result<RegisteredIds> {
-    info!("Registering '{}' in {}", ami_args.name, region);
     let mut cleanup_snapshot_ids = Vec::new();
     let register_result = _register_image(
         ami_args,
@@ -213,7 +171,7 @@ pub(crate) async fn register_image(
 /// Queries EC2 for the given AMI name. If found, returns Ok(Some(id)), if not returns Ok(None).
 pub(crate) async fn get_ami_id<S>(
     name: S,
-    arch: &ArchitectureValues,
+    arch: impl Into<String>,
     region: &Region,
     ec2_client: &Ec2Client,
 ) -> Result<Option<String>>
@@ -230,7 +188,7 @@ where
                 .build(),
             Filter::builder()
                 .set_name(Some("architecture".to_string()))
-                .set_values(Some(vec![arch.as_ref().to_string()]))
+                .set_values(Some(vec![arch.into()]))
                 .build(),
             Filter::builder()
                 .set_name(Some("image-type".to_string()))
@@ -238,7 +196,7 @@ where
                 .build(),
             Filter::builder()
                 .set_name(Some("virtualization-type".to_string()))
-                .set_values(Some(vec![VIRT_TYPE.to_string()]))
+                .set_values(Some(vec![mk_amispec::VIRT_TYPE.to_string()]))
                 .build(),
         ]))
         .send()
@@ -280,29 +238,19 @@ mod error {
     use snafu::Snafu;
     use std::path::PathBuf;
 
+    use super::mk_amispec;
+
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
     pub(crate) enum Error {
+        #[snafu(display("Failed to create an amispec from publication inputs: {}", source))]
+        Amispec { source: mk_amispec::AmispecError },
+
         #[snafu(display("Failed to describe images in {}: {}", region, source))]
         DescribeImages {
             region: String,
             source: SdkError<DescribeImagesError>,
         },
-
-        #[snafu(display("Failed to load variant manifest from {}: {}", path.display(), source))]
-        LoadVariantManifest {
-            path: PathBuf,
-            source: buildsys::manifest::Error,
-        },
-
-        #[snafu(display("Failed to load UEFI data from {}: {}", path.display(), source))]
-        LoadUefiData {
-            path: PathBuf,
-            source: std::io::Error,
-        },
-
-        #[snafu(display("Could not find image layout for {}", path.display()))]
-        MissingImageLayout { path: PathBuf },
 
         #[snafu(display("Image response in {} did not include image ID", region))]
         MissingImageId { region: String },

--- a/tools/pubsys/src/aws/ami/register/mod.rs
+++ b/tools/pubsys/src/aws/ami/register/mod.rs
@@ -1,10 +1,16 @@
 use super::{snapshot::snapshot_from_image, AmiArgs};
+use crate::aws::ami::snapshot::build_progress_bar;
 use aws_sdk_ebs::Client as EbsClient;
 use aws_sdk_ec2::types::Filter;
 use aws_sdk_ec2::{config::Region, Client as Ec2Client};
 use coldsnap::{SnapshotUploader, SnapshotWaiter};
+use futures::future::OptionFuture;
+use indicatif::{MultiProgress, ProgressBar};
 use log::{debug, info, warn};
-use snafu::{ensure, OptionExt, ResultExt};
+use snafu::{ensure, futures::TryFutureExt as _, OptionExt, ResultExt, Snafu};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 mod merge_toml;
 pub(crate) mod mk_amispec;
@@ -22,7 +28,7 @@ async fn _register_image(
     region: &Region,
     ebs_client: EbsClient,
     ec2_client: &Ec2Client,
-    cleanup_snapshot_ids: &mut Vec<String>,
+    cleanup_snapshot_ids: Arc<Mutex<Vec<String>>>,
 ) -> Result<RegisteredIds> {
     let bottlerocket_snapshots = BottlerocketSnapshots::create_snapshots(
         ami_args,
@@ -77,59 +83,105 @@ impl BottlerocketSnapshots {
     /// Creates the EBS snapshots for the OS and (optional) data volume
     ///
     /// Snapshot IDs are added to `cleanup_snapshot_ids` so that they can be deleted on cleanup.
+    async fn create_snapshot(
+        snapshot_uploader: &SnapshotUploader,
+        snapshot_waiter: &SnapshotWaiter,
+        image_path: impl AsRef<Path>,
+        cleanup_snapshot_ids: Arc<Mutex<Vec<String>>>,
+        progress_bar: Option<ProgressBar>,
+    ) -> Result<String, CreateSnapshotError> {
+        use create_snapshot_error::*;
+        let image_path = image_path.as_ref();
+
+        let snapshot_id = snapshot_from_image(image_path, snapshot_uploader, None, progress_bar)
+            .await
+            .context(UploadSnapshotSnafu { path: image_path })?;
+
+        cleanup_snapshot_ids.lock().await.push(snapshot_id.clone());
+
+        info!("Waiting for snapshot {snapshot_id} to become available");
+        snapshot_waiter
+            .wait(&snapshot_id, Default::default())
+            .await
+            .context(WaitSnapshotSnafu)?;
+
+        Ok(snapshot_id)
+    }
+
+    /// Creates the EBS snapshots for the OS and (optional) data volume
+    ///
+    /// Snapshot IDs are added to `cleanup_snapshot_ids` so that they can be deleted on cleanup.
     async fn create_snapshots(
         ami_args: &AmiArgs,
         region: &Region,
         ebs_client: EbsClient,
         ec2_client: &Ec2Client,
-        cleanup_snapshot_ids: &mut Vec<String>,
+        cleanup_snapshot_ids: Arc<Mutex<Vec<String>>>,
     ) -> Result<BottlerocketSnapshots> {
         debug!("Uploading images into EBS snapshots in {}", region);
-        let uploader = SnapshotUploader::new(ebs_client);
-        let os_snapshot =
-            snapshot_from_image(&ami_args.os_image, &uploader, None, ami_args.no_progress)
-                .await
+
+        let multi_progress = MultiProgress::new();
+
+        let create_snapshot_task = |image_path: PathBuf, image_name: &'static str| {
+            let progress_bar = (!ami_args.no_progress)
+                .then_some({
+                    let pb = build_progress_bar(&format!("Upload {image_name} snapshot"))
+                        .context(error::ProgressBarSnafu)?;
+                    Ok(multi_progress.add(pb))
+                })
+                .transpose()?;
+
+            Ok(async move {
+                info!("Registering '{image_name}' snapshot in region '{region}'");
+                let uploader = SnapshotUploader::new(ebs_client.clone());
+                let waiter = SnapshotWaiter::new(ec2_client.clone());
+                let cloned_image_path = image_path.clone();
+
+                Self::create_snapshot(
+                    &uploader,
+                    &waiter,
+                    &cloned_image_path,
+                    Arc::clone(&cleanup_snapshot_ids),
+                    progress_bar.clone(),
+                )
                 .context(error::SnapshotSnafu {
-                    path: &ami_args.os_image,
-                    region: region.as_ref(),
-                })?;
-        cleanup_snapshot_ids.push(os_snapshot.clone());
-
-        let mut data_snapshot = None;
-        if let Some(data_image) = &ami_args.data_image {
-            let snapshot = snapshot_from_image(data_image, &uploader, None, ami_args.no_progress)
+                    snapshot_type: image_name.to_string(),
+                    path: image_path,
+                    region: region.to_string(),
+                })
                 .await
-                .context(error::SnapshotSnafu {
-                    path: &ami_args.os_image,
-                    region: region.as_ref(),
-                })?;
-            cleanup_snapshot_ids.push(snapshot.clone());
-            data_snapshot = Some(snapshot);
-        }
+            })
+        };
 
-        info!("Waiting for snapshots to become available in {}", region);
-        let waiter = SnapshotWaiter::new(ec2_client.clone());
-        waiter
-            .wait(&os_snapshot, Default::default())
-            .await
-            .context(error::WaitSnapshotSnafu {
-                snapshot_type: "root",
-            })?;
+        let os_upload = create_snapshot_task.clone()(ami_args.os_image.clone(), "root")?;
 
-        if let Some(ref data_snapshot) = data_snapshot {
-            waiter
-                .wait(&data_snapshot, Default::default())
-                .await
-                .context(error::WaitSnapshotSnafu {
-                    snapshot_type: "data",
-                })?;
-        }
+        let data_upload: OptionFuture<_> = ami_args
+            .data_image
+            .as_ref()
+            .map(|data_image| create_snapshot_task(data_image.clone(), "data"))
+            .transpose()?
+            .into();
+
+        let (os_snapshot, data_snapshot) = tokio::join!(os_upload, data_upload);
+        let (os_snapshot, data_snapshot) = (os_snapshot?, data_snapshot.transpose()?);
 
         Ok(BottlerocketSnapshots {
             os_snapshot,
             data_snapshot,
         })
     }
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub(crate) enum CreateSnapshotError {
+    #[snafu(display("Failed to create snapshot for {}: {}", path.display(), source))]
+    UploadSnapshot {
+        path: PathBuf,
+        source: crate::aws::ami::snapshot::Error,
+    },
+    #[snafu(display("Failed to wait for snapshot to become available: {}", source))]
+    WaitSnapshot { source: coldsnap::WaitError },
 }
 
 /// Uploads the given images into snapshots and registers an AMI using them as its block device
@@ -140,18 +192,18 @@ pub(crate) async fn register_image(
     ebs_client: EbsClient,
     ec2_client: &Ec2Client,
 ) -> Result<RegisteredIds> {
-    let mut cleanup_snapshot_ids = Vec::new();
+    let cleanup_snapshot_ids = Arc::new(Mutex::new(Vec::new()));
     let register_result = _register_image(
         ami_args,
         region,
         ebs_client,
         ec2_client,
-        &mut cleanup_snapshot_ids,
+        Arc::clone(&cleanup_snapshot_ids),
     )
     .await;
 
     if register_result.is_err() {
-        for snapshot_id in cleanup_snapshot_ids {
+        for snapshot_id in cleanup_snapshot_ids.lock().await.iter() {
             if let Err(e) = ec2_client
                 .delete_snapshot()
                 .set_snapshot_id(Some(snapshot_id.clone()))
@@ -230,15 +282,13 @@ where
 }
 
 mod error {
-    use crate::aws::ami;
+    use super::{mk_amispec, CreateSnapshotError};
     use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::{
         describe_images::DescribeImagesError, register_image::RegisterImageError,
     };
     use snafu::Snafu;
     use std::path::PathBuf;
-
-    use super::mk_amispec;
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
@@ -264,19 +314,19 @@ mod error {
             source: SdkError<RegisterImageError>,
         },
 
-        #[snafu(display("Failed to upload snapshot from {} in {}: {}", path.display(),region, source))]
-        Snapshot {
-            path: PathBuf,
-            region: String,
-            source: ami::snapshot::Error,
+        #[snafu(display("Failed to create progress bar: {}", source))]
+        ProgressBar {
+            source: crate::aws::ami::snapshot::Error,
         },
 
-        #[snafu(display("{} snapshot did not become available: {}", snapshot_type, source))]
-        WaitSnapshot {
+        #[snafu(display("Failed to upload {} snapshot from {} in {}: {}", snapshot_type, path.display(),region, source))]
+        Snapshot {
             snapshot_type: String,
-            source: coldsnap::WaitError,
+            path: PathBuf,
+            region: String,
+            source: CreateSnapshotError,
         },
     }
 }
 pub(crate) use error::Error;
-type Result<T> = std::result::Result<T, error::Error>;
+type Result<T, E = error::Error> = std::result::Result<T, E>;

--- a/tools/pubsys/src/aws/ami/snapshot.rs
+++ b/tools/pubsys/src/aws/ami/snapshot.rs
@@ -3,11 +3,8 @@ use indicatif::{ProgressBar, ProgressStyle};
 use snafu::{OptionExt, ResultExt};
 use std::path::Path;
 
-/// Create a progress bar to show status of snapshot blocks, if wanted.
-fn build_progress_bar(no_progress: bool, verb: &str) -> Result<Option<ProgressBar>> {
-    if no_progress {
-        return Ok(None);
-    }
+/// Create a progress bar to show status of snapshot blocks.
+pub(crate) fn build_progress_bar(verb: &str) -> Result<ProgressBar> {
     let progress_bar = ProgressBar::new(0);
     progress_bar.set_style(
         ProgressStyle::default_bar()
@@ -15,7 +12,7 @@ fn build_progress_bar(no_progress: bool, verb: &str) -> Result<Option<ProgressBa
             .context(error::ProgressBarTemplateSnafu)?
             .progress_chars("=> "),
     );
-    Ok(Some(progress_bar))
+    Ok(progress_bar)
 }
 
 /// Uploads the given path into a snapshot.
@@ -23,20 +20,19 @@ pub(crate) async fn snapshot_from_image<P>(
     path: P,
     uploader: &SnapshotUploader,
     desired_size: Option<i64>,
-    no_progress: bool,
+    progress_bar: Option<ProgressBar>,
 ) -> Result<String>
 where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    let progress_bar = build_progress_bar(no_progress, "Uploading snapshot");
     let filename = path
         .file_name()
         .context(error::InvalidImagePathSnafu { path })?
         .to_string_lossy();
 
     uploader
-        .upload_from_file(path, desired_size, Some(&filename), progress_bar?)
+        .upload_from_file(path, desired_size, Some(&filename), progress_bar.clone())
         .await
         .context(error::UploadSnapshotSnafu)
 }

--- a/tools/pubsys/src/frompath.rs
+++ b/tools/pubsys/src/frompath.rs
@@ -1,0 +1,116 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+/// Represents data that has been loaded from the filesystem at a given path.
+///
+/// Useful for adding path information to error messages.
+/// Implements `Deref<Target=T>` for ergonomic purposes.
+pub enum FromPath<T> {
+    FromPath { data: T, path: PathBuf },
+    NoPath(T),
+}
+
+impl<T> FromPath<T> {
+    pub fn new_from_path(data: T, path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        Self::FromPath { path, data }
+    }
+
+    pub fn new(data: T) -> Self {
+        Self::NoPath(data)
+    }
+
+    pub fn data(&self) -> &T {
+        match self {
+            Self::FromPath { data, .. } => data,
+            Self::NoPath(data) => data,
+        }
+    }
+
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::FromPath { path, .. } => Some(path),
+            Self::NoPath(_) => None,
+        }
+    }
+
+    pub fn display_path(&self) -> String {
+        match self {
+            Self::FromPath { path, .. } => path.display().to_string(),
+            Self::NoPath(_) => "<no path>".to_string(),
+        }
+    }
+}
+
+impl<T> Deref for FromPath<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.data()
+    }
+}
+
+impl<T: Debug> Debug for FromPath<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FromPath { path, data } => f
+                .debug_struct("FromPath")
+                .field("path", path)
+                .field("data", data)
+                .finish(),
+            Self::NoPath(data) => f.debug_tuple("FromPath").field(data).finish(),
+        }
+    }
+}
+
+impl<T: Clone> Clone for FromPath<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::FromPath { path, data } => Self::FromPath {
+                path: path.clone(),
+                data: data.clone(),
+            },
+            Self::NoPath(data) => Self::NoPath(data.clone()),
+        }
+    }
+}
+
+impl<T: Serialize> Serialize for FromPath<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.data().serialize(serializer)
+    }
+}
+
+impl<'de, T> FromPath<T>
+where
+    T: Deserialize<'de>,
+{
+    pub fn deserialize_from_path<D>(
+        path: impl Into<PathBuf>,
+        deserializer: D,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let path = path.into();
+        let data = T::deserialize(deserializer)?;
+        Ok(Self::FromPath { path, data })
+    }
+}
+
+impl<T: Default> Default for FromPath<T> {
+    fn default() -> Self {
+        Self::NoPath(T::default())
+    }
+}
+
+impl<T> From<T> for FromPath<T> {
+    fn from(value: T) -> Self {
+        Self::NoPath(value)
+    }
+}

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -23,6 +23,7 @@ Configuration comes from:
 */
 
 mod aws;
+pub mod frompath;
 mod kit;
 mod repo;
 mod vmware;

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -180,6 +180,9 @@ PUBLISH_REPO_OUTPUT_DIR = "${PUBLISH_REPO_BASE_DIR}/${PUBLISH_REPO}/${BUILDSYS_N
 # The default name of registered AMIs; override by setting PUBLISH_AMI_NAME.
 PUBLISH_AMI_NAME_DEFAULT = "${BUILDSYS_NAME}-${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-v${BUILDSYS_VERSION_IMAGE}-${BUILDSYS_VERSION_BUILD}"
 
+# The name of the amispec template that will be used to derive AWS AMI attributes
+BUILDSYS_AMISPEC_TEMPLATE = "${BUILDSYS_ROOT_DIR}/variants/${BUILDSYS_VARIANT}/amispec.toml"
+
 # The name of the kmod kit archive, used to ease building out-of-tree kernel modules.
 BUILDSYS_KMOD_KIT = "${BUILDSYS_VARIANT}-${BUILDSYS_ARCH}-kmod-kit-v${BUILDSYS_VERSION_IMAGE}.tar.xz"
 BUILDSYS_KMOD_KIT_PATH = "${BUILDSYS_VARIANT_DIR}/${BUILDSYS_KMOD_KIT}"
@@ -1307,6 +1310,10 @@ if [ "${is_split}" == "yes" ] ; then
    data_volume_args+=(--data-image "${data_image}")
 fi
 
+if [ -s "${BUILDSYS_AMISPEC_TEMPLATE}" ]; then
+   AMISPEC_EXISTS=1
+fi
+
 ami_output="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-${AMI_DATA_FILE_SUFFIX}"
 ami_output_latest="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_VARIANT}-${AMI_DATA_FILE_SUFFIX}"
 
@@ -1326,6 +1333,7 @@ pubsys \
    --arch "${BUILDSYS_ARCH}" \
    --name "${ami_name}" \
    --description "${PUBLISH_AMI_DESCRIPTION:-${ami_name}}" \
+   ${AMISPEC_EXISTS:+--amispec-file "${BUILDSYS_AMISPEC_TEMPLATE}"} \
    \
    --ami-output "${ami_output}" \
    \


### PR DESCRIPTION
**Description of changes:**
This change allows `twoliter` users to place an `amispec.toml` template alongside the `Cargo.toml` for their variant, overriding properties of the registered AMI.

Large diff, but a lot of it is tests of the `amispec` generation.

---

    pubsys: integrate with amispec

    Users can now define an `amispec.toml` file alongside their variant's
    Cargo.toml file, specifying overrides for the default AMI properties
    used when registering that variant as an AMI with pubsys.

---

    amispec: add Display implementations to amispec types

---

    amispec: allow u64 inputs to bounded ebs volume fields


**Testing done:**
* Unit tests pass
* Registered an AMI prior to this change, then with this change but only a `name` overridden in `amispec.toml`. This is the diff of `aws describe-images`

```
11c11
<                         "SnapshotId": "snap-001b6ffe9125c9a00",
---
>                         "SnapshotId": "snap-0d2dfc19d789f0725",
21c21
<                         "SnapshotId": "snap-065f575ec94538730",
---
>                         "SnapshotId": "snap-09409c6cf48e306ae",
28c28
<             "CreationDate": "2025-05-02T23:49:33.000Z",
---
>             "CreationDate": "2025-05-02T23:55:12.000Z",
33,34c33,34
<             "ImageId": "REDACTED",
<             "ImageLocation": "REDACTED/bottlerocket-aws-k8s-1.31-aarch64-v1.38.0-78594e2e",
---
>             "ImageId": "REDACTED",
>             "ImageLocation": "REDACTED/bottlerocket-aws-k8s-1.31-aarch64-v1.38.0-78594e2e-extended",
36c36
<             "Name": "bottlerocket-aws-k8s-1.31-aarch64-v1.38.0-78594e2e",
---
>             "Name": "bottlerocket-aws-k8s-1.31-aarch64-v1.38.0-78594e2e-extended"
```
* Registered an AMI with no `amispec.toml` and ensured it used the same default values as prior.
* Registered an AMI using the `unified` partition-plan with the following `amispec.toml`:

```toml
name = "lol what"

[block-device-mappings."/dev/xvda".ebs]
volume-type = "gp3"
iops = "3000"
volume-size = "32"

[block-device-mappings."/dev/xvdb".ebs]
volume-type = "io2"
iops = "800"
volume-size = "16"

[block-device-mappings."/dev/xvdc".ebs]
volume-type = "gp2"
volume-size = "3"
```
Confirmed that the name was `"Name": "lol what",` and that three different EBS volumes were created:

```json
{
    "Ebs": {
        "DeleteOnTermination": true,
        "Iops": 3000,
        "SnapshotId": "REDACTED",
        "VolumeSize": 32,
        "VolumeType": "gp3",
        "Encrypted": false
    },
    "DeviceName": "/dev/xvda"
},
{
    "Ebs": {
        "DeleteOnTermination": true,
        "Iops": 800,
        "VolumeSize": 16,
        "VolumeType": "io2",
        "Encrypted": false
    },
    "DeviceName": "/dev/xvdb"
},
{
    "Ebs": {
        "DeleteOnTermination": true,
        "VolumeSize": 3,
        "VolumeType": "gp2",
        "Encrypted": false
    },
    "DeviceName": "/dev/xvdc"
}
```
* Registered an AMI using the `unified` partition plan, and tried to make the root volume way too small:

```toml
name = "{{ ami.unique_name }} bad size"

[block-device-mappings."/dev/xvda".ebs]
volume-type = "gp3"
volume-size = "1"
```

Confirmed that the name was overridden, only one block device was configured, and my poor `volume-size` directive was ignored:

```json
"BlockDeviceMappings": [
    {
        "Ebs": {
            "DeleteOnTermination": true,
            "SnapshotId": "REDACTED",
            "VolumeSize": 22,
            "VolumeType": "gp3",
            "Encrypted": false
        },
        "DeviceName": "/dev/xvda"
    }
]
```

During this registration, `pubsys` said:

```
00:22:10 [INFO] Merging user-defined amispec template for AMI properties
00:22:10 [WARN] EBS volume 'Gp3(Gp3 { volume_size: Some(Bounded(1)), iops: None, throughput: None, delete_on_termination: Some(true), encrypted: None, kms_key_id: None, outpost_arn: None, snapshot_id: Some("Redacted") })' was configured with size '1', but size hints dictate that it should be larger. Using volume size '22'
00:22:10 [INFO] Making register image call in us-west-2
```

* Confirmed that `uefi` data is properly set for secureboot AMIs.

* Confirmed that AMIs with overridden names are properly detected as being already-registered
* Confirmed that copied AMIs maintain overridden features like `name` and `arch`



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
