### PR TITLE
feat(img2img): add new error when erofs code is called on non-erofs r…

### DIFF
--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -130,6 +130,12 @@ dd if="${OS_IMAGE}" of="${ROOT_IMAGE}" \
 
 # For erofs, extract the root filesystem since we can't modify in-place.
 if [[ "${EROFS_ROOT_PARTITION}" == "yes" ]]; then
+  # Validate that the root image is actually erofs
+  filesystem_type="$(blkid -c /dev/null -o value -s TYPE "${ROOT_IMAGE}")"
+  if [[ "${filesystem_type}" != "erofs" ]]; then
+    echo "root partition is not erofs as expected, found: '${filesystem_type}'" >&2
+    exit 1
+  fi
   fsck.erofs --extract="${ROOT_MOUNT}" "${ROOT_IMAGE}"
   touch -r "${ROOT_IMAGE}" "${ROOT_MOUNT}"
   rm "${ROOT_IMAGE}"


### PR DESCRIPTION
…oot images

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #575

Closes #575 

**Description of changes:**
Adds a check of the filesystem type before using fsck.erofs to extract the root image and will error out if it finds something it does not expect.


**Testing done:**
* Built aws-ecs-2 variant with erofs = false
* Changed erofs enabled in the variant Cargo.toml
* Ran repack-variant to verify error occured

```
2.263 + echo 'root partition is not erofs as expected, found: '\''ext4'\'''
2.263 root partition is not erofs as expected, found: 'ext4'
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
