### PR TITLE
chore: prepare for 0.10.1-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.10.0...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.10.1...HEAD
+
+## [0.10.1] - 2025-05-14
+
+### Fixed
+* Fix a bug which could prevent pubsys from copying existing AMIs when a secureboot profile is not present in the workspace ([#534])
+
+### Added
+* Add a `--dry-run` mode to `pubsys promote-ssm` ([#529])
+
+[#529]: https://github.com/bottlerocket-os/twoliter/pull/529
+[#534]: https://github.com/bottlerocket-os/twoliter/pull/534
+
+[0.10.1]: https://github.com/bottlerocket-os/twoliter/compare/v0.10.0..v0.10.1
 
 ## [0.10.0] - 2025-05-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.10.0"
+version = "0.10.1-rc1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ serde-templated-derive = { version = "0.1", path = "tools/serde-templated-derive
 testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" ] }
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
-twoliter = { version = "0.10.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.10.1-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.10.0"
+version = "0.10.1-rc1"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
**Description of changes:**
Prepare a point release to address:
* pubsys AMI copy bug
* Adding a mechanism for extracting SSM manifests prior to SSM publication, which will help us address a bug in our Bottlerocket release automation.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
