### PR TITLE
feat: add support for 'sbkey' being passed in through ENV

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -824,9 +824,9 @@ fn secrets_args() -> Result<Vec<String>> {
     // Add environment variables for secure boot signing keys, mapping them to the
     // corresponding file names that the local profile expects
     let env_to_file_map = [
-        ("BUILDSYS_SBKEY_SHIM_SIGN_KEY_CONTENT", "shim-sign.key"),
-        ("BUILDSYS_SBKEY_CODE_SIGN_KEY_CONTENT", "code-sign.key"),
-        ("BUILDSYS_SBKEY_CONFIG_SIGN_KEY_CONTENT", "config-sign.key"),
+        ("BUILDSYS_SBKEYS_SHIM_SIGN_KEY_CONTENT", "shim-sign.key"),
+        ("BUILDSYS_SBKEYS_CODE_SIGN_KEY_CONTENT", "code-sign.key"),
+        ("BUILDSYS_SBKEYS_CONFIG_SIGN_KEY_CONTENT", "config-sign.key"),
     ];
 
     for (env_var, file_name) in env_to_file_map {

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -821,6 +821,23 @@ fn secrets_args() -> Result<Vec<String>> {
         );
     }
 
+    // Add environment variables for secure boot signing keys, mapping them to the
+    // corresponding file names that the local profile expects
+    let env_to_file_map = [
+        ("BUILDSYS_SBKEY_SHIM_SIGN_KEY_CONTENT", "shim-sign.key"),
+        ("BUILDSYS_SBKEY_CODE_SIGN_KEY_CONTENT", "code-sign.key"),
+        ("BUILDSYS_SBKEY_CONFIG_SIGN_KEY_CONTENT", "config-sign.key"),
+    ];
+
+    for (env_var, file_name) in env_to_file_map {
+        if let Ok(content) = env::var(env_var) {
+            if !content.is_empty() {
+                // Only add this secret if the environment variable is set and not empty
+                args.build_secret("env", file_name, env_var);
+            }
+        }
+    }
+
     let ca_bundle_var = "BUILDSYS_CACERTS_BUNDLE_OVERRIDE";
     let ca_bundle_value =
         env::var(ca_bundle_var).context(error::EnvironmentSnafu { var: ca_bundle_var })?;

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -688,18 +688,29 @@ profile="${BUILDSYS_SBKEYS_PROFILE_DIR}"
 
 found=0
 # A local profile has signing keys and certificates, while an AWS profile
-# has a config for the aws-kms-pkcs11 helper. Either type is supported.
+# has a config for the aws-kms-pkcs11 helper. The environment variables profile
+# has keys provided through BUILDSYS_SBKEY_* environment variables. Any of
+# these profile types is supported.
 if [ -s "${profile}/shim-sign.key" ] && \
    [ -s "${profile}/shim-sign.crt" ] && \
    [ -s "${profile}/code-sign.key" ] && \
-   [ -s "${profile}/code-sign.crt" ] ; then
+   [ -s "${profile}/code-sign.crt" ] && \
+   [ -s "${profile}/config-sign.key" ] ; then
    let found+=1
-elif [ -s "${profile}/kms-sign.json" ] ; then
+elif [ -s "${profile}/kms-sign.json" ] && \
+     [ -s "${profile}/config-sign.key" ] ; then
+   let found+=1
+# Environment variables case - check if all required env vars are set
+elif [ -n "${BUILDSYS_SBKEY_SHIM_SIGN_KEY_CONTENT}" ] && \
+     [ -n "${BUILDSYS_SBKEY_CODE_SIGN_KEY_CONTENT}" ] && \
+     [ -n "${BUILDSYS_SBKEY_CONFIG_SIGN_KEY_CONTENT}" ] && \
+     [ -s "${profile}/shim-sign.crt" ] && \
+     [ -s "${profile}/code-sign.crt" ] ; then
    let found+=1
 fi
 
 expected=1
-for f in {PK,KEK,db,vendor}.crt config-sign.key efi-vars.{json,aws} ; do
+for f in {PK,KEK,db,vendor}.crt efi-vars.{json,aws} ; do
   let expected+=1
   [ -s "${profile}/${f}" ] && let found+=1
 done


### PR DESCRIPTION
I promise, I have run both clippy and fmt before submitting this!

An interesting observation, which you may or may not be aware of, is that because the disk image is generated and the vendor.crt is embedded into the shim, as well as that the gpg key for the grub config signature and both of these are written into the `EFI-A` partition, even if you disable Secure Boot on the server - the deployment of an update downloaded from a TUF repository, using a different PKI chain for the `code-sign.key` and a different gpg key for `config-sign.key`, will fail on both the shim validation and grub validation (these are done always despite Secure Boot status).

Of course, completely theoretical - I would never have been reckless enough to encounter the above situation.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #542

**Description of changes:**
This introduces three new environment variables to the build process `BUILDSYS_SBKEY_SHIM_SIGN_KEY_CONTENT`, `BUILDSYS_SBKEY_CODE_SIGN_KEY_CONTENT` and `BUILDSYS_SBKEY_CONFIG_SIGN_KEY_CONTENT`.
This allows you to pass in the signing keys needed to sign the artefacts both inside the full disk image, but also the update images.

The primary use-case for this would be to more conveniently enable CI builds without having to manage secrets as files (which few CI systems support in any larger extent).

**Testing done:**
I tested building both with a local profile and with the environment variables (we use these in building our own images in CI currently).


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
