### PR TITLE
feat(pubsys): add support for ami tags

### DIFF
--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -136,6 +136,25 @@ pub struct AwsConfig {
     pub region: HashMap<String, AwsRegionConfig>,
     pub ssm_prefix: Option<String>,
     pub s3: Option<HashMap<String, S3Config>>,
+    pub tags: Option<AmiTags>,
+}
+
+/// AWS ami tags
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct AmiTags {
+    global: Option<HashMap<String, String>>,
+    region: Option<HashMap<String, HashMap<String, String>>>,
+}
+
+impl AmiTags {
+    pub fn resolve_for_region(&self, region: impl AsRef<str>) -> HashMap<String, String> {
+        let mut tags = self.global.clone().unwrap_or_default();
+        if let Some(regional_tags) = self.region.as_ref().and_then(|x| x.get(region.as_ref())) {
+            tags.extend(regional_tags.clone());
+        }
+        tags
+    }
 }
 
 /// AWS region-specific configuration

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -17,7 +17,7 @@ use crate::Args;
 use aws_sdk_ebs::Client as EbsClient;
 use aws_sdk_ec2::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_ec2::operation::copy_image::{CopyImageError, CopyImageOutput};
-use aws_sdk_ec2::types::OperationType;
+use aws_sdk_ec2::types::{OperationType, ResourceType, Tag, TagSpecification};
 use aws_sdk_ec2::{config::Region, Client as Ec2Client};
 use aws_sdk_sts::operation::get_caller_identity::{
     GetCallerIdentityError, GetCallerIdentityOutput,
@@ -208,13 +208,21 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
             "Registering '{}' in {}",
             tentative_amispec.name, base_region
         );
-        let new_ids = register_image(ami_args, &base_region, base_ebs_client, &base_ec2_client)
-            .await
-            .context(error::RegisterImageSnafu {
-                name: &tentative_amispec.name,
-                arch: &arch,
-                region: base_region.as_ref(),
-            })?;
+        let new_ids = register_image(
+            ami_args,
+            &base_region,
+            base_ebs_client,
+            &base_ec2_client,
+            aws.tags
+                .as_ref()
+                .map(|x| x.resolve_for_region(&base_region.to_string())),
+        )
+        .await
+        .context(error::RegisterImageSnafu {
+            name: &tentative_amispec.name,
+            arch: &arch,
+            region: base_region.as_ref(),
+        })?;
         info!(
             "Registered AMI '{}' in {}: {}",
             tentative_amispec.name, base_region, new_ids.image_id
@@ -382,6 +390,10 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         }
 
         let ec2_client = &ec2_clients[&region];
+        let tags = aws
+            .tags
+            .as_ref()
+            .map(|x| x.resolve_for_region(region.to_string()));
         let base_region = base_region.to_owned();
         let copy_future = ec2_client
             .copy_image()
@@ -389,6 +401,16 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
             .set_name(Some(tentative_amispec.name.clone()))
             .set_source_image_id(Some(ids_of_image.image_id.clone()))
             .set_source_region(Some(base_region.as_ref().to_string()))
+            .set_tag_specifications(tags.map(|x| {
+                vec![TagSpecification::builder()
+                    .resource_type(ResourceType::Image)
+                    .set_tags(Some(
+                        x.iter()
+                            .map(|(key, value)| Tag::builder().key(key).value(value).build())
+                            .collect(),
+                    ))
+                    .build()]
+            }))
             .send();
 
         // Store the region so we can output it to the user

--- a/tools/pubsys/src/aws/ami/register/mod.rs
+++ b/tools/pubsys/src/aws/ami/register/mod.rs
@@ -1,7 +1,7 @@
 use super::{snapshot::snapshot_from_image, AmiArgs};
 use crate::aws::ami::snapshot::build_progress_bar;
 use aws_sdk_ebs::Client as EbsClient;
-use aws_sdk_ec2::types::Filter;
+use aws_sdk_ec2::types::{Filter, ResourceType, Tag, TagSpecification};
 use aws_sdk_ec2::{config::Region, Client as Ec2Client};
 use coldsnap::{SnapshotUploader, SnapshotWaiter};
 use futures::future::OptionFuture;
@@ -9,6 +9,7 @@ use futures::TryFutureExt as _;
 use indicatif::{MultiProgress, ProgressBar};
 use log::{debug, info, warn};
 use snafu::{ensure, futures::TryFutureExt as _, OptionExt, ResultExt, Snafu};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -29,6 +30,7 @@ async fn _register_image(
     region: &Region,
     ebs_client: EbsClient,
     ec2_client: &Ec2Client,
+    tags: Option<HashMap<String, String>>,
     cleanup_snapshot_ids: Arc<Mutex<Vec<String>>>,
 ) -> Result<RegisteredIds> {
     let bottlerocket_snapshots = BottlerocketSnapshots::create_snapshots(
@@ -48,6 +50,16 @@ async fn _register_image(
     info!("Making register image call in {region}");
     let register_response = amispec
         .as_register_image_call()
+        .set_tag_specifications(tags.map(|x| {
+            vec![TagSpecification::builder()
+                .resource_type(ResourceType::Image)
+                .set_tags(Some(
+                    x.iter()
+                        .map(|(key, value)| Tag::builder().key(key).value(value).build())
+                        .collect(),
+                ))
+                .build()]
+        }))
         .send_with(ec2_client)
         .await
         .context(error::RegisterImageSnafu {
@@ -199,6 +211,7 @@ pub(crate) async fn register_image(
     region: &Region,
     ebs_client: EbsClient,
     ec2_client: &Ec2Client,
+    tags: Option<HashMap<String, String>>,
 ) -> Result<RegisteredIds> {
     let cleanup_snapshot_ids = Arc::new(Mutex::new(Vec::new()));
     let register_result = _register_image(
@@ -206,6 +219,7 @@ pub(crate) async fn register_image(
         region,
         ebs_client,
         ec2_client,
+        tags,
         Arc::clone(&cleanup_snapshot_ids),
     )
     .await;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #574 

Closes #574 

**Description of changes:**
Adds new section under aws-specific fields in Infra.toml for tags tags defined under tags.global will apply to all AMIs created, while tags created to aws.tags.region.<region> will only apply to that region


**Testing done:**

- Created a bottlerocket build and then created a Infra.toml with:
```toml
[aws]
regions = ["us-west-2", "us-east-1"]

[aws.tags.global]
tag0 = "foo"

[aws.tags.region.us-west-2]
tag1 = "bar"
```
- Ran pubsys publish ami through cargo make
- [x] us-west-2 ami has global tag0 = "foo"
- [x] us-east-1 ami has global tag0 = "foo"
- [x] us-west-2 ami has region specific tag1 = "bar"
- [x] us-east-1 ami DOES NOT have tag1 = "bar"

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
