### PR TITLE
feat: merge SBOM packages and remove old SBOM's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOP := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
-BOTTLEROCKET_SDK_VERSION ?= v0.60.0
+BOTTLEROCKET_SDK_VERSION ?= v0.66.0
 BOTTLEROCKET_SDK_IMAGE ?= public.ecr.aws/bottlerocket/bottlerocket-sdk:$(BOTTLEROCKET_SDK_VERSION)
 
 .PHONY: design

--- a/tests/projects/local-kit/Twoliter.toml
+++ b/tests/projects/local-kit/Twoliter.toml
@@ -4,7 +4,7 @@ release-version = "1.0.0"
 [sdk]
 name = "bottlerocket-sdk"
 vendor = "bottlerocket"
-version = "0.60.0"
+version = "0.66.0"
 
 [vendor.bottlerocket]
 # This test will fail if Twoliter overrides aren't working

--- a/tests/projects/project1/Twoliter.toml
+++ b/tests/projects/project1/Twoliter.toml
@@ -4,7 +4,7 @@ release-version = "1.0.0"
 [sdk]
 name = "bottlerocket-sdk"
 vendor = "bottlerocket"
-version = "0.60.0"
+version = "0.66.0"
 
 [vendor.bottlerocket]
 registry = "twoliter.alpha"

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -298,7 +298,7 @@ RUN --mount=target=/host \
       EXTERNAL_KIT_REPOS+=("--repofrompath=${REPO_NAME},${REPO_PATH}" --enablerepo "${REPO_NAME}"); \
     done && \
     echo "${EXTERNAL_KIT_REPOS[@]}" && \
-    mkdir -p /local/rpms && \
+    mkdir -p /local/rpms /local/sbom-rpms && \
     download_dir_opt="$(dnf install --help | grep -Fwq downloaddir && echo "--downloaddir /local/rpms" ||:)" && \
     dnf -y \
       --disablerepo '*' \
@@ -312,7 +312,8 @@ RUN --mount=target=/host \
       install \
         --downloadonly \
 	${download_dir_opt} \
-        $(printf "bottlerocket-%s\n" metadata ${PACKAGES}) && \
+        $(printf "bottlerocket-%s\n" metadata metadata-sbom ${PACKAGES}) && \
+    find /local/rpms -mindepth 2 -type f -name '*-sbom-*.rpm' -exec mv -t /local/sbom-rpms {} + && \
     find /local/rpms -mindepth 2 -type f -name '*.rpm' -exec mv -t /local/rpms {} + && \
     find /local/rpms -mindepth 1 ! -name '*.rpm' -delete && \
     rm /output && \
@@ -371,6 +372,7 @@ RUN --mount=target=/host \
     /host/build/tools/pipesys link --fd-socket "${OUTPUT_SOCKET}" --target /output && \
     /host/build/tools/rpm2img \
       --package-dir=/local/rpms \
+      --sbom-package-dir=/local/sbom-rpms \
       --output-dir=/output \
       --external-kits-path="/bypass/build/external-kits" \
       --output-fmt="${IMAGE_FORMAT}" \

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -28,11 +28,18 @@ SBKEYS="${HOME}/sbkeys"
 declare -a SHIM_SIGN_KEY CODE_SIGN_KEY
 
 sanity_checks() {
-  local output_fmt partition_plan ovf_template uefi_secure_boot
+  local output_fmt partition_plan ovf_template uefi_secure_boot sbom_package_dir
   output_fmt="${1:?}"
   partition_plan="${2:?}"
   ovf_template="${3:?}"
   uefi_secure_boot="${4:?}"
+  sbom_package_dir="${5:?}"
+
+  if [[ ! -d "${sbom_package_dir}" ]]; then
+    echo "SBOM package directory does not exist: ${sbom_package_dir}" >&2
+    exit 1
+  fi
+
   case "${output_fmt}" in
   raw | qcow2 | vmdk) ;;
   *)

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -69,12 +69,22 @@ Provides: %{_cross_os}image-feature(no-encrypted-storage)
 %description
 %{summary}.
 
+%package sbom
+Summary: SBOM metadata for Bottlerocket image
+Provides: %{_cross_os}image-metadata(sbom)
+
+%description sbom
+SBOM metadata subpackage for Bottlerocket image.
+
 %prep
 
 %build
 
 %install
+mkdir -p %{buildroot}%{_cross_datadir}/bottlerocket
 
 %files
+
+%files sbom
 
 %changelog

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -30,6 +30,7 @@ for opt in "$@"; do
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   --with-encrypted-storage=*) ENCRYPTED_STORAGE="${optarg}" ;;
+  --sbom-package-dir=*) SBOM_PACKAGE_DIR="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -46,7 +47,7 @@ done
 . "${0%/*}/imghelper"
 
 sanity_checks \
-  "${OUTPUT_FMT}" "${PARTITION_PLAN}" "${OVF_TEMPLATE}" "${UEFI_SECURE_BOOT}"
+  "${OUTPUT_FMT}" "${PARTITION_PLAN}" "${OVF_TEMPLATE}" "${UEFI_SECURE_BOOT}" "${SBOM_PACKAGE_DIR}"
 
 # Store output artifacts in a versioned directory.
 OUTPUT_DIR="${OUTPUT_DIR}/${VERSION_ID}-${BUILD_ID}"
@@ -255,6 +256,41 @@ printf "%s\n" "${INVENTORY_DATA}" >"${ROOT_MOUNT}/usr/share/bottlerocket/applica
 # Write the the inventory to a file in the local build output directory so that builders
 # can access the inventory without needed to dig into the generated image.
 printf "%s\n" "${INVENTORY_DATA}" >"${OUTPUT_DIR}/application-inventory.json"
+
+# Install SBOM packages
+SBOM_MOUNT=$(mktemp -d)
+
+# TODO: Eventually this needs to trigger an error also, but it might be too soon to break backwards compatibility.
+mapfile -t sbom_rpms < <(find "${SBOM_PACKAGE_DIR}" -maxdepth 1 -name "*.rpm" -type f)
+
+# There will always be a metadata SBOM package
+if [[ ${#sbom_rpms[@]} -gt 1 ]]; then
+  mkdir -p "${SBOM_MOUNT}/var/lib/rpm"
+  rpm -iv --ignorearch --root "${SBOM_MOUNT}" "${SBOM_PACKAGE_DIR}"/*.rpm
+  usr_dirs=(${SBOM_MOUNT}/*-linux-gnu/sys-root/usr)
+  usr_dir="${usr_dirs[0]}"
+  ln -rs "${usr_dir}" "${SBOM_MOUNT}/usr"
+fi
+
+# Merge SBOMs into a single json file
+KIT_SBOMS_DIR="${SBOM_MOUNT}/usr/share/sboms"
+if [ -d "${KIT_SBOMS_DIR}" ]; then
+  IMAGE_SBOM_DIR="${ROOT_MOUNT}/usr/share/bottlerocket"
+  mkdir -p "${IMAGE_SBOM_DIR}"
+  for format in "spdx" "cyclonedx"; do
+    image_sbom="${format}-sbom.json"
+    image_sbom_path="${IMAGE_SBOM_DIR}/${image_sbom}"
+    find "${KIT_SBOMS_DIR}" -name "*-${format}.json" -type f -exec sbomtool merge --output "${image_sbom_path}" {} \+
+    if [[ ! -f "${image_sbom_path}" ]]; then
+      echo "Could not find image SBOM path: ${image_sbom_path}" >&2
+      exit 1
+    fi
+    cp "${image_sbom_path}" "${OUTPUT_DIR}/${image_sbom}"
+    if [[ "${EROFS_ROOT_PARTITION}" == "no" ]]; then
+      lz4 -z -f "${image_sbom_path}" "${image_sbom_path}.lz4"
+    fi
+  done
+fi
 
 # Regenerate module dependencies, if possible.
 KMOD_DIR="${ROOT_MOUNT}/lib/modules"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #584

Closes #584

**Description of changes:**
Use `sbomtool` to merge SBOM packages into a single file per format

This change consolidates SBOM data from individual package SBOMs into unified, compressed 
files.

Changes:

- Added `metadata-sbom` subpackage to `metadata.spec` that provides a marker file for SBOM 
metadata
- Modified `rpm2img` to install SBOM subpackages into a separate mount point during image 
build
- Iterates through all installed packages and installs their corresponding `-sbom` subpackages
if available
- Uses `sbomtool` merge to combine all package SBOMs into single files for each format (`spdx` 
and `cyclonedx`)
- Compresses merged SBOMs with `lz4` and stores them in `/usr/share/bottlerocket/` on the root 
partition
- Copies compressed SBOMs to the output directory for external access
- Removes individual SBOM JSON files after merging to save space

**Testing done:**
- Built and mounted self-built AMI in build host. Verified the partition did not have a `/usr/share/sboms` directory but had a `usr/share/bottlerocket/sbom/` directory with `image-spdx.json.lz4` and `image-cyclonedx.json.lz4` files.
```
# aarch64
→ ls /mnt/br-ami/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/
audit  bottlerocket  brush  dbus-1  eks  factory  i18n  info  iproute2  keyutils  licenses  locale  logdog.d  man  pci.ids  storewolf  templates  terminfo  updog  whippet  xfsprogs  zoneinfo

→ ll /mnt/br-ami/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/
total 196K
-rw-r--r--. 1 root root  63K Dec 11 03:29 application-inventory.json
-rw-r--r--. 1 root root 365K Dec 11 03:29 cyclonedx-sbom.json
-rw-r--r--. 1 root root   76 Dec 11 03:29 image-features.env
drwxr-xr-x. 3 root root   46 Dec 11 03:29 kernel-devel/
-rw-r--r--. 1 root root 1.4M Dec 11 03:29 spdx-sbom.json
```

```
# x86_64
→ ls /mnt/br-ami/x86_64-bottlerocket-linux-gnu/sys-root/usr/share
audit         brush   eks      i18n  iproute2  licenses  logdog.d  pci.ids    templates  updog    xfsprogs
bottlerocket  dbus-1  factory  info  keyutils  locale    man       storewolf  terminfo   whippet  zoneinfo

→  ll /mnt/br-ami/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/
total 328K
-rw-r--r--. 1 root root  65K Dec 11 04:36 application-inventory.json
-rw-r--r--. 1 root root 612K Dec 11 04:36 cyclonedx-sbom.json
-rw-r--r--. 1 root root   76 Dec 11 04:36 image-features.env
drwxr-xr-x. 3 root root   46 Dec 11 04:36 kernel-devel/
-rw-r--r--. 1 root root 2.6M Dec 11 04:36 spdx-sbom.json
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
