### PR TITLE
fix: a check that prevent inconsistent manual change in twoliter.lock

### DIFF
--- a/twoliter/src/project/lock/mod.rs
+++ b/twoliter/src/project/lock/mod.rs
@@ -204,20 +204,18 @@ impl Lock {
         }
     }
 
+    /// Validates that the version and source URI of each locked image in the lockfile are consistent.
     fn validate_version_source_consistency(&self) -> Result<()> {
-        Self::validate_locked_image_consistency(&self.sdk, "SDK")?;
+        Self::validate_locked_image_consistency(&self.sdk)?;
 
-        for (index, kit) in self.kit.iter().enumerate() {
-            Self::validate_locked_image_consistency(
-                kit,
-                &format!("kit[{}] ({})", index, kit.name),
-            )?;
+        for kit in &self.kit {
+            Self::validate_locked_image_consistency(kit)?;
         }
 
         Ok(())
     }
 
-    fn validate_locked_image_consistency(image: &LockedImage, context: &str) -> Result<()> {
+    fn validate_locked_image_consistency(image: &LockedImage) -> Result<()> {
         let expected_tag = format!("v{}", image.version);
 
         let actual_tag = image
@@ -231,8 +229,9 @@ impl Lock {
                 "Version-source mismatch in lockfile for {}: \
                 version field is '{}' but source URI '{}' has tag '{}'. \
                 Expected source to end with ':{expected_tag}'. \
-                This usually happens when the lockfile was manually edited.",
-                context,
+                This usually happens when the lockfile was manually edited. \
+                You should prevent manually change the twoliter.lock file.",
+                image,
                 image.version,
                 image.source,
                 actual_tag

--- a/twoliter/src/project/lock/mod.rs
+++ b/twoliter/src/project/lock/mod.rs
@@ -190,6 +190,10 @@ impl Lock {
             .context("failed to read lockfile")?;
         let lock: Self =
             toml::from_str(lock_str.as_str()).context("failed to deserialize lockfile")?;
+
+        lock.validate_version_source_consistency()
+            .context("lockfile validation failed")?;
+
         Ok(lock)
     }
 
@@ -198,6 +202,43 @@ impl Lock {
             sdk: self.sdk.clone(),
             kits: self.kit.clone(),
         }
+    }
+
+    fn validate_version_source_consistency(&self) -> Result<()> {
+        Self::validate_locked_image_consistency(&self.sdk, "SDK")?;
+
+        for (index, kit) in self.kit.iter().enumerate() {
+            Self::validate_locked_image_consistency(
+                kit,
+                &format!("kit[{}] ({})", index, kit.name),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_locked_image_consistency(image: &LockedImage, context: &str) -> Result<()> {
+        let expected_tag = format!("v{}", image.version);
+
+        let actual_tag = image
+            .source
+            .rsplit(':')
+            .next()
+            .context("source URI does not contain a tag (missing ':' separator)")?;
+
+        if actual_tag != expected_tag {
+            bail!(
+                "Version-source mismatch in lockfile for {}: \
+                version field is '{}' but source URI '{}' has tag '{}'. \
+                Expected source to end with ':{expected_tag}'. \
+                This usually happens when the lockfile was manually edited.",
+                context,
+                image.version,
+                image.source,
+                actual_tag
+            );
+        }
+        Ok(())
     }
 
     /// Fetches all external kits defined in a Twoliter.lock to the build directory


### PR DESCRIPTION
**Issue number:450**

Closes # https://github.com/bottlerocket-os/twoliter/issues/450

**Description of changes:**
Add a check to prevent manual change in twoliter.lock that causes inconsistency. Now the build would fail if there's such inconsistency

**Testing done:**
Manual tests done on both sdk and kit packages.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
