### PR TITLE
rpm2img: Emit `artifact-metadata.json` with disk utilization

### DIFF
--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -198,6 +198,13 @@ check_image_size "${ROOT_IMAGE}" "${partsize["ROOT-A"]}"
 dd if="${ROOT_IMAGE}" of="${OS_IMAGE}" \
   iflag=fullblock conv=notrunc bs=1M seek="${partoff["ROOT-A"]}"
 
+# Report ROOT partition usage
+if [[ "${EROFS_ROOT_PARTITION}" == "yes" ]]; then
+  root_usage=$(get_erofs_usage "${ROOT_IMAGE}" "ROOT-A" "${partsize["ROOT-A"]}")
+else
+  root_usage=$(get_ext4_usage "${ROOT_IMAGE}" "ROOT-A")
+fi
+
 # Generate a new root verity.
 declare -a DM_VERITY_ROOT
 generate_verity_root "${ROOT_IMAGE}" "${VERITY_IMAGE}" \
@@ -295,6 +302,12 @@ check_debugfs_errors "${GRUB_DEBUGFS_STDERR}"
 check_image_size "${BOOT_IMAGE}" "${partsize["BOOT-A"]}"
 dd if="${BOOT_IMAGE}" of="${OS_IMAGE}" \
   iflag=fullblock conv=notrunc bs=1M seek="${partoff["BOOT-A"]}"
+
+# Report BOOT partition usage
+boot_usage=$(get_ext4_usage "${BOOT_IMAGE}" "BOOT-A")
+
+# Combine usage data into final JSON
+echo "${root_usage}" "${boot_usage}" | jq -s 'add | {disk_usage: .}' > "${OUTPUT_DIR}/artifact-metadata.json"
 
 ###############################################################################
 # Section 7: generate final artifacts and copy to output dir

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -355,6 +355,54 @@ check_image_size() {
   fi
 }
 
+get_ext4_usage() {
+  local image_file partition_name
+  local fs_info block_count free_blocks block_size
+  local used_blocks used_bytes total_bytes bytes_remaining percentage_bytes
+  image_file="${1:?}"
+  partition_name="${2:?}"
+
+  fs_info="$(dumpe2fs -h "${image_file}" 2>/dev/null)"
+  block_count="$(echo "${fs_info}" | grep "^Block count:" | awk '{print $3}')"
+  free_blocks="$(echo "${fs_info}" | grep "^Free blocks:" | awk '{print $3}')"
+  block_size="$(echo "${fs_info}" | grep "^Block size:" | awk '{print $3}')"
+
+  used_blocks="$((block_count - free_blocks))"
+  used_bytes="$((used_blocks * block_size))"
+  total_bytes="$((block_count * block_size))"
+  bytes_remaining="$((free_blocks * block_size))"
+  percentage_bytes="$((used_bytes * 100 / total_bytes))"
+
+  jq -n \
+    --arg partition "${partition_name}" \
+    --argjson bytes_total "${total_bytes}" \
+    --argjson bytes_used "${used_bytes}" \
+    --argjson bytes_remaining "${bytes_remaining}" \
+    --argjson percentage_bytes "${percentage_bytes}" \
+    '{($partition): {bytes_total: $bytes_total, bytes_used: $bytes_used, bytes_remaining: $bytes_remaining, percentage_bytes: $percentage_bytes}}'
+}
+
+get_erofs_usage() {
+  local image_file partition_name partition_size_mib
+  local used_bytes total_bytes bytes_remaining percentage_bytes
+  image_file="${1:?}"
+  partition_name="${2:?}"
+  partition_size_mib="${3:?}"
+
+  used_bytes="$(stat -c %s "${image_file}")"
+  total_bytes="$((partition_size_mib * 1024 * 1024))"
+  bytes_remaining="$((total_bytes - used_bytes))"
+  percentage_bytes="$((used_bytes * 100 / total_bytes))"
+
+  jq -n \
+    --arg partition "${partition_name}" \
+    --argjson bytes_total "${total_bytes}" \
+    --argjson bytes_used "${used_bytes}" \
+    --argjson bytes_remaining "${bytes_remaining}" \
+    --argjson percentage_bytes "${percentage_bytes}" \
+    '{($partition): {bytes_total: $bytes_total, bytes_used: $bytes_used, bytes_remaining: $bytes_remaining, percentage_bytes: $percentage_bytes}}'
+}
+
 generate_verity_root() {
   local root_image verity_image veritypart_mib
   local -n dm_verity_root

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -405,6 +405,13 @@ else
 fi
 dd if="${ROOT_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff["ROOT-A"]}"
 
+# Report ROOT partition usage
+if [[ "${EROFS_ROOT_PARTITION}" == "yes" ]]; then
+  root_usage=$(get_erofs_usage "${ROOT_IMAGE}" "ROOT-A" "${partsize["ROOT-A"]}")
+else
+  root_usage=$(get_ext4_usage "${ROOT_IMAGE}" "ROOT-A")
+fi
+
 # BOTTLEROCKET-VERITY-A
 declare -a DM_VERITY_ROOT
 generate_verity_root "${ROOT_IMAGE}" "${VERITY_IMAGE}" "${partsize["HASH-A"]}" \
@@ -502,6 +509,12 @@ mkfs.ext4 -O ^has_journal -d "${BOOT_MOUNT}" "${BOOT_IMAGE}" "${partsize["BOOT-A
 echo "${BOOT_LABELS}" | debugfs -w -f - "${BOOT_IMAGE}"
 resize2fs -M "${BOOT_IMAGE}"
 dd if="${BOOT_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff["BOOT-A"]}"
+
+# Report BOOT partition usage
+boot_usage=$(get_ext4_usage "${BOOT_IMAGE}" "BOOT-A")
+
+# Combine usage data into final JSON
+echo "${root_usage}" "${boot_usage}" | jq -s 'add | {disk_usage: .}' > "${OUTPUT_DIR}/artifact-metadata.json"
 
 # BOTTLEROCKET-PRIVATE
 


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/twoliter/issues/580

**Description of changes:**
Add helper functions and invocations to rpm2img to get the utilization of a partition and emit this into a file called artifact-metadata.json with data for ROOT-A and BOOT-A partitions. This can be extended to provide other metadata about the images but this helps track the resulting utilization of the various partitions created via an image build.


**Testing done:**
Built images with this and found the file in the images directory:
```
cat build/images/x86_64-aws-k8s-1.30-nvidia/latest/artifact-metadata.json
{
  "disk_usage": {
    "ROOT-A": {
      "bytes_total": 1929379840,
      "bytes_used": 1821106176,
      "bytes_remaining": 108273664,
      "percentage_bytes": 94
    },
    "BOOT-A": {
      "bytes_total": 46589952,
      "bytes_used": 26313728,
      "bytes_remaining": 20276224,
      "percentage_bytes": 56
    }
  }
}
```
Or EROFS volumes:
```
cat build/images/x86_64-aws-k8s-1.33/latest/artifact-metadata.json
{
  "disk_usage": {
    "ROOT-A": {
      "bytes_total": 964689920,
      "bytes_used": 325574656,
      "bytes_remaining": 639115264,
      "percentage_bytes": 33
    },
    "BOOT-A": {
      "bytes_total": 26564608,
      "bytes_used": 16827392,
      "bytes_remaining": 9737216,
      "blocks_remaining": 9509,
      "percentage_bytes": 63
    }
  }
}
```
img2img results in different sizes but both files are generated:
```
# cargo make -e BUILDSYS_VARIANT=aws-k8s-1.28
{
  "disk_usage": {
    "ROOT-A": {
      "bytes_total": 964689920,
      "bytes_used": 794816512,
      "bytes_remaining": 169873408,
      "percentage_bytes": 82
    },
    "BOOT-A": {
      "bytes_total": 41943040,
      "bytes_used": 25523200,
      "bytes_remaining": 16419840,
      "percentage_bytes": 60
    }
  }
}
# cargo make -e BUILDSYS_VARIANT=aws-k8s-1.28 -e BUILDSYS_CACERTS_BUNDLE_OVERRIDE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem repack-variant
{
  "disk_usage": {
    "ROOT-A": {
      "bytes_total": 964689920,
      "bytes_used": 794812416,
      "bytes_remaining": 169877504,
      "percentage_bytes": 82
    },
    "BOOT-A": {
      "bytes_total": 41943040,
      "bytes_used": 25523200,
      "bytes_remaining": 16419840,
      "percentage_bytes": 60
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
