### PR TITLE
fix: remove features to workaround cargo-dist bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ ci = ["github"]
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
-features = ["pubsys", "testsys"]
 
 [workspace.metadata.cross.build]
 pre-build = [

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -45,9 +45,9 @@ zstd.workspace = true
 twoliter-tool-buildsys.workspace = true
 twoliter-tool-embedded-bundle.workspace = true
 twoliter-tool-pipesys.workspace = true
-twoliter-tool-pubsys = { workspace = true, optional = true }
-twoliter-tool-pubsys-setup = { workspace = true, optional = true }
-twoliter-tool-testsys = { workspace = true, optional = true }
+twoliter-tool-pubsys.workspace = true
+twoliter-tool-pubsys-setup.workspace = true
+twoliter-tool-testsys.workspace = true
 twoliter-tool-tuftool.workspace = true
 twoliter-tool-unplug.workspace = true
 
@@ -60,10 +60,8 @@ tar.workspace = true
 test-case.workspace = true
 
 [features]
-default = ["integ-tests", "pubsys", "testsys"]
+default = ["integ-tests"]
 integ-tests = []
-pubsys = ["dep:twoliter-tool-pubsys", "dep:twoliter-tool-pubsys-setup"]
-testsys = ["dep:twoliter-tool-testsys"]
 
 [lints]
 workspace = true

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -34,7 +34,7 @@ pub(crate) async fn install_tools(tools_dir: impl AsRef<Path>) -> Result<()> {
         .context("Unable to get Dockerfile metadata")?;
     let mtime = FileTime::from_last_modification_time(&metadata);
 
-    let mut write_tasks = vec![
+    let write_tasks = vec![
         write_bin(
             "buildsys",
             twoliter_tool_buildsys::BUILDSYS.reader(),
@@ -55,31 +55,20 @@ pub(crate) async fn install_tools(tools_dir: impl AsRef<Path>) -> Result<()> {
         ),
         write_bin("unplug", twoliter_tool_unplug::UNPLUG.reader(), &dir, mtime),
         write_bin("krane", krane_bundle::KRANE_BIN.reader(), &dir, mtime),
-    ];
-
-    #[cfg(feature = "pubsys")]
-    {
-        write_tasks.push(write_bin(
+        write_bin(
             "pubsys-setup",
             twoliter_tool_pubsys_setup::PUBSYS_SETUP.reader(),
             &dir,
             mtime,
-        ));
-        write_tasks.push(write_bin(
-            "pubsys",
-            twoliter_tool_pubsys::PUBSYS.reader(),
+        ),
+        write_bin("pubsys", twoliter_tool_pubsys::PUBSYS.reader(), &dir, mtime),
+        write_bin(
+            "testsys",
+            twoliter_tool_testsys::TESTSYS.reader(),
             &dir,
             mtime,
-        ));
-    }
-
-    #[cfg(feature = "testsys")]
-    write_tasks.push(write_bin(
-        "testsys",
-        twoliter_tool_testsys::TESTSYS.reader(),
-        &dir,
-        mtime,
-    ));
+        ),
+    ];
 
     try_join_all(write_tasks.into_iter()).await?;
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
* Removed the features restriction on pubsys and testsys that hit a bug in our fork of cargo-dist when calling build with feature flags

**Bug that was Hit**
We found that when our cargo-dist fork runs cargo build when you provide multiple features instead of adding the appropriate features list it adds a second --features argument leading to the error.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
