### PR TITLE
chore: remove erofs-root-partition from EXPERIMENTAL_IMAGE_FEATURES list

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -819,7 +819,7 @@ pub enum ImageFeature {
     ExternalKmodDevelopment,
 }
 
-const EXPERIMENTAL_IMAGE_FEATURES: [&ImageFeature; 1] = [&ImageFeature::ErofsRootPartition];
+const EXPERIMENTAL_IMAGE_FEATURES: [&ImageFeature; 0] = [];
 
 impl TryFrom<String> for ImageFeature {
     type Error = Error;


### PR DESCRIPTION
**Issue number:**

Closes https://github.com/bottlerocket-os/twoliter/issues/585

**Description of changes:**

`erofs-root-partition` is no longer an experimental feature. This change declutters the AMI build output a bit.


**Testing done:**

N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
