### PR TITLE
pubsys: add --dry-run mode to promote-ssm

### DIFF
--- a/tools/pubsys/src/aws/promote_ssm/mod.rs
+++ b/tools/pubsys/src/aws/promote_ssm/mod.rs
@@ -9,7 +9,7 @@ use crate::aws::{parse_arch, region_from_string};
 use crate::Args;
 use aws_sdk_ec2::types::ArchitectureValues;
 use aws_sdk_ssm::{config::Region, Client as SsmClient};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use log::{info, trace};
 use pubsys_config::InfraConfig;
 use snafu::{ensure, ResultExt};
@@ -18,6 +18,11 @@ use std::path::PathBuf;
 
 /// Copies sets of SSM parameters
 #[derive(Debug, Parser)]
+#[command(group(
+    ArgGroup::new("dry_run_requirements")
+        .arg("dry_run")
+        .requires("ssm_parameter_output")
+))]
 pub(crate) struct PromoteArgs {
     /// The architecture of the machine image
     #[arg(long, value_parser = parse_arch)]
@@ -47,6 +52,10 @@ pub(crate) struct PromoteArgs {
     /// and where the newly promoted parameters will be written
     #[arg(long)]
     ssm_parameter_output: Option<PathBuf>,
+
+    /// If enabled, only parameter manifest will generated, and SSM will not promoted
+    #[arg(long)]
+    dry_run: bool,
 }
 
 /// Common entrypoint from main()
@@ -212,6 +221,12 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
     // parameters
     if let Some(ssm_parameter_output) = &promote_args.ssm_parameter_output {
         append_rendered_parameters(ssm_parameter_output, &full_target_parameters).await?;
+    }
+
+    // Exit early if `--dry-run` is enabled
+    if promote_args.dry_run {
+        info!("Dry-run mode enabled: Exiting after writing parameter manifest.");
+        return Ok(());
     }
 
     // SSM set   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1560,7 +1560,8 @@ pubsys \
    --template-path "${PUBLISH_SSM_TEMPLATES_PATH}" \
    --ssm-parameter-output "${ssm_parameter_output}" \
    \
-   ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"}
+   ${PUBLISH_REGIONS:+--regions "${PUBLISH_REGIONS}"} \
+   ${PUBLISH_SSM_DRY_RUN:+--dry-run}
 '''
 ]
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #356

**Description of changes:**
Add `--dry-run` flag to `pubsys promote-ssm` subcommand, allowing users to generate a manifest of SSM parameter updates without actually modifying AWS SSM parameters. 


**Testing done:**
- [x] Exit early when `--dry-run` and `-ssm-parameter-output` set.
- [x] Error when `--ssm-parameter-output` not set when `--dry-run` enabled.
- [x] Promote ssm when `--dry-run` is set.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
