### PR TITLE
workspace: use "fat" lto for dist and "thin" for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ members = [
 
 [profile.release]
 strip = "debuginfo"
-codegen-units = 1
-lto = true
+lto = "thin"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]
@@ -161,7 +160,8 @@ which = "6"
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+lto = "fat"
+codegen-units = 1
 
 [workspace.lints.clippy]
 disallowed-methods = "deny"


### PR DESCRIPTION
**Description of changes:**
Compiling `twoliter` with `--release` takes ~12 minutes; however, our `dist` builds actually compile with fewer optimizations than our `--release` builds. Whoops!

This flips the script, using `fat` LTO and fewer codegen units for an optimal binary at `dist` time while allowing for lighter optimizations when compiling with `--release`

**Testing done:**
* `cargo build --release` now completes in ~4 minutes on my machine

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
