### PR TITLE
fix: make sure to read env var at build script exec time, not at build time

### DIFF
--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -14,8 +14,6 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use std::{env, fs};
 
-const DATA_INPUT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/embedded");
-
 fn main() {
     let paths = Paths::new();
     println!("cargo:rerun-if-changed={}", paths.data_input_dir.display());
@@ -79,11 +77,13 @@ impl Paths {
     fn new() -> Self {
         // This is the directory that cargo creates for us so that we can pass things from the build
         // script to the main compilation phase.
+        let cargo_manifest_dir =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("The cargo variable 'CARGO_MANIFEST_DIR' is missing"));
         let out_dir =
             PathBuf::from(env::var("OUT_DIR").expect("The cargo variable 'OUT_DIR' is missing"));
 
         Self {
-            data_input_dir: PathBuf::from(DATA_INPUT_DIR),
+            data_input_dir: cargo_manifest_dir.join("embedded"),
             prep_dir: out_dir.join("tools"),
             tar_gz: out_dir.join("tools.tar.gz"),
         }

--- a/twoliter/build.rs
+++ b/twoliter/build.rs
@@ -77,8 +77,10 @@ impl Paths {
     fn new() -> Self {
         // This is the directory that cargo creates for us so that we can pass things from the build
         // script to the main compilation phase.
-        let cargo_manifest_dir =
-            PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("The cargo variable 'CARGO_MANIFEST_DIR' is missing"));
+        let cargo_manifest_dir = PathBuf::from(
+            env::var("CARGO_MANIFEST_DIR")
+                .expect("The cargo variable 'CARGO_MANIFEST_DIR' is missing"),
+        );
         let out_dir =
             PathBuf::from(env::var("OUT_DIR").expect("The cargo variable 'OUT_DIR' is missing"));
 


### PR DESCRIPTION
**Description of changes:**
We briefly discussed this during the community meeting. I encountered this when building twoliter using Bazel, which I understand don't follow maybe the implicit expectations of the regular cargo build process, but the "problem" is that you rely on `DATA_INPUT_DIR` in runtime being derived from `CARGO_MANIFEST_DIR` at build time. If this is different between the build script being built (when the `env!` macro is expanded into the const) and the build script being executed (when it produces the `twoliter` binary), the current code will break.
(this is something Bazel, with its parallelization and sandboxing, does)


**Testing done:**
Tested building using both Bazel and the regular build process and it worked fine. :)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
