### PR TITLE
fix(buildsys): start bypass container in main thread

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -624,6 +624,7 @@ impl DockerBuild {
             "run \
             --name {tag}-bypass \
             --rm \
+            --detach \
             --init \
             --net host \
             --pid host \
@@ -648,6 +649,10 @@ impl DockerBuild {
         // Clean up the stopped bypass container if it exists.
         let _ = docker(&rm_bypass, Retry::No);
 
+        // Start the bypass container that will serve the project root file
+        // descriptor.
+        docker(&run_bypass, Retry::No)?;
+
         let runtime = tokio::runtime::Runtime::new().context(error::AsyncRuntimeSnafu)?;
 
         // Spawn a background task to share the file descriptors for the output directory.
@@ -657,12 +662,6 @@ impl DockerBuild {
             PipesysServer::for_path(output_socket, ROOT_UID, &output_dir)
                 .serve()
                 .await
-        });
-
-        // Spawn a background task for the bypass container that will serve the project root file
-        // descriptor.
-        runtime.spawn(async move {
-            let _ = docker(&run_bypass, Retry::No);
         });
 
         // Build the image, which builds the artifacts we want.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

There's a race in `buildsys` between the bypass container starting and the build action. Previously, the bypass container was started with a background thread using the blocking `docker run` behavior. You'll sometimes get an error like:
```
#6 0.184 Error: failed to connect to socket buildsys-repack-aws-k8s-1.29-x86_64-bypass
```

This PR moves the `docker run` invocation to the main thread, and adds the `--detach` flag. This seems to synchronize things more reliably, since the container has to actually exist before we proceed.

**Testing done:**

This issue arose in `repack-variant`, on an `r5.4xlarge`. The issue occurs every time I tested, and after this change does not occur.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
