### PR TITLE
testsys: add support to delete individual tests

### DIFF
--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -146,6 +146,11 @@ impl CrdCreator for AwsEcsCreator {
         let labels = test_input.crd_input.labels(btreemap! {
             "testsys/type".to_string() => test_input.test_type.to_string(),
             "testsys/cluster".to_string() => cluster_resource_name.to_string(),
+            "testsys/test-name".to_string() => format!(
+                "{}-{}",
+                cluster_resource_name,
+                test_input.name_suffix.unwrap_or(test_input.crd_input.test_flavor.as_str())
+            ),
         });
 
         let test_crd = EcsTestConfig::builder()
@@ -222,6 +227,11 @@ pub(crate) fn workload_crd(region: &str, test_input: TestInput) -> Result<Test> 
     let labels = test_input.crd_input.labels(btreemap! {
         "testsys/type".to_string() => test_input.test_type.to_string(),
         "testsys/cluster".to_string() => cluster_resource_name.to_string(),
+        "testsys/test-name".to_string() => format!(
+            "{}-{}",
+            cluster_resource_name,
+            test_input.name_suffix.unwrap_or("test")
+        ),
     });
     let gpu = test_input.crd_input.variant.variant_flavor() == Some("nvidia");
     let plugins: Vec<_> = test_input

--- a/tools/testsys/src/delete.rs
+++ b/tools/testsys/src/delete.rs
@@ -11,6 +11,10 @@ pub(crate) struct Delete {
     #[clap(long)]
     test: bool,
 
+    /// Delete a particular test
+    #[clap(long)]
+    test_name: Option<String>,
+
     /// Focus status on a particular arch
     #[clap(long)]
     arch: Option<String>,
@@ -49,12 +53,16 @@ impl Delete {
         };
         let crd_type = self.test.then_some(CrdType::Test);
         let mut labels = Vec::new();
+        if let Some(test_name) = self.test_name {
+            labels.push(format!("testsys/test-name={}", test_name))
+        };
         if let Some(arch) = self.arch {
             labels.push(format!("testsys/arch={}", arch))
         };
         if let Some(variant) = self.variant {
             labels.push(format!("testsys/variant={}", variant))
         };
+
         let mut stream = client
             .delete(
                 &SelectionParams {
@@ -63,7 +71,7 @@ impl Delete {
                     crd_type,
                     ..Default::default()
                 },
-                false,
+                !self.test,
             )
             .await?;
 

--- a/tools/testsys/src/migration.rs
+++ b/tools/testsys/src/migration.rs
@@ -21,6 +21,11 @@ pub(crate) fn migration_crd(
     let labels = migration_input.crd_input.labels(btreemap! {
         "testsys/type".to_string() => "migration".to_string(),
         "testsys/cluster".to_string() => cluster_resource_name.to_string(),
+        "testsys/test-name".to_string() => format!(
+            "{}-{}",
+            cluster_resource_name,
+            migration_input.name_suffix.unwrap_or(migration_input.crd_input.test_flavor.as_str())
+        ),
     });
 
     // Determine which version should be migrated to from `migration_input`.

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -28,6 +28,11 @@ pub(crate) fn sonobuoy_crd(test_input: TestInput) -> Result<Test> {
         "testsys/type".to_string() => test_input.test_type.to_string(),
         "testsys/flavor".to_string() => test_input.crd_input.test_flavor.clone(),
         "testsys/cluster".to_string() => cluster_resource_name.to_string(),
+        "testsys/test-name".to_string() => format!(
+            "{}-{}",
+            cluster_resource_name,
+            test_input.name_suffix.unwrap_or(test_input.crd_input.test_flavor.as_str())
+        ),
     });
 
     SonobuoyConfig::builder()
@@ -100,6 +105,11 @@ pub(crate) fn workload_crd(test_input: TestInput) -> Result<Test> {
     let labels = test_input.crd_input.labels(btreemap! {
         "testsys/type".to_string() => test_input.test_type.to_string(),
         "testsys/cluster".to_string() => cluster_resource_name.to_string(),
+        "testsys/test-name".to_string() => format!(
+            "{}-{}",
+            cluster_resource_name,
+            test_input.name_suffix.unwrap_or("test")
+        ),
     });
     let gpu = test_input.crd_input.variant.variant_flavor() == Some("nvidia");
     let plugins: Vec<_> = test_input

--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1875,6 +1875,16 @@ script = [
     '''
 ]
 
+# This task will clear a specific test by name and its resources from the testsys cluster.
+[tasks.reset-single-test]
+script = [
+    '''
+    set -eu
+    export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
+    testsys --log-level=${TESTSYS_LOG_LEVEL} ${CARGO_MAKE_TESTSYS_ARGS} delete --test-name ${@}
+    '''
+]
+
 # This task will clear all testsys components from the testsys cluster.
 [tasks.uninstall-test]
 script = [


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #548 

**Description of changes:**

This PR adds the capability for testsys to delete individual tests and its resources (`reset-single-test` task).

This is implemented by label filtering (similar to how it's done for aarch and variant) thru the use of a new label `test-name` which is comprised of the `cluster_resource_name` + `name_suffix` fields   that is unique to each test.

The various test CRDs in the following test type files are updated to add this new label during creation so they can be filtered for later:
- `aws-ecs.rs`
- `migration.rs`
- `sonobuoy.rs`

Ideally, I wanted to add support for a list of tests being passed rather than a single one, but that seems to require additional changes in the TestManager logic in [bottlerocket-test-system](https://github.com/bottlerocket-os/bottlerocket-test-system), so I wanted to release this in the meantime. Users can invoke this command in a script to delete multiple specified tests.

**Testing done:**
- Twoliter builds with changes
- `test-name` label gets created for test CRDs and matches the actual name of the test:
```
$ kd test x86-64-aws-k8s-130-nvidia-quick -n testsys
Name:         x86-64-aws-k8s-130-nvidia-quick
Namespace:    testsys
Labels:       testsys/arch=x86_64
              ...
              testsys/test-name=x86-64-aws-k8s-130-nvidia-quick

$ kd test x86-64-aws-k8s-130-nvidia-conformance -n testsys
Name:         x86-64-aws-k8s-130-nvidia-conformance
Namespace:    testsys
Labels:       testsys/arch=x86_64
              ...
              testsys/test-name=x86-64-aws-k8s-130-nvidia-conformance

$ kd test x86-64-aws-k8s-130-nvidia-test -n testsys
Name:         x86-64-aws-k8s-130-nvidia-test
Namespace:    testsys
Labels:       testsys/arch=x86_64
              ...
              testsys/test-name=x86-64-aws-k8s-130-nvidia-test

$ kd test x86-64-vmware-k8s-129-conformance  -n testsys
Name:         x86-64-vmware-k8s-129-conformance
Namespace:    testsys
Labels:       testsys/arch=x86_64
              ...
              testsys/test-name=x86-64-vmware-k8s-129-conformance
```

- `reset-single-test` task deletes the test and its related resources:
```
$ cargo make     -e=TWOLITER_ALLOW_SOURCE_INSTALL=false     -e=TWOLITER_ALLOW_BINARY_INSTALL=false     -e=TWOLITER_SKIP_VERSION_CHECK=true reset-single-test x86-64-aws-k8s-130-nvidia-test
....
[cargo-make][1] INFO - Running Task: reset-single-test
Starting delete for x86-64-aws-k8s-130-nvidia-test
Delete finished for x86-64-aws-k8s-130-nvidia-test
Starting delete for x86-64-aws-k8s-130-nvidia-instances-unuj
Delete finished for x86-64-aws-k8s-130-nvidia-instances-unuj
Starting delete for x86-64-aws-k8s-130-nvidia
Delete finished for x86-64-aws-k8s-130-nvidia
[2025-06-21T00:33:21Z INFO  testsys::delete] Delete finished
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
