### PR TITLE
feat: allow keys from env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,6 +3013,7 @@ version = "0.1.0"
 dependencies = [
  "amispec",
  "async-stream",
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-ebs",

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -163,6 +163,9 @@ pub enum SigningKeyConfig {
     ssm {
         parameter: String,
     },
+    env {
+        var_name: String,
+    },
 }
 
 /// AWS region-specific configuration
@@ -201,6 +204,9 @@ impl TryFrom<SigningKeyConfig> for Url {
                     format!("/{}", parameter)
                 };
                 Url::parse(&format!("aws-ssm://{}", parameter)).map_err(|_| ())
+            }
+            SigningKeyConfig::env { var_name } => {
+                Url::parse(&format!("env://{}", var_name)).map_err(|_| ())
             }
         }
     }

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 amispec.workspace = true
 async-stream.workspace = true
+async-trait.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true
 aws-sdk-ebs.workspace = true

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -5,10 +5,13 @@ pub(crate) mod fetch_variant;
 pub(crate) mod refresh_repo;
 pub(crate) mod validate_repo;
 
+mod env_key_source;
+
 use crate::{friendly_version, read_stream, Args};
 use aws_sdk_kms::{config::Region, Client as KmsClient};
 use chrono::{DateTime, Utc};
 use clap::Parser;
+use env_key_source::EnvKeySource;
 use lazy_static::lazy_static;
 use log::{debug, info, trace, warn};
 use parse_datetime::parse_datetime;
@@ -428,6 +431,9 @@ fn get_signing_key_source(signing_key_config: &SigningKeyConfig) -> Result<Box<d
             profile: None,
             parameter_name: parameter.clone(),
             key_id: None,
+        })),
+        SigningKeyConfig::env { var_name } => Ok(Box::new(EnvKeySource {
+            var_name: var_name.clone(),
         })),
     }
 }

--- a/tools/pubsys/src/repo/env_key_source.rs
+++ b/tools/pubsys/src/repo/env_key_source.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use log::{debug,warn};
+use log::{debug, warn};
 use snafu::Snafu;
 use std::env;
 use tough::key_source::KeySource;

--- a/tools/pubsys/src/repo/env_key_source.rs
+++ b/tools/pubsys/src/repo/env_key_source.rs
@@ -1,0 +1,52 @@
+use async_trait::async_trait;
+use log::debug;
+use snafu::Snafu;
+use std::env;
+use tough::key_source::KeySource;
+use tough::sign::{parse_keypair, Sign};
+
+#[derive(Debug)]
+pub struct EnvKeySource {
+    pub var_name: String,
+}
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Environment variable '{}' not found", var_name))]
+    EnvVarNotFound { var_name: String },
+
+    #[snafu(display("Failed to parse key from environment variable '{}': {}", var_name, source))]
+    KeyParse {
+        var_name: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+#[async_trait]
+impl KeySource for EnvKeySource {
+    async fn as_sign(&self) -> std::result::Result<Box<dyn Sign>, Box<dyn std::error::Error + Send + Sync>> {
+        debug!("Reading key from environment variable: {}", self.var_name);
+
+        // Get the key data from the environment variable
+        let key_data = env::var(&self.var_name)
+            .map_err(|_| Error::EnvVarNotFound {
+                var_name: self.var_name.clone(),
+            })?;
+
+        // Parse the key data into a signer
+        let key = parse_keypair(key_data.as_bytes())
+            .map_err(|e| Error::KeyParse {
+                var_name: self.var_name.clone(),
+                source: Box::new(e),
+            })?;
+
+        Ok(Box::new(key))
+    }
+
+    async fn write(&self, _value: &str, _key_id_hex: &str) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // We don't support writing keys back to environment variables
+        // as this wouldn't persist beyond the current process
+        debug!("Writing keys back to environment variables is not supported");
+        Ok(())
+    }
+}

--- a/tools/pubsys/src/repo/env_key_source.rs
+++ b/tools/pubsys/src/repo/env_key_source.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use log::debug;
+use log::{debug,warn};
 use snafu::Snafu;
 use std::env;
 use tough::key_source::KeySource;

--- a/tools/pubsys/src/repo/env_key_source.rs
+++ b/tools/pubsys/src/repo/env_key_source.rs
@@ -15,7 +15,11 @@ pub enum Error {
     #[snafu(display("Environment variable '{}' not found", var_name))]
     EnvVarNotFound { var_name: String },
 
-    #[snafu(display("Failed to parse key from environment variable '{}': {}", var_name, source))]
+    #[snafu(display(
+        "Failed to parse key from environment variable '{}': {}",
+        var_name,
+        source
+    ))]
     KeyParse {
         var_name: String,
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -24,29 +28,33 @@ pub enum Error {
 
 #[async_trait]
 impl KeySource for EnvKeySource {
-    async fn as_sign(&self) -> std::result::Result<Box<dyn Sign>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn as_sign(
+        &self,
+    ) -> std::result::Result<Box<dyn Sign>, Box<dyn std::error::Error + Send + Sync>> {
         debug!("Reading key from environment variable: {}", self.var_name);
 
         // Get the key data from the environment variable
-        let key_data = env::var(&self.var_name)
-            .map_err(|_| Error::EnvVarNotFound {
-                var_name: self.var_name.clone(),
-            })?;
+        let key_data = env::var(&self.var_name).map_err(|_| Error::EnvVarNotFound {
+            var_name: self.var_name.clone(),
+        })?;
 
         // Parse the key data into a signer
-        let key = parse_keypair(key_data.as_bytes())
-            .map_err(|e| Error::KeyParse {
-                var_name: self.var_name.clone(),
-                source: Box::new(e),
-            })?;
+        let key = parse_keypair(key_data.as_bytes()).map_err(|e| Error::KeyParse {
+            var_name: self.var_name.clone(),
+            source: Box::new(e),
+        })?;
 
         Ok(Box::new(key))
     }
 
-    async fn write(&self, _value: &str, _key_id_hex: &str) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn write(
+        &self,
+        _value: &str,
+        _key_id_hex: &str,
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // We don't support writing keys back to environment variables
         // as this wouldn't persist beyond the current process
-        debug!("Writing keys back to environment variables is not supported");
+        warn!("Writing keys back to environment variables is not supported");
         Ok(())
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #464 

**Description of changes:**
This adds support for getting the key for signing repositories from the env as well as file/kms etc.


**Testing done:**
Has been used in a production setting for a few months.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
