### PR TITLE
rpm2img: reclaim reserved space on ext4

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -397,8 +397,9 @@ else
   ROOT_LABELS=$(setfiles -n -d -F -m -r "${ROOT_MOUNT}" \
     "${SELINUX_FILE_CONTEXTS}" "${ROOT_MOUNT}" |
     awk -v root="${ROOT_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_set", $1, "security.selinux", $4}')
-  mkfs.ext4 -E "lazy_itable_init=0,stride=${ROOT_STRIDE},stripe_width=${ROOT_STRIPE_WIDTH}" \
-    -O ^has_journal -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" "${partsize["ROOT-A"]}M"
+  mkfs.ext4 -E "lazy_itable_init=0,stride=${ROOT_STRIDE},stripe_width=${ROOT_STRIPE_WIDTH},num_backup_sb=0" -m 0 \
+    -O ^has_journal -O ^resize_inode -O sparse_super2 \
+    -b "${VERITY_DATA_BLOCK_SIZE}" -d "${ROOT_MOUNT}" "${ROOT_IMAGE}" "${partsize["ROOT-A"]}M"
   echo "${ROOT_LABELS}" | debugfs -w -f - "${ROOT_IMAGE}"
   resize2fs -M "${ROOT_IMAGE}"
 fi


### PR DESCRIPTION
**Description of changes:**
`ext4` reserves 5% of the filesystem for the super-user to avoid situations where non-privileged processes or users use up the disk space and the superuser needs some [space to clear the usage](https://linux.die.net/man/8/mkfs.ext4). Since the root filesystem we are creating in `rpm2img` is read only, this reserved space is not needed. This results in disk utilization showing the same number of blocks in use, but available is 5% higher. This change will result in all variants using ext4 for the root filesystem "gaining" 5% of their root disk space back since we don't need to reserve any space for internal writes.

The ext4 feature for online resizing reserves additional blocks for making it possible extend the block group descriptor table when making a filesystem larger. Since we will never resize this filesystem, it is safe to disable it with `^resize_inode` and the filesystem provides additional blocks for usage. This frees up about 2% of the blocks.

The root filesystem doesn't need as many super blocks and block descriptors so using the stricter sparse_super2 saves a bit on space. Since the file system is typically small, the savings is small as well but I included it since it is related. Thanks to @bcressey for some hints to find the extra space!


**Testing done:**
Built an AMI with this twoliter change and validated that the usage shows more available and that there we no failures in the logs.

```
bash-5.1# df -h
Filesystem       Size  Used Avail Use% Mounted on
/dev/root        1.8G  1.6G  202M  89% /
...
bash-5.1# df
Filesystem      1K-blocks    Used Available Use% Mounted on
/dev/root         1854556 1632012    206160  89% /
...
bash-5.1# dmesg | grep EXT4
[    0.683979] EXT4-fs (dm-0): mounted filesystem without journal. Quota mode: none.
[    8.821186] EXT4-fs (nvme0n1p3): mounted filesystem without journal. Quota mode: none.
[   12.489656] EXT4-fs (nvme0n1p12): mounted filesystem with ordered data mode. Quota mode: none.
```
On a system without the change:
```
bash-5.1# df -h
Filesystem       Size  Used Avail Use% Mounted on
/dev/root        1.8G  1.6G   70M  96% /
...
bash-5.1# df
Filesystem      1K-blocks    Used Available Use% Mounted on
/dev/root         1849036 1667036     71408  96% /
```
Note the Used are the same but the Available has gone up.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
