### PR TITLE
pubsys: allow ami copies when uefi-data not provided

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -55,7 +55,7 @@ pub(crate) struct AmiArgs {
 
     /// Path to the UEFI data
     #[arg(short = 'e', long, value_parser = parse_uefi_data)]
-    uefi_data: FromPath<String>,
+    uefi_data: Option<FromPath<String>>,
 
     /// The architecture of the machine image
     #[arg(short = 'a', long)]
@@ -144,7 +144,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     // This is used to determine the desired name and architecture, so that we can see if our AMI
     // already exists.
     let tentative_amispec =
-        mk_amispec::create_amispec(ami_args, None).context(error::AmispecSnafu)?;
+        mk_amispec::create_minimal_amispec(ami_args).context(error::AmispecSnafu)?;
 
     let arch = tentative_amispec
         .architecture

--- a/tools/pubsys/src/aws/ami/register/mk_amispec.rs
+++ b/tools/pubsys/src/aws/ami/register/mk_amispec.rs
@@ -80,36 +80,77 @@ pub(crate) fn create_amispec(
     ami_args: &AmiArgs,
     bottlerocket_snapshots: Option<&BottlerocketSnapshots>,
 ) -> Result<AmiSpec> {
-    use amispec_error::*;
-
-    let mut amispec_template_toml = default_amispec_template(
+    let amispec_template_toml = default_amispec_template(
         &ami_args.variant_manifest,
         bottlerocket_snapshots,
-        &ami_args.uefi_data,
+        ami_args.uefi_data.as_ref().map(|s| s.as_str()),
     )?;
-
-    if let Some(user_amispec_template) = &ami_args.amispec_file {
-        info!("Merging user-defined amispec template for AMI properties");
-        amispec_template_toml.merge(user_amispec_template);
-    } else {
-        info!("Using default amispec for AMI properties");
-    }
-
-    debug!("Creating amispec with template:\n{amispec_template_toml}");
-    let amispec_template: TemplatedAmiSpec = amispec_template_toml
-        .try_into()
-        .context(ParseAmiSpecTemplateSnafu)?;
 
     let render_context = AmispecRenderContext::from_ami_args(ami_args, bottlerocket_snapshots)?;
     debug!("Creating amispec with render context:\n{render_context:#?}",);
 
-    let mut amispec = amispec_template
-        .render(&render_context)
-        .context(RenderAmiSpecSnafu)?;
+    let mut amispec = create_amispec_from_base(amispec_template_toml, &render_context, ami_args)?;
 
     ensure_amispec_volume_sizes(&mut amispec, &render_context.block_devices)?;
 
     Ok(amispec)
+}
+
+fn create_amispec_from_base(
+    mut base_amispec_template: toml::Table,
+    render_context: &AmispecRenderContext,
+    ami_args: &AmiArgs,
+) -> Result<AmiSpec> {
+    use amispec_error::*;
+
+    if let Some(user_amispec_template) = &ami_args.amispec_file {
+        info!("Merging user-defined amispec template for AMI properties");
+        base_amispec_template.merge(user_amispec_template);
+    } else {
+        info!("Using default amispec for AMI properties");
+    }
+
+    debug!("Creating amispec with template:\n{base_amispec_template}");
+    let amispec_template: TemplatedAmiSpec = base_amispec_template
+        .try_into()
+        .context(ParseAmiSpecTemplateSnafu)?;
+
+    amispec_template
+        .render(&render_context)
+        .context(RenderAmiSpecSnafu)
+}
+
+/// A partial rendered AmiSpec
+///
+/// Useful for determining the desired name, description, and architecture of an AMI prior to the
+/// creation of EBS snapshots.
+pub(crate) struct MinimalAmiSpec {
+    pub name: String,
+    pub description: Option<String>,
+    pub architecture: Option<amispec::Architecture>,
+}
+
+impl From<AmiSpec> for MinimalAmiSpec {
+    fn from(amispec: AmiSpec) -> Self {
+        let AmiSpec {
+            name,
+            description,
+            architecture,
+            ..
+        } = amispec;
+
+        Self {
+            name,
+            description,
+            architecture,
+        }
+    }
+}
+
+pub(crate) fn create_minimal_amispec(ami_args: &AmiArgs) -> Result<MinimalAmiSpec> {
+    let render_context = AmispecRenderContext::from_ami_args(ami_args, None)?;
+    create_amispec_from_base(DEFAULT_AMISPEC_TEMPLATE.clone(), &render_context, ami_args)
+        .map(Into::into)
 }
 
 /// Configure's the volume sizes for an AmiSpec based on a desired block device layout.
@@ -185,8 +226,10 @@ fn ensure_amispec_volume_sizes(
 fn default_amispec_template(
     variant_manifest: &VariantManifest,
     bottlerocket_snapshots: Option<&BottlerocketSnapshots>,
-    uefi_data: &str,
+    uefi_data: Option<&str>,
 ) -> Result<toml::Table> {
+    use amispec_error::*;
+
     let mut amispec_template = DEFAULT_AMISPEC_TEMPLATE.clone();
     let mut block_device_mappings = toml::Table::new();
 
@@ -213,7 +256,10 @@ fn default_amispec_template(
         .any(|f| *f == ImageFeature::UefiSecureBoot)
     {
         amispec_template.insert("boot-mode".into(), "uefi-preferred".into());
-        amispec_template.insert("uefi-data".into(), uefi_data.into());
+        amispec_template.insert(
+            "uefi-data".into(),
+            uefi_data.context(MissingUefiDataSnafu)?.into(),
+        );
     }
 
     Ok(amispec_template)
@@ -331,6 +377,11 @@ pub(crate) enum AmispecError {
     MissingImageLayout {
         variant_manifest: Box<VariantManifest>,
     },
+
+    #[snafu(display(
+        "No uefi-data provided. Cannot register 'uefi-secure-boot' without uefi-data."
+    ))]
+    MissingUefiData,
 
     #[snafu(display("Failed to parse AMI spec template: {}", source))]
     ParseAmiSpecTemplate { source: toml::de::Error },
@@ -482,7 +533,7 @@ mod test {
                     uefi-secure-boot = true
                 }.try_into().unwrap(),
             ),
-            uefi_data: "uefi-data!".to_string().into(),
+            uefi_data: Some("uefi-data!".to_string().into()),
             arch: "x86_64".into(),
             name: "test-ami".into(),
             description: Some("test description".into()),
@@ -553,7 +604,7 @@ mod test {
                     partition-plan = "unified"
                 }.try_into().unwrap(),
             ),
-            uefi_data: "uefi-data!".to_string().into(),
+            uefi_data: Some("uefi-data!".to_string().into()),
             arch: "x86_64".into(),
             name: "test-ami".into(),
             description: Some("test description".into()),
@@ -802,7 +853,7 @@ mod test {
         let actual_template = default_amispec_template(
             &VariantManifest::new(variant_manifest),
             Some(&bottlerocket_snapshots),
-            uefi_data,
+            Some(uefi_data),
         )
         .unwrap();
 

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1311,13 +1311,17 @@ if [ "${is_split}" == "yes" ] ; then
 fi
 
 if [ -s "${BUILDSYS_AMISPEC_TEMPLATE}" ]; then
-   AMISPEC_EXISTS=1
+   amispec_exists=1
 fi
 
 ami_output="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-${AMI_DATA_FILE_SUFFIX}"
 ami_output_latest="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_VARIANT}-${AMI_DATA_FILE_SUFFIX}"
 
 ami_name="${PUBLISH_AMI_NAME:-${PUBLISH_AMI_NAME_DEFAULT}}"
+
+if [ -s "${BUILDSYS_SBKEYS_PROFILE_DIR}/efi-vars.aws" ]; then
+   has_uefi_data=1
+fi
 
 pubsys \
    --log-level "${PUBLISH_LOG_LEVEL}" \
@@ -1329,11 +1333,11 @@ pubsys \
    "${data_volume_args[@]}" \
    \
    --variant-manifest "${BUILDSYS_ROOT_DIR}/variants/${BUILDSYS_VARIANT}/Cargo.toml" \
-   --uefi-data "${BUILDSYS_SBKEYS_PROFILE_DIR}/efi-vars.aws" \
+   ${has_uefi_data:+--uefi-data "${BUILDSYS_SBKEYS_PROFILE_DIR}/efi-vars.aws"} \
    --arch "${BUILDSYS_ARCH}" \
    --name "${ami_name}" \
    --description "${PUBLISH_AMI_DESCRIPTION:-${ami_name}}" \
-   ${AMISPEC_EXISTS:+--amispec-file "${BUILDSYS_AMISPEC_TEMPLATE}"} \
+   ${amispec_exists:+--amispec-file "${BUILDSYS_AMISPEC_TEMPLATE}"} \
    \
    --ami-output "${ami_output}" \
    \


### PR DESCRIPTION
**Description of changes:**
#524 introduced a bug.

* Previously, `uefi-data` was always expected by `pubsys ami`; however, if the command would only result in AMI copies, the file was never parsed.
* With #524, the file is parsed at the same time as CLI arguments. This would lead to an issue in which sbkey profiles aren't present while attempting to copy an image.


This change makes `uefi-data` optional, and only requires that it be present when needed to register an AMI that should have `uefi-secure-boot` enabled.


**Testing done:**
* Registered an AMI with UEFI secure boot
* Removed the UEFI data from my workspace and attempted to copy the AMI (succeeded)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
