### PR TITLE
cargo: enable profile-hint-mostly-unused for AWS SDKs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [unstable]
 bindeps = true
+profile-hint-mostly-unused = true
 
 [build]
 # This is the recommended configuration that yields the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,26 @@ walkdir = "2"
 which = "6"
 zstd = "0.13"
 
+[profile.dev.package]
+aws-config = { hint-mostly-unused = true }
+aws-sdk-ebs = { hint-mostly-unused = true }
+aws-sdk-ec2 = { hint-mostly-unused = true }
+aws-sdk-kms = { hint-mostly-unused = true }
+aws-sdk-ssm = { hint-mostly-unused = true }
+aws-sdk-sts = { hint-mostly-unused = true }
+aws-smithy-types = { hint-mostly-unused = true }
+aws-types = { hint-mostly-unused = true }
+
+[profile.release.package]
+aws-config = { hint-mostly-unused = true }
+aws-sdk-ebs = { hint-mostly-unused = true }
+aws-sdk-ec2 = { hint-mostly-unused = true }
+aws-sdk-kms = { hint-mostly-unused = true }
+aws-sdk-ssm = { hint-mostly-unused = true }
+aws-sdk-sts = { hint-mostly-unused = true }
+aws-smithy-types = { hint-mostly-unused = true }
+aws-types = { hint-mostly-unused = true }
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # particular date of the nightly compiler, but we want builds to be reproducable, so we lock to a
 # specific, recent instance of nightly.
 [toolchain]
-channel = "nightly-2025-02-28"
+channel = "nightly-2025-07-15"
 profile = "default"

--- a/tools/bottlerocket-variant/src/lib.rs
+++ b/tools/bottlerocket-variant/src/lib.rs
@@ -157,7 +157,7 @@ impl Variant {
     /// This can be used in a `build.rs` file to tell cargo that the crate needs to be rebuilt if
     /// the variant changes.
     pub fn rerun_if_changed() {
-        println!("cargo:rerun-if-env-changed={}", VARIANT_ENV);
+        println!("cargo:rerun-if-env-changed={VARIANT_ENV}");
     }
 
     /// This can be used in a `build.rs` file to emit `cfg` values that can be used for conditional
@@ -177,7 +177,7 @@ impl Variant {
     /// `#[cfg(variant_flavor = "none")]`
     pub fn emit_cfgs(&self) {
         Self::rerun_if_changed();
-        println!("cargo:rustc-cfg=variant=\"{}\"", self);
+        println!("cargo:rustc-cfg=variant=\"{self}\"");
         println!("cargo:rustc-cfg=variant_platform=\"{}\"", self.platform());
         println!("cargo:rustc-cfg=variant_runtime=\"{}\"", self.runtime());
         println!("cargo:rustc-cfg=variant_family=\"{}\"", self.family());
@@ -222,7 +222,7 @@ impl Variant {
                 variant: variant.clone()
             }
         );
-        let variant_family = format!("{}-{}", platform, runtime);
+        let variant_family = format!("{platform}-{runtime}");
         let variant_version = parts.next().map(|s| s.to_string());
         if let Some(value) = variant_version.as_ref() {
             ensure!(
@@ -293,7 +293,7 @@ impl<'de> Deserialize<'de> for Variant {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Variant::new(value).map_err(|e| D::Error::custom(format!("Error parsing variant: {}", e)))
+        Variant::new(value).map_err(|e| D::Error::custom(format!("Error parsing variant: {e}")))
     }
 }
 

--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -206,7 +206,7 @@ fn sensitive_env_vars(build_type: BuildFlags) -> impl Iterator<Item = &'static s
 pub(crate) fn rerun_for_envs(build_type: BuildType) {
     let build_flags: BuildFlags = build_type.into();
     for var in sensitive_env_vars(build_flags) {
-        println!("cargo:rerun-if-env-changed={}", var)
+        println!("cargo:rerun-if-env-changed={var}")
     }
 }
 

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -262,7 +262,7 @@ impl VariantBuildArgs {
         args.build_arg("VERSION_ID", &self.version_image);
 
         for image_feature in self.image_features.iter() {
-            args.build_arg(format!("{}", image_feature), "1");
+            args.build_arg(format!("{image_feature}"), "1");
         }
 
         args
@@ -303,7 +303,7 @@ impl RepackVariantBuildArgs {
         args.build_arg("VERSION_ID", &self.version_image);
 
         for image_feature in self.image_features.iter() {
-            args.build_arg(format!("{}", image_feature), "1");
+            args.build_arg(format!("{image_feature}"), "1");
         }
 
         args

--- a/tools/buildsys/src/cache.rs
+++ b/tools/buildsys/src/cache.rs
@@ -63,14 +63,14 @@ impl LookasideCache {
                 match Self::verify_file(path, hash) {
                     Ok(_) => continue,
                     Err(e) => {
-                        println!("{}", e);
+                        println!("{e}");
                         fs::remove_file(path).context(error::ExternalFileDeleteSnafu { path })?;
                     }
                 }
             }
 
             let name = &path.display().to_string();
-            let tmp = PathBuf::from(format!(".{}", name));
+            let tmp = PathBuf::from(format!(".{name}"));
 
             // first check the lookaside cache
             let mut url = self.lookaside_cache.clone();
@@ -93,7 +93,7 @@ impl LookasideCache {
                 Err(e) => {
                     // next check with upstream, if permitted
                     if f.force_upstream.unwrap_or(false) || self.upstream_fallback {
-                        println!("Source not found in lookaside-cache. Fetching {:?} from upstream source", url_file_name);
+                        println!("Source not found in lookaside-cache. Fetching {url_file_name:?} from upstream source");
                         self.fetch_file(&f.url, &tmp, hash)?;
                         fs::rename(&tmp, path)
                             .context(error::ExternalFileRenameSnafu { path: &tmp })?;

--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -117,7 +117,7 @@ impl GoMod {
             module_path: package_dir,
             sdk_image: sdk.to_string(),
             go_mod_cache: &root_dir.join(".gomodcache"),
-            command: format!("./{}", GO_MOD_DOCKER_SCRIPT_NAME),
+            command: format!("./{GO_MOD_DOCKER_SCRIPT_NAME}"),
         };
 
         // Create and/or write the temporary script file to the package directory

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -101,7 +101,7 @@ type Result<T> = std::result::Result<T, error::Error>;
 fn main() {
     let args = Buildsys::parse();
     if let Err(e) = run(args) {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         process::exit(1);
     }
 }
@@ -119,7 +119,7 @@ fn run(args: Buildsys) -> Result<()> {
 fn build_package(args: BuildPackageArgs) -> Result<()> {
     let manifest_file = "Cargo.toml";
     let manifest_path = args.common.cargo_manifest_dir.join(manifest_file);
-    println!("cargo:rerun-if-changed={}", manifest_file);
+    println!("cargo:rerun-if-changed={manifest_file}");
     println!(
         "cargo:rerun-if-changed={}",
         args.common.root_dir.join(EXTERNAL_KIT_METADATA).display()
@@ -184,8 +184,8 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
     // Package developer can override name of package if desired, e.g. to name package with
     // characters invalid in Cargo crate names
     let package = manifest.info().package_name();
-    let spec = format!("{}.spec", package);
-    println!("cargo:rerun-if-changed={}", spec);
+    let spec = format!("{package}.spec");
+    println!("cargo:rerun-if-changed={spec}");
 
     let info = SpecInfo::new(PathBuf::from(&spec)).context(error::SpecParseSnafu)?;
 
@@ -209,7 +209,7 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
 
 fn build_kit(args: BuildKitArgs) -> Result<()> {
     let manifest_file = "Cargo.toml";
-    println!("cargo:rerun-if-changed={}", manifest_file);
+    println!("cargo:rerun-if-changed={manifest_file}");
     println!(
         "cargo:rerun-if-changed={}",
         args.common.root_dir.join(EXTERNAL_KIT_METADATA).display()
@@ -233,7 +233,7 @@ fn build_kit(args: BuildKitArgs) -> Result<()> {
 
 fn build_variant(args: BuildVariantArgs) -> Result<()> {
     let manifest_file = "Cargo.toml";
-    println!("cargo:rerun-if-changed={}", manifest_file);
+    println!("cargo:rerun-if-changed={manifest_file}");
     println!(
         "cargo:rerun-if-changed={}",
         args.common.root_dir.join(EXTERNAL_KIT_METADATA).display()

--- a/tools/include-env-compressed/include-env-compressed-macro/src/lib.rs
+++ b/tools/include-env-compressed/include-env-compressed-macro/src/lib.rs
@@ -94,16 +94,16 @@ trait IncludedArchive {
 impl IncludedArchive for MacroArgs<Zstd> {
     fn emit_archive(&self) -> Result<TokenStream, IncludeError> {
         let env_var = &self.env_var;
-        let path = std::env::var(&env_var).context(EnvVarSnafu { env_var })?;
+        let path = std::env::var(env_var).context(EnvVarSnafu { env_var })?;
 
         let data = std::fs::read(&path).context(ReadArchiveSnafu { path })?;
 
         let compressed = zstd::encode_all(data.as_slice(), self.level).unwrap();
         let literal = Literal::byte_string(&compressed);
 
-        Ok(TokenStream::from(quote! {
+        Ok(quote! {
             ::include_env_compressed::Archive::zstd(#literal)
-        }))
+        })
     }
 }
 
@@ -131,9 +131,9 @@ impl<Compression> Parse for MacroArgs<Compression> {
 impl IncludedArchive for MacroArgs<Uncompressed> {
     fn emit_archive(&self) -> Result<TokenStream, IncludeError> {
         let env_var = &self.env_var;
-        Ok(TokenStream::from(quote! {
+        Ok(quote! {
             ::include_env_compressed::Archive::uncompressed(include_bytes!(env!(#env_var)))
-        }))
+        })
     }
 }
 

--- a/tools/krane/build.rs
+++ b/tools/krane/build.rs
@@ -98,7 +98,7 @@ fn get_goos() -> &'static str {
         "windows" => "windows",
         "macos" => "darwin",
         // Add more mappings as needed
-        other => panic!("Unsupported target OS: {}", other),
+        other => panic!("Unsupported target OS: {other}"),
     }
 }
 
@@ -112,6 +112,6 @@ fn get_goarch() -> &'static str {
         "arm" => "arm",
         "wasm32" => "wasm",
         // Add more mappings as needed
-        other => panic!("Unsupported target architecture: {}", other),
+        other => panic!("Unsupported target architecture: {other}"),
     }
 }

--- a/tools/oci-cli-wrapper/src/cli.rs
+++ b/tools/oci-cli-wrapper/src/cli.rs
@@ -14,7 +14,7 @@ impl CommandLine {
         let debug_cmd = [
             vec![format!("{}", self.path.display())],
             args.iter()
-                .map(|arg| format!("'{}'", arg))
+                .map(|arg| format!("'{arg}'"))
                 .collect::<Vec<_>>(),
         ]
         .concat()
@@ -58,7 +58,7 @@ impl CommandLine {
             "Executing '{}' with args [{}]",
             self.path.display(),
             args.iter()
-                .map(|arg| format!("'{}'", arg))
+                .map(|arg| format!("'{arg}'"))
                 .collect::<Vec<_>>()
                 .join(", ")
         );

--- a/tools/oci-cli-wrapper/src/crane.rs
+++ b/tools/oci-cli-wrapper/src/crane.rs
@@ -33,7 +33,7 @@ impl ImageToolImpl for CraneCLI {
         self.cli
             .spawn(
                 &Self::crane_cmd(&["pull", "--format", "oci", uri, archive_path.as_ref()]),
-                format!("failed to pull image archive from {}", uri),
+                format!("failed to pull image archive from {uri}"),
             )
             .await?;
         Ok(())
@@ -43,7 +43,7 @@ impl ImageToolImpl for CraneCLI {
         self.cli
             .output(
                 &Self::crane_cmd(&["manifest", uri]),
-                format!("failed to fetch manifest for resource at {}", uri),
+                format!("failed to fetch manifest for resource at {uri}"),
             )
             .await
     }
@@ -53,7 +53,7 @@ impl ImageToolImpl for CraneCLI {
             .cli
             .output(
                 &Self::crane_cmd(&["config", uri]),
-                format!("failed to fetch image config from {}", uri),
+                format!("failed to fetch image config from {uri}"),
             )
             .await?;
         let image_view: ImageView =
@@ -73,7 +73,7 @@ impl ImageToolImpl for CraneCLI {
         self.cli
             .spawn(
                 &Self::crane_cmd(&["push", &temp_dir.path().to_string_lossy(), uri]),
-                format!("failed to push image {}", uri),
+                format!("failed to push image {uri}"),
             )
             .await
     }
@@ -96,7 +96,7 @@ impl ImageToolImpl for CraneCLI {
         self.cli
             .output(
                 &Self::crane_cmd(&manifest_create_args),
-                format!("could not push multi-platform manifest to {}", uri),
+                format!("could not push multi-platform manifest to {uri}"),
             )
             .await?;
 

--- a/tools/pipesys/src/cmd/mod.rs
+++ b/tools/pipesys/src/cmd/mod.rs
@@ -76,14 +76,14 @@ const MIN_FD: i32 = 3;
 #[cfg(target_os = "linux")]
 fn fetch_fd(socket: &str) -> Result<i32> {
     let addr = uds::UnixSocketAddr::from_abstract(socket.as_bytes())
-        .with_context(|| format!("failed to create socket {}", socket))?;
+        .with_context(|| format!("failed to create socket {socket}"))?;
     let client = uds::UnixSeqpacketConn::connect_unix_addr(&addr)
-        .with_context(|| format!("failed to connect to socket {}", socket))?;
+        .with_context(|| format!("failed to connect to socket {socket}"))?;
 
     let mut fd_buf = [-1; 1];
     let (_, _, fds) = client
         .recv_fds(&mut [0u8; 1], &mut fd_buf)
-        .with_context(|| format!("failed to receive file descriptor from socket {}", socket))?;
+        .with_context(|| format!("failed to receive file descriptor from socket {socket}"))?;
 
     ensure!(
         fds == 1,
@@ -93,12 +93,7 @@ fn fetch_fd(socket: &str) -> Result<i32> {
     let fd = fd_buf
         .first()
         .filter(|fd| **fd >= MIN_FD)
-        .with_context(|| {
-            format!(
-                "did not receive valid file descriptor from socket {}",
-                socket
-            )
-        })?;
+        .with_context(|| format!("did not receive valid file descriptor from socket {socket}"))?;
 
     let dupfd =
         duplicate_fd(*fd).with_context(|| format!("failed to duplicate file descriptor {fd}"))?;

--- a/tools/pipesys/src/server.rs
+++ b/tools/pipesys/src/server.rs
@@ -67,7 +67,7 @@ impl Server {
 
             let peer_uid = peer_creds.euid();
             if peer_uid != self.client_uid {
-                warn!("ignoring connection from peer with UID {}", peer_uid);
+                warn!("ignoring connection from peer with UID {peer_uid}");
                 continue;
             }
 
@@ -76,7 +76,7 @@ impl Server {
             tokio::spawn(async move {
                 conn.send_fds(b"fds", &fds)
                     .await
-                    .with_context(|| format!("failed to send file descriptors over {}", socket))
+                    .with_context(|| format!("failed to send file descriptors over {socket}"))
             });
         }
     }

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -193,20 +193,20 @@ impl TryFrom<SigningKeyConfig> for Url {
                 key_id = if key_id.starts_with('/') {
                     key_id.to_string()
                 } else {
-                    format!("/{}", key_id)
+                    format!("/{key_id}")
                 };
-                Url::parse(&format!("aws-kms://{}", key_id)).map_err(|_| ())
+                Url::parse(&format!("aws-kms://{key_id}")).map_err(|_| ())
             }
             SigningKeyConfig::ssm { parameter } => {
                 let parameter = if parameter.starts_with('/') {
                     parameter
                 } else {
-                    format!("/{}", parameter)
+                    format!("/{parameter}")
                 };
-                Url::parse(&format!("aws-ssm://{}", parameter)).map_err(|_| ())
+                Url::parse(&format!("aws-ssm://{parameter}")).map_err(|_| ())
             }
             SigningKeyConfig::env { var_name } => {
-                Url::parse(&format!("env://{}", var_name)).map_err(|_| ())
+                Url::parse(&format!("env://{var_name}")).map_err(|_| ())
             }
         }
     }

--- a/tools/pubsys-config/src/vmware.rs
+++ b/tools/pubsys-config/src/vmware.rs
@@ -190,7 +190,7 @@ fn get_env(var: &str) -> Option<String> {
     match env::var(var) {
         Ok(v) => Some(v),
         Err(e) => {
-            debug!("Unable to read environment variable '{}': {}", var, e);
+            debug!("Unable to read environment variable '{var}': {e}");
             None
         }
     }

--- a/tools/pubsys-setup/src/main.rs
+++ b/tools/pubsys-setup/src/main.rs
@@ -181,7 +181,7 @@ fn find_root_role_and_key(args: &Args) -> Result<(Option<&PathBuf>, Option<Url>)
     {
         let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
             .context(error::ConfigSnafu)?;
-        trace!("Parsed infra config: {:?}", infra_config);
+        trace!("Parsed infra config: {infra_config:?}");
 
         // Check whether the user has the relevant repo defined in their Infra.toml.
         if let Some(repo_config) = infra_config
@@ -301,7 +301,7 @@ fn find_root_role_and_key(args: &Args) -> Result<(Option<&PathBuf>, Option<Url>)
 // https://github.com/shepmaster/snafu/issues/110
 fn main() {
     if let Err(e) = run() {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         process::exit(1);
     }
 }

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -108,7 +108,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     // If a lock file exists, use that, otherwise use Infra.toml or default
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, true)
         .context(error::ConfigSnafu)?;
-    trace!("Using infra config: {:?}", infra_config);
+    trace!("Using infra config: {infra_config:?}");
 
     let aws = infra_config.aws.unwrap_or_default();
 
@@ -394,8 +394,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         // Store the region so we can output it to the user
         let region_future = ready(region.clone());
         // Let the user know the copy is starting, when this future goes to run
-        let message_future =
-            lazy(move |_| info!("Starting copy from {} to {}", base_region, region));
+        let message_future = lazy(move |_| info!("Starting copy from {base_region} to {region}"));
         copy_requests.push(message_future.then(|_| join(region_future, copy_future)));
     }
 
@@ -531,7 +530,7 @@ async fn get_account_ids(
         })?;
         grant_accounts.insert(account_id);
     }
-    trace!("Found account IDs {:?}", grant_accounts);
+    trace!("Found account IDs {grant_accounts:?}");
 
     Ok(grant_accounts)
 }
@@ -595,7 +594,8 @@ mod error {
         DescribeImageAttribute {
             image_id: String,
             region: String,
-            source: super::launch_permissions::Error,
+            #[snafu(source(from(super::launch_permissions::Error, Box::new)))]
+            source: Box<super::launch_permissions::Error>,
         },
 
         #[snafu(display("Error getting AMI ID for {} {} in {}: {}", arch, name, region, source))]
@@ -603,13 +603,15 @@ mod error {
             name: String,
             arch: String,
             region: String,
-            source: ami::register::Error,
+            #[snafu(source(from(ami::register::Error, Box::new)))]
+            source: Box<ami::register::Error>,
         },
 
         #[snafu(display("Error getting account ID in {}: {}", region, source))]
         GetCallerIdentity {
             region: String,
-            source: SdkError<GetCallerIdentityError>,
+            #[snafu(source(from(SdkError<GetCallerIdentityError>, Box::new)))]
+            source: Box<SdkError<GetCallerIdentityError>>,
         },
 
         #[snafu(display(
@@ -621,21 +623,24 @@ mod error {
         GetSnapshots {
             image_id: String,
             region: String,
-            source: publish_ami::Error,
+            #[snafu(source(from(publish_ami::Error, Box::new)))]
+            source: Box<publish_ami::Error>,
         },
 
         #[snafu(display("Failed to grant access to {} in {}: {}", thing, region, source))]
         GrantAccess {
             thing: String,
             region: String,
-            source: publish_ami::Error,
+            #[snafu(source(from(publish_ami::Error, Box::new)))]
+            source: Box<publish_ami::Error>,
         },
 
         #[snafu(display("Failed to grant access to {} in {}: {}", thing, region, source))]
         GrantImageAccess {
             thing: String,
             region: String,
-            source: SdkError<ModifyImageAttributeError>,
+            #[snafu(source(from(SdkError<ModifyImageAttributeError>, Box::new)))]
+            source: Box<SdkError<ModifyImageAttributeError>>,
         },
 
         #[snafu(display(
@@ -688,20 +693,23 @@ mod error {
             name: String,
             arch: String,
             region: String,
-            source: ami::register::Error,
+            #[snafu(source(from(ami::register::Error, Box::new)))]
+            source: Box<ami::register::Error>,
         },
 
         #[snafu(display("AMI '{}' in {} did not become available: {}", id, region, source))]
         WaitAmi {
             id: String,
             region: String,
-            source: ami::wait::Error,
+            #[snafu(source(from(ami::wait::Error, Box::new)))]
+            source: Box<ami::wait::Error>,
         },
 
         #[snafu(display("Failed to write AMIs to '{}': {}", path.display(), source))]
         WriteAmis {
             path: PathBuf,
-            source: publish_ami::Error,
+            #[snafu(source(from(publish_ami::Error, Box::new)))]
+            source: Box<publish_ami::Error>,
         },
     }
 }

--- a/tools/pubsys/src/aws/ami/register/mod.rs
+++ b/tools/pubsys/src/aws/ami/register/mod.rs
@@ -44,8 +44,8 @@ async fn _register_image(
     let amispec = mk_amispec::create_amispec(ami_args, Some(&bottlerocket_snapshots))
         .context(error::AmispecSnafu)?;
 
-    debug!("Registering AMI with amispec '{:?}'", amispec);
-    info!("Making register image call in {}", region);
+    debug!("Registering AMI with amispec '{amispec:?}'");
+    info!("Making register image call in {region}");
     let register_response = amispec
         .as_register_image_call()
         .send_with(ec2_client)
@@ -119,7 +119,7 @@ impl BottlerocketSnapshots {
         ec2_client: &Ec2Client,
         cleanup_snapshot_ids: Arc<Mutex<Vec<String>>>,
     ) -> Result<BottlerocketSnapshots> {
-        debug!("Uploading images into EBS snapshots in {}", region);
+        debug!("Uploading images into EBS snapshots in {region}");
 
         let multi_progress = MultiProgress::new();
 
@@ -185,7 +185,8 @@ pub(crate) enum CreateSnapshotError {
     #[snafu(display("Failed to create snapshot for {}: {}", path.display(), source))]
     UploadSnapshot {
         path: PathBuf,
-        source: crate::aws::ami::snapshot::Error,
+        #[snafu(source(from(crate::aws::ami::snapshot::Error, Box::new)))]
+        source: Box<crate::aws::ami::snapshot::Error>,
     },
     #[snafu(display("Failed to wait for snapshot to become available: {}", source))]
     WaitSnapshot { source: coldsnap::WaitError },
@@ -217,10 +218,7 @@ pub(crate) async fn register_image(
                 .send()
                 .await
             {
-                warn!(
-                    "While cleaning up, failed to delete snapshot {}: {}",
-                    snapshot_id, e
-                );
+                warn!("While cleaning up, failed to delete snapshot {snapshot_id}: {e}");
             }
         }
     }

--- a/tools/pubsys/src/aws/ami/snapshot.rs
+++ b/tools/pubsys/src/aws/ami/snapshot.rs
@@ -60,7 +60,10 @@ mod error {
         },
 
         #[snafu(display("Failed to upload snapshot: {}", source))]
-        UploadSnapshot { source: coldsnap::UploadError },
+        UploadSnapshot {
+            #[snafu(source(from(coldsnap::UploadError, Box::new)))]
+            source: Box<coldsnap::UploadError>,
+        },
     }
 }
 pub(crate) use error::Error;

--- a/tools/pubsys/src/aws/ami/wait.rs
+++ b/tools/pubsys/src/aws/ami/wait.rs
@@ -58,7 +58,7 @@ pub(crate) async fn wait_for_ami(
                             saw_it = true;
                             successes += 1;
                             if successes >= successes_required {
-                                info!("Found {} {} in {}", id, state, region);
+                                info!("Found {id} {state} in {region}");
                                 return Ok(());
                             }
                             break;
@@ -92,8 +92,7 @@ pub(crate) async fn wait_for_ami(
 
         if attempts % 5 == 1 {
             info!(
-                "Waiting for {} in {} to be {}... (attempt {} of {})",
-                id, region, state, attempts, max_attempts
+                "Waiting for {id} in {region} to be {state}... (attempt {attempts} of {max_attempts})"
             );
         }
         sleep(Duration::from_secs(seconds_between_attempts));

--- a/tools/pubsys/src/aws/promote_ssm/mod.rs
+++ b/tools/pubsys/src/aws/promote_ssm/mod.rs
@@ -71,7 +71,7 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
         .context(error::ConfigSnafu)?;
 
-    trace!("Parsed infra config: {:#?}", infra_config);
+    trace!("Parsed infra config: {infra_config:#?}");
     let aws = infra_config.aws.unwrap_or_default();
     let ssm_prefix = aws.ssm_prefix.as_deref().unwrap_or("");
 
@@ -169,10 +169,7 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
     let current_source_parameters = ssm::get_parameters(&source_keys, &ssm_clients)
         .await
         .context(error::FetchSsmSnafu)?;
-    trace!(
-        "Current source SSM parameters: {:#?}",
-        current_source_parameters
-    );
+    trace!("Current source SSM parameters: {current_source_parameters:#?}");
     ensure!(
         !current_source_parameters.is_empty(),
         error::EmptySourceSnafu {
@@ -183,10 +180,7 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
     let current_target_parameters = ssm::get_parameters(&target_keys, &ssm_clients)
         .await
         .context(error::FetchSsmSnafu)?;
-    trace!(
-        "Current target SSM parameters: {:#?}",
-        current_target_parameters
-    );
+    trace!("Current target SSM parameters: {current_target_parameters:#?}");
 
     // Build a map of rendered source parameter names to rendered target parameter names.  This
     // will let us find which target parameters to set based on the source parameter names we get

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -94,7 +94,7 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
         serde_json::from_slice(&ami_input_bytes).context(error::DeserializeSnafu {
             path: &publish_args.ami_input,
         })?;
-    trace!("Parsed AMI input: {:?}", ami_input);
+    trace!("Parsed AMI input: {ami_input:?}");
 
     // pubsys will not create a file if it did not create AMIs, so we should only have an empty
     // file if a user created one manually, and they shouldn't be creating an empty file.
@@ -108,7 +108,7 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
     // If a lock file exists, use that, otherwise use Infra.toml or default
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, true)
         .context(error::ConfigSnafu)?;
-    trace!("Using infra config: {:?}", infra_config);
+    trace!("Using infra config: {infra_config:?}");
 
     let aws = infra_config.aws.unwrap_or_default();
 
@@ -193,12 +193,9 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
     }
 
     let snapshots = get_regional_snapshots(&amis, &ec2_clients).await?;
-    trace!("Found snapshots: {:?}", snapshots);
+    trace!("Found snapshots: {snapshots:?}");
 
-    info!(
-        "Updating all snapshot permissions before changing any AMI permissions - {}",
-        description
-    );
+    info!("Updating all snapshot permissions before changing any AMI permissions - {description}");
     modify_regional_snapshots(
         &publish_args.modify_opts,
         &operation,
@@ -207,7 +204,7 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
     )
     .await?;
 
-    info!("Updating AMI permissions - {}", description);
+    info!("Updating AMI permissions - {description}");
     modify_regional_images(
         &publish_args.modify_opts,
         &operation,
@@ -515,7 +512,7 @@ pub(crate) async fn modify_regional_images(
         match modify_image_response {
             Ok(_) => {
                 success_count += 1;
-                info!("Modified permissions of image {} in {}", image_id, region);
+                info!("Modified permissions of image {image_id} in {region}");
 
                 // Set the `public` and `launch_permissions` fields for the Image object
                 let image = images.get_mut(&Region::new(region.clone())).ok_or(

--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -94,7 +94,7 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
     // If a lock file exists, use that, otherwise use Infra.toml
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
         .context(error::ConfigSnafu)?;
-    trace!("Parsed infra config: {:#?}", infra_config);
+    trace!("Parsed infra config: {infra_config:#?}");
     let aws = infra_config.aws.unwrap_or_default();
     let ssm_prefix = aws.ssm_prefix.as_deref().unwrap_or("");
 
@@ -142,7 +142,7 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
     let new_parameters =
         template::render_parameters(template_parameters, &amis, ssm_prefix, &build_context)
             .context(error::RenderTemplatesSnafu)?;
-    trace!("Generated templated parameters: {:#?}", new_parameters);
+    trace!("Generated templated parameters: {new_parameters:#?}");
 
     // If the path to an output file was given, write the rendered parameters to this file
     if let Some(ssm_parameter_output) = &ssm_args.ssm_parameter_output {
@@ -216,7 +216,7 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
         result.context(error::FetchSsmSnafu)?
     };
 
-    trace!("Current SSM parameters: {:#?}", current_parameters);
+    trace!("Current SSM parameters: {current_parameters:#?}");
 
     // Show the difference between source and target parameters in SSM.
     let parameters_to_set = key_difference(
@@ -271,10 +271,7 @@ pub(crate) fn write_rendered_parameters(
     ssm_parameters_output: &PathBuf,
     parameters: &HashMap<String, HashMap<String, String>>,
 ) -> Result<()> {
-    info!(
-        "Writing rendered SSM parameters to {:#?}",
-        ssm_parameters_output
-    );
+    info!("Writing rendered SSM parameters to {ssm_parameters_output:#?}");
 
     serde_json::to_writer_pretty(
         &File::create(ssm_parameters_output).context(error::WriteRenderedSsmParametersSnafu {
@@ -284,10 +281,7 @@ pub(crate) fn write_rendered_parameters(
     )
     .context(error::ParseRenderedSsmParametersSnafu)?;
 
-    info!(
-        "Wrote rendered SSM parameters to {:#?}",
-        ssm_parameters_output
-    );
+    info!("Wrote rendered SSM parameters to {ssm_parameters_output:#?}");
     Ok(())
 }
 
@@ -388,7 +382,7 @@ fn parse_ami_input(regions: &[String], ssm_args: &SsmArgs) -> Result<HashMap<Reg
         serde_json::from_reader(file).context(error::DeserializeSnafu {
             path: &ssm_args.ami_input,
         })?;
-    trace!("Parsed AMI input: {:#?}", ami_input);
+    trace!("Parsed AMI input: {ami_input:#?}");
 
     // pubsys will not create a file if it did not create AMIs, so we should only have an empty
     // file if a user created one manually, and they shouldn't be creating an empty file.
@@ -504,7 +498,10 @@ mod error {
         },
 
         #[snafu(display("Failed to fetch parameters from SSM: {}", source))]
-        FetchSsm { source: ssm::Error },
+        FetchSsm {
+            #[snafu(source(from(ssm::Error, Box::new)))]
+            source: Box<ssm::Error>,
+        },
 
         #[snafu(display("Failed to {} '{}': {}", op, path.display(), source))]
         File {
@@ -532,7 +529,10 @@ mod error {
         RenderTemplates { source: template::Error },
 
         #[snafu(display("Failed to set SSM parameters: {}", source))]
-        SetSsm { source: ssm::Error },
+        SetSsm {
+            #[snafu(source(from(ssm::Error, Box::new)))]
+            source: Box<ssm::Error>,
+        },
 
         #[snafu(display(
             "Given region(s) in Infra.toml / regions argument that are not in --ami-input file: {}",
@@ -541,7 +541,10 @@ mod error {
         UnknownRegions { regions: Vec<String> },
 
         #[snafu(display("Failed to validate SSM parameters: {}", source))]
-        ValidateSsm { source: ssm::Error },
+        ValidateSsm {
+            #[snafu(source(from(ssm::Error, Box::new)))]
+            source: Box<ssm::Error>,
+        },
 
         #[snafu(display("Failed to parse rendered SSM parameters to JSON: {}", source))]
         ParseRenderedSsmParameters { source: serde_json::Error },

--- a/tools/pubsys/src/aws/ssm/ssm.rs
+++ b/tools/pubsys/src/aws/ssm/ssm.rs
@@ -98,7 +98,7 @@ where
                 let region = region.clone();
                 async move {
                     rate_limit_ssm_get_parameters(&region).await;
-                    trace!("Requesting {:?} in {}", names_chunk, region);
+                    trace!("Requesting {names_chunk:?} in {region}");
                     ssm_client
                         .get_parameters()
                         .set_names((!names_chunk.is_empty()).then_some(names_chunk))
@@ -159,10 +159,7 @@ where
             error::MissingInResponseSnafu {
                 region: region.as_ref(),
                 request_type: "GetParameters",
-                missing: format!(
-                    "parameters - got {}, expected {}",
-                    total_count, expected_len
-                ),
+                missing: format!("parameters - got {total_count}, expected {expected_len}"),
             }
         );
 
@@ -178,7 +175,7 @@ where
                     let value = parameter.value.context(error::MissingInResponseSnafu {
                         region: region.as_ref(),
                         request_type: "GetParameters",
-                        missing: format!("value for parameter {}", name),
+                        missing: format!("value for parameter {name}"),
                     })?;
                     parameters.insert(SsmKey::new(region.clone(), name), value);
                 }
@@ -187,10 +184,7 @@ where
     }
 
     for region in new_regions {
-        warn!(
-            "Invalid namespace in {}, this is OK for the first publish in a region",
-            region
-        );
+        warn!("Invalid namespace in {region}, this is OK for the first publish in a region");
     }
 
     Ok(parameters)
@@ -205,7 +199,7 @@ pub(crate) async fn get_parameters_by_prefix<'a>(
     // region
     let mut requests = Vec::with_capacity(clients.len());
     for region in clients.keys() {
-        trace!("Requesting parameters in {}", region);
+        trace!("Requesting parameters in {region}");
         let ssm_client: &SsmClient = &clients[region];
         let get_future = get_parameters_by_prefix_in_region(region, ssm_client, ssm_prefix);
 
@@ -226,7 +220,7 @@ pub(crate) async fn get_parameters_by_prefix_in_region(
     client: &SsmClient,
     ssm_prefix: &str,
 ) -> Result<SsmParameters> {
-    info!("Retrieving SSM parameters in {}", region);
+    info!("Retrieving SSM parameters in {region}");
     let mut parameters = HashMap::new();
 
     let paginated_response_stream = stream! {
@@ -278,7 +272,7 @@ pub(crate) async fn get_parameters_by_prefix_in_region(
             );
         }
     }
-    info!("SSM parameters in {} have been retrieved", region);
+    info!("SSM parameters in {region} have been retrieved");
     Ok(parameters)
 }
 
@@ -325,10 +319,7 @@ pub(crate) async fn set_parameters(
 
         if should_increase_interval {
             request_interval *= interval_factor;
-            warn!(
-                "Requests were throttled, increasing interval to {:?}",
-                request_interval
-            );
+            warn!("Requests were throttled, increasing interval to {request_interval:?}");
         }
         should_increase_interval = false;
 
@@ -422,7 +413,7 @@ pub(crate) async fn set_parameters(
     if !failed_parameters.is_empty() {
         for (region, failures) in &failed_parameters {
             for (parameter, error) in failures {
-                error!("Failed to set {} in {}: {}", parameter, region, error);
+                error!("Failed to set {parameter} in {region}: {error}");
             }
         }
         return error::SetParametersSnafu {
@@ -457,7 +448,7 @@ pub(crate) async fn validate_parameters(
         retry_strategy,
         || async { validate_parameters_inner(expected_parameters, ssm_clients).await },
         |e: &'_ Error| {
-            error!("Failed to validate SSM parameters: {}", e);
+            error!("Failed to validate SSM parameters: {e}");
             true
         },
     )
@@ -484,14 +475,11 @@ async fn validate_parameters_inner(
         // parameter wasn't updated / created.
         if let Some(updated_value) = updated_parameters.get(expected_key) {
             if updated_value != expected_value {
-                error!("Failed to set {} in {}", expected_name, expected_region);
+                error!("Failed to set {expected_name} in {expected_region}");
                 success = false;
             }
         } else {
-            error!(
-                "{} in {} still doesn't exist",
-                expected_name, expected_region
-            );
+            error!("{expected_name} in {expected_region} still doesn't exist");
             success = false;
         }
     }

--- a/tools/pubsys/src/aws/ssm/template.rs
+++ b/tools/pubsys/src/aws/ssm/template.rs
@@ -50,7 +50,7 @@ pub(crate) async fn get_parameters(
         toml::from_str(&templates_str).context(error::InvalidTomlSnafu {
             path: &template_path,
         })?;
-    trace!("Parsed templates: {:#?}", template_parameters);
+    trace!("Parsed templates: {template_parameters:#?}");
 
     // You shouldn't point to an empty file, but if all the entries are removed by
     // conditionals below, we allow that and just don't set any parameters.
@@ -67,7 +67,7 @@ pub(crate) async fn get_parameters(
         (p.variants.is_empty() || p.variants.contains(&variant))
             && (p.arches.is_empty() || p.arches.contains(&arch))
     });
-    trace!("Templates after conditionals: {:#?}", template_parameters);
+    trace!("Templates after conditionals: {template_parameters:#?}");
 
     Ok(template_parameters)
 }
@@ -173,9 +173,9 @@ fn join_name(ssm_prefix: &str, name_suffix: &str) -> String {
     if ssm_prefix.ends_with('/') && name_suffix.starts_with('/') {
         format!("{}{}", ssm_prefix, &name_suffix[1..])
     } else if ssm_prefix.ends_with('/') || name_suffix.starts_with('/') {
-        format!("{}{}", ssm_prefix, name_suffix)
+        format!("{ssm_prefix}{name_suffix}")
     } else {
-        format!("{}/{}", ssm_prefix, name_suffix)
+        format!("{ssm_prefix}/{name_suffix}")
     }
 }
 

--- a/tools/pubsys/src/aws/validate_ami/ami.rs
+++ b/tools/pubsys/src/aws/validate_ami/ami.rs
@@ -86,7 +86,7 @@ pub(crate) async fn describe_images<'a>(
     // region
     let mut requests = Vec::with_capacity(clients.len());
     clients.iter().for_each(|(region, ec2_client)| {
-        trace!("Requesting images in {}", region);
+        trace!("Requesting images in {region}");
         let get_future = describe_images_in_region(
             region,
             ec2_client,
@@ -116,7 +116,7 @@ pub(crate) async fn describe_images_in_region(
     client: &Ec2Client,
     expected_images: HashMap<String, ImageDef>,
 ) -> Result<HashMap<String, ImageDef>> {
-    info!("Retrieving images in {}", region);
+    info!("Retrieving images in {region}");
     let mut images = HashMap::new();
 
     // Send the request
@@ -175,7 +175,7 @@ pub(crate) async fn describe_images_in_region(
         }
     }
 
-    info!("Images in {} have been retrieved", region);
+    info!("Images in {region} have been retrieved");
     Ok(images)
 }
 

--- a/tools/pubsys/src/aws/validate_ami/mod.rs
+++ b/tools/pubsys/src/aws/validate_ami/mod.rs
@@ -53,7 +53,7 @@ pub(crate) async fn validate(
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
         .context(error::ConfigSnafu)?;
 
-    trace!("Parsed infra config: {:#?}", infra_config);
+    trace!("Parsed infra config: {infra_config:#?}");
 
     let aws = infra_config.aws.unwrap_or_default();
 
@@ -89,7 +89,7 @@ pub(crate) async fn validate(
             (
                 region,
                 result.map_err(|e| {
-                    error!("Failed to retrieve images in region {}: {}", region, e);
+                    error!("Failed to retrieve images in region {region}: {e}");
                     error::Error::UnreachableRegion {
                         region: region.to_string(),
                     }
@@ -224,7 +224,7 @@ pub(crate) async fn run(args: &Args, validate_ami_args: &ValidateAmiArgs) -> Res
                 .context(error::SerializeResultsSummarySnafu)?
         )
     } else {
-        println!("{}", results);
+        println!("{results}");
     }
     Ok(())
 }

--- a/tools/pubsys/src/aws/validate_ami/results.rs
+++ b/tools/pubsys/src/aws/validate_ami/results.rs
@@ -138,7 +138,7 @@ impl Display for AmiValidationResults {
                 .collect::<Vec<(String, &AmiValidationRegionSummary)>>(),
         )
         .to_string();
-        write!(f, "{}", table)
+        write!(f, "{table}")
     }
 }
 

--- a/tools/pubsys/src/aws/validate_ssm/mod.rs
+++ b/tools/pubsys/src/aws/validate_ssm/mod.rs
@@ -57,7 +57,7 @@ pub async fn validate(
 
     let aws = infra_config.aws.clone().unwrap_or_default();
 
-    trace!("Parsed infra config: {:#?}", infra_config);
+    trace!("Parsed infra config: {infra_config:#?}");
 
     let ssm_prefix = aws.ssm_prefix.as_deref().unwrap_or("");
 
@@ -86,7 +86,7 @@ pub async fn validate(
             (
                 region,
                 result.map_err(|e| {
-                    error!("Failed to retrieve images in region {}: {}", region, e);
+                    error!("Failed to retrieve images in region {region}: {e}");
                     error::Error::UnreachableRegion {
                         region: region.to_string(),
                     }
@@ -246,7 +246,7 @@ pub(crate) async fn run(args: &Args, validate_ssm_args: &ValidateSsmArgs) -> Res
                 .context(error::SerializeResultsSummarySnafu)?
         )
     } else {
-        println!("{}", results)
+        println!("{results}")
     }
     Ok(())
 }

--- a/tools/pubsys/src/aws/validate_ssm/results.rs
+++ b/tools/pubsys/src/aws/validate_ssm/results.rs
@@ -142,7 +142,7 @@ impl Display for SsmValidationResults {
                 .collect::<Vec<(String, &SsmValidationRegionSummary)>>(),
         )
         .to_string();
-        write!(f, "{}", table)
+        write!(f, "{table}")
     }
 }
 

--- a/tools/pubsys/src/kit/publish_kit/mod.rs
+++ b/tools/pubsys/src/kit/publish_kit/mod.rs
@@ -36,7 +36,7 @@ pub(crate) async fn run(args: &Args, publish_kit_args: &PublishKitArgs) -> Resul
     // If a lock file exists, use that, otherwise use Infra.toml
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
         .context(error::ConfigSnafu)?;
-    trace!("Parsed infra config: {:?}", infra_config);
+    trace!("Parsed infra config: {infra_config:?}");
 
     publish_kit(infra_config, publish_kit_args, &image_tool).await
 }
@@ -56,10 +56,7 @@ async fn publish_kit(
             name: publish_kit_args.vendor.clone(),
         })?;
     let vendor_registry_uri = vendor.registry.clone();
-    debug!(
-        "Found vendor container registry at uri: {}",
-        vendor_registry_uri
-    );
+    debug!("Found vendor container registry at uri: {vendor_registry_uri}");
 
     // Auto resolve the expected paths for the kit contents archive
     let kit_path = publish_kit_args.kit_path.as_path();
@@ -84,7 +81,7 @@ async fn publish_kit(
         let path = kit_path.join(&kit_filename);
 
         if !path.exists() {
-            debug!("Kit image does not exist for arch {}", arch);
+            debug!("Kit image does not exist for arch {arch}");
             continue;
         }
 
@@ -110,10 +107,7 @@ async fn publish_kit(
         error::NoArchiveSnafu { path: kit_path }
     );
 
-    let target_uri = format!(
-        "{}/{}:{}",
-        vendor_registry_uri, repository_target, kit_version
-    );
+    let target_uri = format!("{vendor_registry_uri}/{repository_target}:{kit_version}");
 
     info!("Pushing kit to {}", &target_uri);
 
@@ -122,7 +116,7 @@ async fn publish_kit(
         .await
         .context(error::PublishKitSnafu)?;
 
-    info!("Successfully published kit to {}", target_uri);
+    info!("Successfully published kit to {target_uri}");
 
     Ok(())
 }

--- a/tools/pubsys/src/main.rs
+++ b/tools/pubsys/src/main.rs
@@ -152,22 +152,22 @@ pub struct Args {
 
 #[derive(Debug, Parser)]
 enum SubCommands {
-    Repo(repo::RepoArgs),
-    ValidateRepo(repo::validate_repo::ValidateRepoArgs),
-    CheckRepoExpirations(repo::check_expirations::CheckExpirationsArgs),
-    RefreshRepo(repo::refresh_repo::RefreshRepoArgs),
-    FetchVariant(repo::fetch_variant::FetchVariantArgs),
-    Ami(aws::ami::AmiArgs),
-    PublishAmi(aws::publish_ami::Who),
-    ValidateAmi(aws::validate_ami::ValidateAmiArgs),
+    Repo(Box<repo::RepoArgs>),
+    ValidateRepo(Box<repo::validate_repo::ValidateRepoArgs>),
+    CheckRepoExpirations(Box<repo::check_expirations::CheckExpirationsArgs>),
+    RefreshRepo(Box<repo::refresh_repo::RefreshRepoArgs>),
+    FetchVariant(Box<repo::fetch_variant::FetchVariantArgs>),
+    Ami(Box<aws::ami::AmiArgs>),
+    PublishAmi(Box<aws::publish_ami::Who>),
+    ValidateAmi(Box<aws::validate_ami::ValidateAmiArgs>),
 
-    Ssm(aws::ssm::SsmArgs),
-    PromoteSsm(aws::promote_ssm::PromoteArgs),
-    ValidateSsm(aws::validate_ssm::ValidateSsmArgs),
+    Ssm(Box<aws::ssm::SsmArgs>),
+    PromoteSsm(Box<aws::promote_ssm::PromoteArgs>),
+    ValidateSsm(Box<aws::validate_ssm::ValidateSsmArgs>),
 
-    UploadOva(vmware::upload_ova::UploadArgs),
+    UploadOva(Box<vmware::upload_ova::UploadArgs>),
 
-    PublishKit(kit::publish_kit::PublishKitArgs),
+    PublishKit(Box<kit::publish_kit::PublishKitArgs>),
 }
 
 /// Parses a SemVer, stripping a leading 'v' if present
@@ -271,7 +271,7 @@ mod error {
         match error.amis_affected() {
             0 => String::from("No AMI permissions were updated"),
             1 => String::from("Permissions for 1 AMI were updated, the rest failed"),
-            n => format!("Permissions for {} AMIs were updated, the rest failed", n),
+            n => format!("Permissions for {n} AMIs were updated, the rest failed"),
         }
     }
 }

--- a/tools/pubsys/src/repo.rs
+++ b/tools/pubsys/src/repo.rs
@@ -160,7 +160,7 @@ fn update_manifest(repo_args: &RepoArgs, manifest: &mut Manifest) -> Result<()> 
         release
             .migrations
             .keys()
-            .map(|(from, to)| format!("({}, {})", from, to))
+            .map(|(from, to)| format!("({from}, {to})"))
             .collect::<Vec<String>>()
     );
     // Replace the manifest 'migrations' section with the new data
@@ -173,10 +173,7 @@ fn update_manifest(repo_args: &RepoArgs, manifest: &mut Manifest) -> Result<()> 
         "Using wave policy from path: {}",
         repo_args.wave_policy_path.display()
     );
-    info!(
-        "Offsets from that file will be added to the release start time of: {}",
-        wave_start_time
-    );
+    info!("Offsets from that file will be added to the release start time of: {wave_start_time}");
     let waves = UpdateWaves::from_path(&repo_args.wave_policy_path).context(
         error::UpdateMetadataReadSnafu {
             path: &repo_args.wave_policy_path,
@@ -208,8 +205,7 @@ fn set_expirations(
     let targets_expiration = expiration_start_time + expiration_policy.targets_expiration;
     let timestamp_expiration = expiration_start_time + expiration_policy.timestamp_expiration;
     info!(
-        "Setting non-root metadata expiration times:\n\tsnapshot:  {}\n\ttargets:   {}\n\ttimestamp: {}",
-        snapshot_expiration, targets_expiration, timestamp_expiration
+        "Setting non-root metadata expiration times:\n\tsnapshot:  {snapshot_expiration}\n\ttargets:   {targets_expiration}\n\ttimestamp: {timestamp_expiration}"
     );
     editor
         .snapshot_expires(snapshot_expiration)
@@ -227,7 +223,7 @@ fn set_versions(editor: &mut RepositoryEditor) -> Result<()> {
     let seconds = Utc::now().timestamp();
     let unsigned_seconds = seconds.try_into().expect("System clock before 1970??");
     let version = NonZeroU64::new(unsigned_seconds).expect("System clock exactly 1970??");
-    debug!("Repo version: {}", version);
+    debug!("Repo version: {version}");
     editor
         .snapshot_version(version)
         .targets_version(version)
@@ -284,8 +280,7 @@ where
     let targets_expiration = expiration_start_time + expiration.targets_expiration;
     let timestamp_expiration = expiration_start_time + expiration.timestamp_expiration;
     info!(
-        "Repo expiration times:\n\tsnapshot:  {}\n\ttargets:   {}\n\ttimestamp: {}",
-        snapshot_expiration, targets_expiration, timestamp_expiration
+        "Repo expiration times:\n\tsnapshot:  {snapshot_expiration}\n\ttargets:   {targets_expiration}\n\ttimestamp: {timestamp_expiration}"
     );
     editor
         .snapshot_expires(snapshot_expiration)
@@ -300,7 +295,7 @@ where
     let seconds = Utc::now().timestamp();
     let unsigned_seconds = seconds.try_into().expect("System clock before 1970??");
     let version = NonZeroU64::new(unsigned_seconds).expect("System clock exactly 1970??");
-    debug!("Repo version: {}", version);
+    debug!("Repo version: {version}");
     editor
         .snapshot_version(version)
         .targets_version(version)
@@ -325,13 +320,12 @@ fn repo_urls<'a>(
             } else {
                 "/"
             };
-            let metadata_url_str =
-                format!("{}{}{}/{}", metadata_base_url, base_slash, variant, arch);
+            let metadata_url_str = format!("{metadata_base_url}{base_slash}{variant}/{arch}");
             let metadata_url = Url::parse(&metadata_url_str).context(error::ParseUrlSnafu {
                 input: &metadata_url_str,
             })?;
 
-            debug!("Using metadata url: {}", metadata_url);
+            debug!("Using metadata url: {metadata_url}");
             return Ok(Some((metadata_url, targets_url)));
         }
     }
@@ -479,7 +473,7 @@ pub(crate) async fn run(args: &Args, repo_args: &RepoArgs) -> Result<()> {
     // If a lock file exists, use that, otherwise use Infra.toml or default
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, true)
         .context(error::ConfigSnafu)?;
-    trace!("Using infra config: {:?}", infra_config);
+    trace!("Using infra config: {infra_config:?}");
 
     // If the user has the requested (or "default") repo defined in their Infra.toml, use it,
     // otherwise use a default config.
@@ -508,10 +502,7 @@ pub(crate) async fn run(args: &Args, repo_args: &RepoArgs) -> Result<()> {
         {
             Some((editor, manifest)) => (editor, manifest),
             None => {
-                warn!(
-                    "Did not find repo at '{}', starting a new one",
-                    metadata_url
-                );
+                warn!("Did not find repo at '{metadata_url}', starting a new one");
                 (
                     RepositoryEditor::new(&repo_args.root_role_path)
                         .await

--- a/tools/pubsys/src/repo/check_expirations/mod.rs
+++ b/tools/pubsys/src/repo/check_expirations/mod.rs
@@ -43,10 +43,7 @@ fn find_upcoming_metadata_expiration(
     end_date: DateTime<Utc>,
 ) -> HashMap<tough::schema::RoleType, DateTime<Utc>> {
     let mut expirations = HashMap::new();
-    info!(
-        "Looking for metadata expirations happening from now to {}",
-        end_date
-    );
+    info!("Looking for metadata expirations happening from now to {end_date}");
     if repo.root().signed.expires <= end_date {
         expirations.insert(tough::schema::RoleType::Root, repo.root().signed.expires);
     }
@@ -91,7 +88,7 @@ async fn check_expirations(
     .context(repo_error::RepoLoadSnafu {
         metadata_base_url: metadata_url.clone(),
     })?;
-    info!("Loaded TUF repo:\t{}", metadata_url);
+    info!("Loaded TUF repo:\t{metadata_url}");
 
     info!("Root expiration:\t{}", repo.root().signed.expires);
     info!("Snapshot expiration:\t{}", repo.snapshot().signed.expires);
@@ -103,10 +100,7 @@ async fn check_expirations(
         let now = Utc::now();
         for (role, expiration_date) in upcoming_expirations {
             if expiration_date < now {
-                error!(
-                    "Repo '{}': '{}' expired on {}",
-                    metadata_url, role, expiration_date
-                )
+                error!("Repo '{metadata_url}': '{role}' expired on {expiration_date}")
             } else {
                 warn!(
                     "Repo '{}': '{}' expiring in {} at {}",
@@ -130,7 +124,7 @@ pub(crate) async fn run(args: &Args, check_expirations_args: &CheckExpirationsAr
     // If a lock file exists, use that, otherwise use Infra.toml
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
         .context(repo_error::ConfigSnafu)?;
-    trace!("Parsed infra config: {:?}", infra_config);
+    trace!("Parsed infra config: {infra_config:?}");
     let repo_config = infra_config
         .repo
         .as_ref()

--- a/tools/pubsys/src/repo/fetch_variant/mod.rs
+++ b/tools/pubsys/src/repo/fetch_variant/mod.rs
@@ -169,7 +169,7 @@ async fn fetch_variant(
 pub(crate) async fn run(args: &Args, fetch_variant_args: &FetchVariantArgs) -> Result<(), Error> {
     let infra_config =
         InfraConfig::from_path(&args.infra_config_path).context(repo_error::ConfigSnafu)?;
-    trace!("Parsed infra config: {:?}", infra_config);
+    trace!("Parsed infra config: {infra_config:?}");
     let repo_config = infra_config
         .repo
         .as_ref()

--- a/tools/pubsys/src/repo/refresh_repo/mod.rs
+++ b/tools/pubsys/src/repo/refresh_repo/mod.rs
@@ -97,7 +97,7 @@ async fn refresh_repo(
     let mut repo_editor = RepositoryEditor::from_repo(root_role_path, repo)
         .await
         .context(repo_error::EditorFromRepoSnafu)?;
-    info!("Loaded TUF repo: {}", metadata_url);
+    info!("Loaded TUF repo: {metadata_url}");
 
     // Refresh the expiration dates of all non-root metadata files
     set_expirations(&mut repo_editor, expiration, *EXPIRATION_START_TIME)?;
@@ -133,7 +133,7 @@ pub(crate) async fn run(args: &Args, refresh_repo_args: &RefreshRepoArgs) -> Res
     // If a lock file exists, use that, otherwise use Infra.toml
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
         .context(repo_error::ConfigSnafu)?;
-    trace!("Parsed infra config: {:?}", infra_config);
+    trace!("Parsed infra config: {infra_config:?}");
 
     let repo_config = infra_config
         .repo

--- a/tools/pubsys/src/repo/validate_repo/mod.rs
+++ b/tools/pubsys/src/repo/validate_repo/mod.rs
@@ -98,7 +98,7 @@ async fn validate_repo(
     .context(repo_error::RepoLoadSnafu {
         metadata_base_url: metadata_url.clone(),
     })?;
-    info!("Loaded TUF repo: {}", metadata_url);
+    info!("Loaded TUF repo: {metadata_url}");
     if validate_targets {
         // Try retrieving listed targets
         retrieve_targets(&repo).await?;
@@ -112,7 +112,7 @@ pub(crate) async fn run(args: &Args, validate_repo_args: &ValidateRepoArgs) -> R
     // If a lock file exists, use that, otherwise use Infra.toml
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, false)
         .context(repo_error::ConfigSnafu)?;
-    trace!("Parsed infra config: {:?}", infra_config);
+    trace!("Parsed infra config: {infra_config:?}");
     let repo_config = infra_config
         .repo
         .as_ref()

--- a/tools/pubsys/src/vmware/govc.rs
+++ b/tools/pubsys/src/vmware/govc.rs
@@ -79,7 +79,7 @@ impl Govc {
         let govc_cmd = &[
             Self::GOVC,
             "import.ova",
-            &format!("-options={}", import_spec_container_path),
+            &format!("-options={import_spec_container_path}"),
             "-name",
             name,
             ova_container_path,
@@ -102,7 +102,7 @@ fn docker_run(docker_env: &[&str], mount: Option<&[&str]>, command: &[&str]) -> 
     let sdk = env::var("TLPRIVATE_SDK_IMAGE").context(error::EnvironmentSnafu {
         var: "TLPRIVATE_SDK_IMAGE",
     })?;
-    trace!("SDK image: {}", sdk);
+    trace!("SDK image: {sdk}");
 
     let mut args = vec!["run"];
     args.push("--net=host");
@@ -123,7 +123,7 @@ fn docker_run(docker_env: &[&str], mount: Option<&[&str]>, command: &[&str]) -> 
         .context(error::CommandStartSnafu)?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    trace!("{}", stdout);
+    trace!("{stdout}");
     if output.status.success() {
         Ok(output)
     } else {

--- a/tools/pubsys/src/vmware/upload_ova/mod.rs
+++ b/tools/pubsys/src/vmware/upload_ova/mod.rs
@@ -47,7 +47,7 @@ pub(crate) async fn run(args: &Args, upload_args: &UploadArgs) -> Result<()> {
     // If a lock file exists, use that, otherwise use Infra.toml or default
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, true)
         .context(error::InfraConfigSnafu)?;
-    trace!("Using infra config: {:?}", infra_config);
+    trace!("Using infra config: {infra_config:?}");
 
     let vmware = infra_config
         .vmware

--- a/tools/serde-templated-derive/src/container_visitor.rs
+++ b/tools/serde-templated-derive/src/container_visitor.rs
@@ -27,12 +27,12 @@ pub(crate) fn visit_container_leaves_of_type(
         syn::Type::Path(type_path) => {
             if is_container_type(&type_path.path) {
                 // Get the generic args for the type and visit them
-                if let Some(seg) = type_path.path.segments.last_mut() {
-                    if let syn::PathArguments::AngleBracketed(generic_args) = &mut seg.arguments {
-                        for generic_arg in &mut generic_args.args {
-                            if let syn::GenericArgument::Type(inner_ty) = generic_arg {
-                                visit_container_leaves_of_type(inner_ty, visitor);
-                            }
+                if let Some(seg) = type_path.path.segments.last_mut()
+                    && let syn::PathArguments::AngleBracketed(generic_args) = &mut seg.arguments
+                {
+                    for generic_arg in &mut generic_args.args {
+                        if let syn::GenericArgument::Type(inner_ty) = generic_arg {
+                            visit_container_leaves_of_type(inner_ty, visitor);
                         }
                     }
                 }

--- a/tools/testsys-config/src/lib.rs
+++ b/tools/testsys-config/src/lib.rs
@@ -97,7 +97,7 @@ impl TestConfig {
                     (test_type, configs)
                 },
             );
-        debug!("Resolved test-type '{}'", test_type);
+        debug!("Resolved test-type '{test_type}'");
         (
             configs
                 .into_iter()
@@ -225,7 +225,7 @@ impl GenericConfig {
             // If the current test config specifies another test type, that test type needs to be
             // added to the configurations.
             if let Some(test_type) = test_config.test_type.to_owned() {
-                trace!("Test-type '{}' resolves to '{}'", cur_test_type, test_type);
+                trace!("Test-type '{cur_test_type}' resolves to '{test_type}'");
                 cur_test_type = test_type;
             } else {
                 break;
@@ -428,33 +428,29 @@ impl TestsysImages {
         S: Into<String>,
     {
         let registry = registry.into();
-        let tag = tag.unwrap_or_else(|| format!("v{}", TESTSYS_VERSION));
+        let tag = tag.unwrap_or_else(|| format!("v{TESTSYS_VERSION}"));
         Self {
-            eks_resource_agent_image: Some(format!("{}/eks-resource-agent:{tag}", registry)),
-            ecs_resource_agent_image: Some(format!("{}/ecs-resource-agent:{tag}", registry)),
+            eks_resource_agent_image: Some(format!("{registry}/eks-resource-agent:{tag}")),
+            ecs_resource_agent_image: Some(format!("{registry}/ecs-resource-agent:{tag}")),
             vsphere_k8s_cluster_resource_agent_image: Some(format!(
-                "{}/vsphere-k8s-cluster-resource-agent:{tag}",
-                registry
+                "{registry}/vsphere-k8s-cluster-resource-agent:{tag}"
             )),
             metal_k8s_cluster_resource_agent_image: Some(format!(
-                "{}/metal-k8s-cluster-resource-agent:{tag}",
-                registry
+                "{registry}/metal-k8s-cluster-resource-agent:{tag}"
             )),
-            ec2_resource_agent_image: Some(format!("{}/ec2-resource-agent:{tag}", registry)),
+            ec2_resource_agent_image: Some(format!("{registry}/ec2-resource-agent:{tag}")),
             ec2_karpenter_resource_agent_image: Some(format!(
-                "{}/ec2-karpenter-resource-agent:{tag}",
-                registry
+                "{registry}/ec2-karpenter-resource-agent:{tag}"
             )),
             vsphere_vm_resource_agent_image: Some(format!(
-                "{}/vsphere-vm-resource-agent:{tag}",
-                registry
+                "{registry}/vsphere-vm-resource-agent:{tag}"
             )),
-            sonobuoy_test_agent_image: Some(format!("{}/sonobuoy-test-agent:{tag}", registry)),
-            ecs_test_agent_image: Some(format!("{}/ecs-test-agent:{tag}", registry)),
-            migration_test_agent_image: Some(format!("{}/migration-test-agent:{tag}", registry)),
-            k8s_workload_agent_image: Some(format!("{}/k8s-workload-agent:{tag}", registry)),
-            ecs_workload_agent_image: Some(format!("{}/ecs-workload-agent:{tag}", registry)),
-            controller_image: Some(format!("{}/controller:{tag}", registry)),
+            sonobuoy_test_agent_image: Some(format!("{registry}/sonobuoy-test-agent:{tag}")),
+            ecs_test_agent_image: Some(format!("{registry}/ecs-test-agent:{tag}")),
+            migration_test_agent_image: Some(format!("{registry}/migration-test-agent:{tag}")),
+            k8s_workload_agent_image: Some(format!("{registry}/k8s-workload-agent:{tag}")),
+            ecs_workload_agent_image: Some(format!("{registry}/ecs-workload-agent:{tag}")),
+            controller_image: Some(format!("{registry}/controller:{tag}")),
             testsys_agent_pull_secret: None,
         }
     }

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -67,7 +67,7 @@ impl CrdCreator for AwsEcsCreator {
             .pop()
         {
             // Return the name of the existing CRD for the cluster.
-            debug!("ECS cluster CRD already exists with name '{}'", cluster_crd);
+            debug!("ECS cluster CRD already exists with name '{cluster_crd}'");
             return Ok(CreateCrdOutput::ExistingCrd(cluster_crd));
         }
 

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -21,19 +21,19 @@ pub(crate) fn ami(ami_input: &str, region: &str) -> Result<String> {
     // Convert the `ami_input` file to a `HashMap` that maps regions to AMI id.
     let amis: HashMap<String, AmiImage> =
         serde_json::from_reader(file).context(error::SerdeJsonSnafu {
-            what: format!("Unable to deserialize '{}'", ami_input),
+            what: format!("Unable to deserialize '{ami_input}'"),
         })?;
     // Make sure there are some AMIs present in the `ami_input` file.
     ensure!(
         !amis.is_empty(),
         error::InvalidSnafu {
-            what: format!("{} is empty", ami_input)
+            what: format!("{ami_input} is empty")
         }
     );
     Ok(amis
         .get(region)
         .context(error::InvalidSnafu {
-            what: format!("AMI not found for region '{}'", region),
+            what: format!("AMI not found for region '{region}'"),
         })?
         .id
         .clone())
@@ -102,10 +102,7 @@ where
 
 /// Get the standard Bottlerocket AMI name.
 pub(crate) fn ami_name(arch: &str, variant: &str, version: &str, commit_id: &str) -> String {
-    format!(
-        "bottlerocket-{}-{}-{}-{}",
-        variant, arch, version, commit_id
-    )
+    format!("bottlerocket-{variant}-{arch}-{version}-{commit_id}")
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -225,7 +222,7 @@ pub(crate) async fn ec2_crd(
 
     let suffix: String = repeat_with(fastrand::lowercase).take(4).collect();
     ec2_builder
-        .build(format!("{}-instances-{}", cluster_name, suffix))
+        .build(format!("{cluster_name}-instances-{suffix}"))
         .context(error::BuildSnafu {
             what: "EC2 instance provider CRD",
         })
@@ -342,7 +339,7 @@ pub(crate) async fn ec2_karpenter_crd(
 
     let suffix: String = repeat_with(fastrand::lowercase).take(4).collect();
     ec2_builder
-        .build(format!("{}-karpenter-{}", cluster_name, suffix))
+        .build(format!("{cluster_name}-karpenter-{suffix}"))
         .context(error::BuildSnafu {
             what: "EC2 instance provider CRD",
         })

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -44,8 +44,7 @@ impl CrdInput<'_> {
             &self.repo_config.targets_url,
         ) {
             debug!(
-                "Using TUF metadata from Infra.toml, metadata: '{}', targets: '{}'",
-                metadata_base_url, targets_url
+                "Using TUF metadata from Infra.toml, metadata: '{metadata_base_url}', targets: '{targets_url}'"
             );
             Some(TufRepoConfig {
                 metadata_url: format!("{}{}/{}/", metadata_base_url, &self.variant, &self.arch),
@@ -82,9 +81,9 @@ impl CrdInput<'_> {
             .map(|label| {
                 labels
                     .get(&label.to_string())
-                    .map(|value| format!("{}={}", label, value))
+                    .map(|value| format!("{label}={value}"))
                     .context(error::InvalidSnafu {
-                        what: format!("The label '{}' was missing", label),
+                        what: format!("The label '{label}' was missing"),
                     })
             })
             .collect::<Result<Vec<String>>>()?
@@ -162,10 +161,7 @@ impl CrdInput<'_> {
             .into_iter()
             .find(|path| path.exists())
             .context(error::InvalidSnafu {
-                what: format!(
-                    "Could not find userdata '{}' for test type '{}'",
-                    userdata, test_type
-                ),
+                what: format!("Could not find userdata '{userdata}' for test type '{test_type}'"),
             })
     }
 
@@ -460,15 +456,13 @@ pub(crate) trait CrdCreator: Sync {
             KnownTestType::Migration => {
                 if let Some(image_id) = &crd_input.starting_image_id {
                     debug!(
-                        "Using the provided starting image id for migration testing '{}'",
-                        image_id
+                        "Using the provided starting image id for migration testing '{image_id}'"
                     );
                     image_id.to_string()
                 } else {
                     let image_id = self.starting_image_id(crd_input).await?;
                     debug!(
-                        "A starting image id was not provided, '{}' will be used instead.",
-                        image_id
+                        "A starting image id was not provided, '{image_id}' will be used instead."
                     );
                     image_id
                 }
@@ -505,7 +499,7 @@ pub(crate) trait CrdCreator: Sync {
                 .await?;
             let cluster_crd_name = cluster_output.crd_name();
             if let Some(crd) = cluster_output.crd() {
-                debug!("Cluster crd was created for '{}'", cluster_name);
+                debug!("Cluster crd was created for '{cluster_name}'");
                 crds.push(crd)
             }
             let bottlerocket_output = self
@@ -520,7 +514,7 @@ pub(crate) trait CrdCreator: Sync {
             match &test_type {
                 KnownTestType::Conformance | KnownTestType::Quick => {
                     if let Some(crd) = bottlerocket_output.crd() {
-                        debug!("Bottlerocket crd was created for '{}'", cluster_name);
+                        debug!("Bottlerocket crd was created for '{cluster_name}'");
                         crds.push(crd)
                     }
                     let test_output = self
@@ -539,7 +533,7 @@ pub(crate) trait CrdCreator: Sync {
                 }
                 KnownTestType::Workload => {
                     if let Some(crd) = bottlerocket_output.crd() {
-                        debug!("Bottlerocket crd was created for '{}'", cluster_name);
+                        debug!("Bottlerocket crd was created for '{cluster_name}'");
                         crds.push(crd)
                     }
                     let test_output = self
@@ -558,7 +552,7 @@ pub(crate) trait CrdCreator: Sync {
                 }
                 KnownTestType::Migration => {
                     if let Some(crd) = bottlerocket_output.crd() {
-                        debug!("Bottlerocket crd was created for '{}'", cluster_name);
+                        debug!("Bottlerocket crd was created for '{cluster_name}'");
                         crds.push(crd)
                     }
                     let mut tests = Vec::new();
@@ -658,10 +652,7 @@ pub(crate) trait CrdCreator: Sync {
         let crd_template_file_path = &override_crd_template
             .or_else(|| crd_input.custom_crd_template_file_path())
             .context(error::InvalidSnafu {
-                what: format!(
-                    "A custom yaml file could not be found for test type '{}'",
-                    test_type
-                ),
+                what: format!("A custom yaml file could not be found for test type '{test_type}'"),
             })?;
         info!(
             "Creating custom crd from '{}'",

--- a/tools/testsys/src/delete.rs
+++ b/tools/testsys/src/delete.rs
@@ -54,13 +54,13 @@ impl Delete {
         let crd_type = self.test.then_some(CrdType::Test);
         let mut labels = Vec::new();
         if let Some(test_name) = self.test_name {
-            labels.push(format!("testsys/test-name={}", test_name))
+            labels.push(format!("testsys/test-name={test_name}"))
         };
         if let Some(arch) = self.arch {
-            labels.push(format!("testsys/arch={}", arch))
+            labels.push(format!("testsys/arch={arch}"))
         };
         if let Some(variant) = self.variant {
-            labels.push(format!("testsys/variant={}", variant))
+            labels.push(format!("testsys/variant={variant}"))
         };
 
         let mut stream = client

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -28,7 +28,8 @@ pub enum Error {
 
     #[snafu(context(false), display("{}", source))]
     DescribeImages {
-        source: SdkError<DescribeImagesError>,
+        #[snafu(source(from(SdkError<DescribeImagesError>, Box::new)))]
+        source: Box<SdkError<DescribeImagesError>>,
     },
 
     #[snafu(display("Unable to read file '{}': {}", path.display(), source))]
@@ -87,7 +88,8 @@ pub enum Error {
 
     #[snafu(context(false), display("{}", source))]
     TestManager {
-        source: testsys_model::test_manager::Error,
+        #[snafu(source(from(testsys_model::test_manager::Error, Box::new)))]
+        source: Box<testsys_model::test_manager::Error>,
     },
 
     #[snafu(context(false), display("{}", source))]

--- a/tools/testsys/src/install.rs
+++ b/tools/testsys/src/install.rs
@@ -41,10 +41,7 @@ impl Install {
             .controller_image
             .expect("The default controller image is missing.");
 
-        trace!(
-            "Installing testsys using controller image '{}'",
-            controller_uri
-        );
+        trace!("Installing testsys using controller image '{controller_uri}'");
 
         let controller_image = match images.testsys_agent_pull_secret {
             Some(secret) => ImageConfig::WithCreds {

--- a/tools/testsys/src/main.rs
+++ b/tools/testsys/src/main.rs
@@ -87,9 +87,9 @@ enum Command {
 async fn main() {
     let args = TestsysArgs::parse();
     init_logger(args.log_level);
-    debug!("{:?}", args);
+    debug!("{args:?}");
     if let Err(e) = args.run().await {
-        error!("{}", e);
+        error!("{e}");
         std::process::exit(1);
     }
 }

--- a/tools/testsys/src/run.rs
+++ b/tools/testsys/src/run.rs
@@ -210,7 +210,7 @@ impl Run {
         let variant = Variant::new(&self.variant).context(error::VariantSnafu {
             variant: self.variant,
         })?;
-        debug!("Using variant '{}'", variant);
+        debug!("Using variant '{variant}'");
 
         // Use Test.toml or default
         let test_config = TestConfig::from_path_or_default(&self.test_config_path)?;

--- a/tools/testsys/src/status.rs
+++ b/tools/testsys/src/status.rs
@@ -52,10 +52,10 @@ impl Status {
         let crd_type = self.test.then_some(CrdType::Test);
         let mut labels = Vec::new();
         if let Some(arch) = self.arch {
-            labels.push(format!("testsys/arch={}", arch))
+            labels.push(format!("testsys/arch={arch}"))
         };
         if let Some(variant) = self.variant {
-            labels.push(format!("testsys/variant={}", variant))
+            labels.push(format!("testsys/variant={variant}"))
         };
         let mut status = client
             .status(&SelectionParams {
@@ -109,8 +109,8 @@ impl Status {
         let (width, _) = terminal_size::terminal_size()
             .map(|(w, h)| (w.0 as usize, h.0))
             .unwrap_or((80, 0));
-        debug!("Window width '{}'", width);
-        println!("{:width$}", status);
+        debug!("Window width '{width}'");
+        println!("{status:width$}");
 
         Ok(())
     }

--- a/tools/testsys/src/vmware_k8s.rs
+++ b/tools/testsys/src/vmware_k8s.rs
@@ -212,9 +212,9 @@ impl CrdCreator for VmwareK8sCreator {
             .vcenter_resource_pool(&self.datacenter.resource_pool)
             .vcenter_workload_folder(&self.datacenter.folder)
             .cluster(VSphereK8sClusterInfo {
-                name: format!("${{{}.clusterName}}", cluster_name),
-                control_plane_endpoint_ip: format!("${{{}.endpoint}}", cluster_name),
-                kubeconfig_base64: format!("${{{}.encodedKubeconfig}}", cluster_name),
+                name: format!("${{{cluster_name}.clusterName}}"),
+                control_plane_endpoint_ip: format!("${{{cluster_name}.endpoint}}"),
+                kubeconfig_base64: format!("${{{cluster_name}.encodedKubeconfig}}"),
             })
             .custom_user_data(
                 bottlerocket_input
@@ -260,7 +260,7 @@ impl CrdCreator for VmwareK8sCreator {
                     .collect(),
             ))
             .depends_on(cluster_name)
-            .build(format!("{}-vms-{}", cluster_name, suffix))
+            .build(format!("{cluster_name}-vms-{suffix}"))
             .context(error::BuildSnafu {
                 what: "vSphere VM CRD",
             })?;

--- a/tools/update-metadata/src/se.rs
+++ b/tools/update-metadata/src/se.rs
@@ -15,13 +15,10 @@ where
         let key = format!(
             "({}, {})",
             serde_plain::to_string(&from).map_err(|e| S::Error::custom(format!(
-                "Could not serialize 'from' version: {}",
-                e
+                "Could not serialize 'from' version: {e}"
             )))?,
-            serde_plain::to_string(&to).map_err(|e| S::Error::custom(format!(
-                "Could not serialize 'to' version: {}",
-                e
-            )))?,
+            serde_plain::to_string(&to)
+                .map_err(|e| S::Error::custom(format!("Could not serialize 'to' version: {e}")))?,
         );
         map.insert(key, val);
     }

--- a/twoliter/src/cargo_make.rs
+++ b/twoliter/src/cargo_make.rs
@@ -142,7 +142,7 @@ fn build_system_env_vars() -> Result<Vec<String>> {
         if is_build_system_env(key.as_str()) {
             trace!("Passing env var {} to cargo make", key);
             args.push("-e".to_string());
-            args.push(format!("{}={}", key, val));
+            args.push(format!("{key}={val}"));
         }
 
         // To avoid confusion, environment variables whose values have been moved to

--- a/twoliter/src/cmd/debug.rs
+++ b/twoliter/src/cmd/debug.rs
@@ -39,7 +39,7 @@ pub(crate) struct CheckToolArgs {
 fn unique_name() -> String {
     let uuid = format!("{}", Uuid::new_v4());
     let slug = &uuid[0..8];
-    format!("twoliter-tools-{}", slug)
+    format!("twoliter-tools-{slug}")
 }
 
 impl CheckToolArgs {

--- a/twoliter/src/project/lock/image.rs
+++ b/twoliter/src/project/lock/image.rs
@@ -178,7 +178,7 @@ impl EncodedKitMetadata {
             .decode(&self.0)
             .ok()
             .and_then(|bytes| serde_json::from_slice(bytes.as_slice()).ok())
-            .map(|metadata: ImageMetadata| format!("<ImageMetadata(decoded) [{:?}]>", metadata))
+            .map(|metadata: ImageMetadata| format!("<ImageMetadata(decoded) [{metadata:?}]>"))
     }
 }
 
@@ -285,7 +285,7 @@ impl ImageResolver {
         let canonical_metadata = embedded_kit_metadata
             .try_next()
             .await?
-            .context(format!("could not find metadata for kit {}", uri))?;
+            .context(format!("could not find metadata for kit {uri}"))?;
 
         trace!("Checking that all manifests refer to the same kit.");
         while let Some(kit_metadata) = embedded_kit_metadata.try_next().await? {
@@ -337,8 +337,7 @@ impl ImageResolver {
             .find(|x| x.platform.as_ref().unwrap().architecture == docker_arch)
             .cloned()
             .context(format!(
-                "could not find image for architecture '{}' at {}",
-                docker_arch, uri
+                "could not find image for architecture '{docker_arch}' at {uri}"
             ))?;
 
         let registry = uri.registry.context("failed to resolve image registry")?;

--- a/twoliter/src/project/lock/views.rs
+++ b/twoliter/src/project/lock/views.rs
@@ -45,8 +45,7 @@ impl<'de> Deserialize<'de> for ContainerDigest {
         let digest = String::deserialize(deserializer)?;
         if !digest.starts_with("sha256:") {
             return Err(D::Error::custom(format!(
-                "invalid digest detected in layer: {}",
-                digest
+                "invalid digest detected in layer: {digest}"
             )));
         };
         Ok(Self(digest))


### PR DESCRIPTION
**Description of changes:**
This takes advantage of a newly-introduced nightly compile feature: https://blog.rust-lang.org/inside-rust/2025/07/15/call-for-testing-hint-mostly-unused/

The AWS SDKs are a substantial portion of compile times for twoliter. Enabling this new nightly feature allows cargo codegen specific dependencies "just-in-time" rather than up-front. This allows cargo to refrain from generating code for unused portions of an API surface.

On my machine this reduces release and debug build times by nearly a full minute.

### Release Builds Without Hints
<img width="1234" height="575" alt="without-hints" src="https://github.com/user-attachments/assets/a1870b24-2a64-4524-8d66-534f2f719b2c" />


### Release Builds With Hints
<img width="960" height="553" alt="with-hints" src="https://github.com/user-attachments/assets/b4787feb-71e0-4336-86c0-0c828a4be080" />

**Testing done:**
* [x] build and publish core-kit
* [x] build and publish aws-k8s-1.32 variants


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
