### PR TITLE
twoliter: extract kits concurrently

### DIFF
--- a/twoliter/src/project/lock/archive.rs
+++ b/twoliter/src/project/lock/archive.rs
@@ -1,11 +1,14 @@
 use super::views::{IndexView, ManifestLayoutView};
 use crate::common::fs::{create_dir_all, read, read_to_string, remove_dir_all, write};
 use anyhow::{Context, Result};
+use futures::TryStreamExt;
 use oci_cli_wrapper::ImageTool;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use tar::Archive as TarArchive;
 use tracing::{debug, instrument, trace};
+
+const CONCURRENT_LAYER_EXTRACTIONS: usize = 4;
 
 #[derive(Debug)]
 pub(crate) struct OCIArchive {
@@ -64,7 +67,7 @@ impl OCIArchive {
     where
         P: AsRef<Path>,
     {
-        let path = out_dir.as_ref();
+        let path = out_dir.as_ref().to_path_buf();
         let digest_file = path.join("digest");
         let digest_uri = self.uri();
         if digest_file.exists() {
@@ -83,8 +86,8 @@ impl OCIArchive {
         }
 
         debug!("Unpacking layers for image from '{}'", digest_uri);
-        remove_dir_all(path).await?;
-        create_dir_all(path).await?;
+        remove_dir_all(&path).await?;
+        create_dir_all(&path).await?;
         let index_bytes = read(self.archive_path().join("index.json")).await?;
         let index: IndexView = serde_json::from_slice(index_bytes.as_slice())
             .context("failed to deserialize oci image index")?;
@@ -105,21 +108,44 @@ impl OCIArchive {
 
         // Extract each layer into the target directory
         trace!(from = %digest_uri, "Extracting image layers");
-        for layer in manifest_layout.layers {
-            let digest = layer.digest.to_string().replace(':', "/");
-            let layer_blob = File::open(self.archive_path().join(format!("blobs/{digest}")))
-                .context("failed to read layer of oci image")?;
-            let mut layer_archive = TarArchive::new(layer_blob);
-            layer_archive
-                .unpack(path)
-                .context("failed to unpack layer to disk")?;
-        }
-        write(&digest_file, self.digest.as_str())
-            .await
-            .context(format!(
-                "failed to record digest to {}",
-                digest_file.display()
-            ))?;
+        let layer_unpack_stream =
+            futures::stream::iter(manifest_layout.layers.iter().map(|layer| {
+                let digest = layer.digest.to_string().replace(':', "/");
+                let archive_path = self.archive_path().join(format!("blobs/{digest}"));
+                let dest_path = path.clone();
+                Ok(async {
+                    tokio::task::spawn_blocking(move || {
+                        let layer_blob = File::open(archive_path)
+                            .context("failed to read layer of oci image")?;
+                        let mut layer_archive = TarArchive::new(layer_blob);
+                        layer_archive
+                            .unpack(dest_path)
+                            .context("failed to unpack layer to disk")?;
+
+                        Result::<_, anyhow::Error>::Ok(())
+                    })
+                    .await
+                    .context("Faild to join layer extraction task")
+                    .and_then(std::convert::identity)
+                })
+            }))
+            .try_buffer_unordered(CONCURRENT_LAYER_EXTRACTIONS)
+            .try_collect::<Vec<_>>();
+
+        let digest_write_task = async {
+            write(&digest_file, self.digest.as_str())
+                .await
+                .context(format!(
+                    "failed to record digest to {}",
+                    digest_file.display()
+                ))?;
+            Ok(())
+        };
+
+        tokio::try_join! {
+            layer_unpack_stream,
+            digest_write_task,
+        }?;
 
         Ok(())
     }

--- a/twoliter/src/project/lock/mod.rs
+++ b/twoliter/src/project/lock/mod.rs
@@ -18,6 +18,7 @@ use crate::common::fs::{create_dir_all, read, write};
 use crate::project::{Project, ValidIdentifier};
 use crate::schema_version::SchemaVersion;
 use anyhow::{bail, ensure, Context, Result};
+use futures::{stream, StreamExt, TryStreamExt};
 use image::{ImageResolver, LockedImage};
 use oci_cli_wrapper::ImageTool;
 use olpc_cjson::CanonicalFormatter as CanonicalJsonFormatter;
@@ -33,6 +34,8 @@ use tracing::{debug, error, info, instrument};
 use super::{Locked, ProjectLock, Unlocked};
 
 const TWOLITER_LOCK: &str = "Twoliter.lock";
+
+const CONCURRENT_KIT_EXTRACTIONS: usize = 8;
 
 #[derive(Serialize, Debug)]
 struct ExternalKitMetadata {
@@ -214,15 +217,28 @@ impl Lock {
             dependencies = ?self.kit.iter().map(ToString::to_string).collect::<Vec<_>>(),
             "Extracting kit dependencies."
         );
-        for image in self.kit.iter() {
-            let image = project.as_project_image(image)?;
-            let resolver = ImageResolver::from_image(&image)?;
-            resolver
-                .extract(&image_tool, &project.external_kits_dir(), arch)
-                .await?;
-        }
 
-        self.synchronize_metadata(project).await
+        let kit_stream = stream::iter(self.kit.iter());
+        kit_stream
+            .map(|kit| {
+                Result::<_, anyhow::Error>::Ok(async {
+                    let image = project.as_project_image(kit)?;
+                    let resolver = ImageResolver::from_image(&image)?;
+                    resolver
+                        .extract(&image_tool, &project.external_kits_dir(), arch)
+                        .await?;
+                    Ok(())
+                })
+            })
+            .try_buffer_unordered(CONCURRENT_KIT_EXTRACTIONS)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        self.synchronize_metadata(project).await?;
+
+        info!("Finished fetching kit dependencies.");
+
+        Ok(())
     }
 
     pub(crate) async fn synchronize_metadata(&self, project: &Project<Locked>) -> Result<()> {


### PR DESCRIPTION
**Description of changes:**
This improves dependency resolution in Twoliter by allowing OCI dependencies to be extracted to the filesystem concurrently via tokio.


**Testing:**
Running `cargo make fetch-external-kits` in `bottlerocket-os/bottlerocket`

Before:

```
[2025-07-28T21:20:59Z INFO  twoliter::project::lock::image] Extracting kit 'bottlerocket-kernel-kit' to '/home/ec2-user/brdev/bottlerocket/build/external-kits'
[2025-07-28T21:21:05Z INFO  twoliter::project::lock::image] Extracting kit 'bottlerocket-core-kit' to '/home/ec2-user/brdev/bottlerocket/build/external-kits'
[cargo-make] INFO - Build Done in 15.23 seconds.
cargo make -e BUILDSYS_ARCH=aarch64 -e BUILDSYS_VARIANT=aws-k8s-1.33   7.36s user 6.28s system 89% cpu 15.295 total
```

After:

```
[2025-07-28T21:21:26Z INFO  twoliter::project::lock::image] Extracting kit 'bottlerocket-kernel-kit' to '/home/ec2-user/brdev/bottlerocket/build/external-kits'
[2025-07-28T21:21:26Z INFO  twoliter::project::lock::image] Extracting kit 'bottlerocket-core-kit' to '/home/ec2-user/brdev/bottlerocket/build/external-kits'
[2025-07-28T21:21:31Z INFO  twoliter::project::lock] Finished fetching kit dependencies.
[cargo-make] INFO - Build Done in 8.28 seconds.
cargo make -e BUILDSYS_ARCH=aarch64 -e BUILDSYS_VARIANT=aws-k8s-1.33   7.61s user 6.09s system 164% cpu 8.343 total
```

* Built `bottlerocket-os/bottlerocket` variants, tested resultant AMIs.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
