### PR TITLE
twoliter: always fetch kit deps before build tasks

### DIFF
--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -53,7 +53,10 @@ impl BuildKit {
     pub(super) async fn run(&self) -> Result<()> {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let project = project.load_lock::<Locked>().await?;
+        project.fetch(self.arch.as_str()).await?;
+
         let toolsdir = project.project_dir().join("build/tools");
+
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");
 
@@ -113,6 +116,8 @@ impl BuildVariant {
     pub(super) async fn run(&self) -> Result<()> {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let project = project.load_lock::<Locked>().await?;
+        project.fetch(self.arch.as_str()).await?;
+
         let toolsdir = project.project_dir().join("build/tools");
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");

--- a/twoliter/src/cmd/make.rs
+++ b/twoliter/src/cmd/make.rs
@@ -54,7 +54,7 @@ pub(crate) struct Make {
 impl Make {
     pub(super) async fn run(&self) -> Result<()> {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
-        let sdk_source = self.locked_sdk(&project).await?;
+        let sdk_source = self.lock_and_fetch(&project).await?;
         let toolsdir = project.project_dir().join("build/tools");
         install_tools(&toolsdir).await?;
         let makefile_path = toolsdir.join("Makefile.toml");
@@ -77,11 +77,15 @@ impl Make {
     }
 
     /// Returns the locked SDK image for the project.
-    async fn locked_sdk(&self, project: &project::Project<Unlocked>) -> Result<String> {
+    ///
+    /// Fetches kits if needed.
+    async fn lock_and_fetch(&self, project: &project::Project<Unlocked>) -> Result<String> {
         Ok(if self.can_skip_kit_verification(project) {
             project.load_lock::<SDKLocked>().await?.sdk_image()
         } else {
-            project.load_lock::<Locked>().await?.sdk_image()
+            let project = project.load_lock::<Locked>().await?;
+            project.fetch(self.arch.as_str()).await?;
+            project.sdk_image()
         }
         .project_image_uri()
         .to_string())


### PR DESCRIPTION
**Issue number:**

Related to  #421

**Description of changes:**
Currently, when building `bottlerocket-os/bottlerocket`, twoliter resolves dependencies twice on startup. Once when [fetching external kits](https://github.com/bottlerocket-os/bottlerocket/blob/54e53fdc7299cb0379c0e711b4a80ab62b4f47da/Makefile.toml#L405-L416), and then again just prior to the build. This is because the `Makefile.toml` file triggers the fetch to ensure that all dependencies are prepared locally prior to starting the build.

This change removes the requirement to explicitly fetch deps by just making twoliter do it on each build.

**Testing done:**
* Removed the dependency fetching step from `bottlerocket-os/bottlerocket` and performed image builds from a clean workspace.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
