### PR TITLE
chore: release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.11.0...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.12.0...HEAD
 
-## [0.12.0-rc1] - 2025-08-21
+## [0.12.0] - 2025-08-21
+
+### Breaking Changes
+* Update schema-version of Twoliter.toml to version 2. This introduces a new field project-vendor. ([#551])
+  * Users will need to run `twoliter update` after updating twoliter on any kits or variant repositories to migrate their lockfile to schema-version 2.
+  * Users will need to bump the schema-version to 2 in Twoliter.toml if they want to use the new project-vendor field
 
 ### Fixed
 * Fix a check that prevent inconsistent manual change in twoliter.lock ([#563])
-
-### Added
-* Add schema-version 2 of Twoliter.toml. Introduces new field project-vendor ([#551])
 
 ### Changed
 * Always fetch kit deps before build tasks ([#565])
@@ -32,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#566]: https://github.com/bottlerocket-os/twoliter/pull/566
 [#570]: https://github.com/bottlerocket-os/twoliter/pull/570
 
-[0.12.0-rc1]: https://github.com/bottlerocket-os/twoliter/compare/v0.11.0...v0.12.0-rc1
+[0.12.0]: https://github.com/bottlerocket-os/twoliter/compare/v0.11.0...v0.12.0
 
 ## [0.11.0] - 2025-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.12.0-rc1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" 
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
 
-twoliter = { version = "0.12.0-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.12.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
 twoliter-tool-buildsys = { version = "0.1", path = "twoliter/src/tool-crates/buildsys" }
 twoliter-tool-embedded-bundle = { version = "0.1", path = "twoliter/src/tool-crates/embedded-bundle" }
 twoliter-tool-pipesys = { version = "0.1", path = "twoliter/src/tool-crates/pipesys" }

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.12.0-rc1"
+version = "0.12.0"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
**Description of changes:**
Release of Twoliter 0.12.0


**Testing done:**
- [x] Built core kit x86_64
- [x] Built core kit aarch64
- [x] Built kernel kit x86_64
- [x] Built kernel kit aarch64
- [x] Built bob ami without project-vendor and launched instance validating   /etc/os-release Vendor lists Bottlerocket
- [x] Built bob ami with project-vendor=Foo and launched instance validating /etc/os-release Vendor lists Foo 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
