### PR TITLE
add encrypted storage feature and deprecate older features

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -828,6 +828,7 @@ const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[];
 
 const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
     &ImageFeature::GrubSetPrivateVar,
+    &ImageFeature::SystemdNetworkd,
 ];
 
 impl TryFrom<String> for ImageFeature {

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -519,6 +519,11 @@ impl ManifestInfo {
                 println!("cargo:warning=Image feature {experiment} is experimental; use at your own risk!");
             }
         }
+        for deprecated in DEPRECATED_IMAGE_FEATURES {
+            if features.contains(deprecated) {
+                println!("cargo:warning=Image feature {deprecated} is deprecated and will be removed in a future release!");
+            }
+        }
         Some(features)
     }
 
@@ -819,7 +824,9 @@ pub enum ImageFeature {
     ExternalKmodDevelopment,
 }
 
-const EXPERIMENTAL_IMAGE_FEATURES: [&ImageFeature; 0] = [];
+const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[];
+
+const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[];
 
 impl TryFrom<String> for ImageFeature {
     type Error = Error;

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -246,6 +246,13 @@ fips = true
 external-kmod-development = true
 ```
 
+`encrypted-storage` enables encryption for writable filesystems and block devices. This should
+only be enabled for variants that can guarantee that a TPM 2.0 device will be present at runtime.
+
+```ignore
+[package.metadata.build-variant.image-features]
+encrypted-storage = true
+```
 
 */
 
@@ -822,9 +829,10 @@ pub enum ImageFeature {
     InPlaceUpdates,
     HostContainers,
     ExternalKmodDevelopment,
+    EncryptedStorage,
 }
 
-const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[];
+const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[&ImageFeature::EncryptedStorage];
 
 const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
     &ImageFeature::GrubSetPrivateVar,
@@ -844,6 +852,7 @@ impl TryFrom<String> for ImageFeature {
             "in-place-updates" => Ok(ImageFeature::InPlaceUpdates),
             "host-containers" => Ok(ImageFeature::HostContainers),
             "external-kmod-development" => Ok(ImageFeature::ExternalKmodDevelopment),
+            "encrypted-storage" => Ok(ImageFeature::EncryptedStorage),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -861,6 +870,7 @@ impl fmt::Display for ImageFeature {
             ImageFeature::InPlaceUpdates => write!(f, "IN_PLACE_UPDATES"),
             ImageFeature::HostContainers => write!(f, "HOST_CONTAINERS"),
             ImageFeature::ExternalKmodDevelopment => write!(f, "EXTERNAL_KMOD_DEVELOPMENT"),
+            ImageFeature::EncryptedStorage => write!(f, "ENCRYPTED_STORAGE"),
         }
     }
 }

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -826,7 +826,9 @@ pub enum ImageFeature {
 
 const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[];
 
-const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[];
+const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
+    &ImageFeature::GrubSetPrivateVar,
+];
 
 impl TryFrom<String> for ImageFeature {
     type Error = Error;

--- a/tools/pubsys/src/aws/ami/register/mk_amispec.rs
+++ b/tools/pubsys/src/aws/ami/register/mk_amispec.rs
@@ -12,6 +12,8 @@
 //!     * Default EBS block device mappings are created for each snapshot
 //!     * If the variant supports secure boot, then the template has uefi-data updated, and sets
 //!       the default `boot-mode` to `uefi-preferred`
+//!     * If the variant supports encrypted storage, then the template sets the default `boot-mode`
+//!       to `uefi` and enables the TPM 2.0 device
 //! * The default TOML template is merged with the user-provided TOML document, using a recursive
 //!   "upsert" procedure.
 //! * The resulting TOML document is parsed as a `TemplatedAmiSpec`
@@ -223,6 +225,9 @@ fn ensure_amispec_volume_sizes(
 /// * If the variant has secure boot enabled:
 ///     * `boot-mode` is set to `uefi-preferred`
 ///     * `uefi-data` is set to the input string
+/// * If the variant has encrypted storage enabled:
+///     * `boot-mode` is set to `uefi`
+///     * `tpm-support` is set to `v2.0`
 fn default_amispec_template(
     variant_manifest: &VariantManifest,
     bottlerocket_snapshots: Option<&BottlerocketSnapshots>,
@@ -260,6 +265,17 @@ fn default_amispec_template(
             "uefi-data".into(),
             uefi_data.context(MissingUefiDataSnafu)?.into(),
         );
+    }
+
+    // Setup UEFI boot mode and TPM 2.0 support if encrypted storage is enabled
+    if variant_manifest
+        .image_features()
+        .iter()
+        .flatten()
+        .any(|f| *f == ImageFeature::EncryptedStorage)
+    {
+        amispec_template.insert("boot-mode".into(), "uefi".into());
+        amispec_template.insert("tpm-support".into(), "v2.0".into());
     }
 
     Ok(amispec_template)

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -211,6 +211,7 @@ ARG IN_PLACE_UPDATES
 ARG HOST_CONTAINERS
 ARG FIPS
 ARG EXTERNAL_KMOD_DEVELOPMENT
+ARG ENCRYPTED_STORAGE
 
 USER builder
 WORKDIR /home/builder
@@ -233,7 +234,8 @@ RUN \
    && echo -e -n "${EROFS_ROOT_PARTITION:+%bcond_without erofs_root_partition\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${IN_PLACE_UPDATES:+%bcond_without in_place_updates\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${HOST_CONTAINERS:+%bcond_without host_containers\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${EXTERNAL_KMOD_DEVELOPMENT:+%bcond_without external_kmod_development\n}" >> "${RPM_BCONDS}"
+   && echo -e -n "${EXTERNAL_KMOD_DEVELOPMENT:+%bcond_without external_kmod_development\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${ENCRYPTED_STORAGE:+%bcond_without encrypted_storage\n}" >> "${RPM_BCONDS}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an RPM repository from packages created in Section 1 and kits from Section 2.
@@ -341,6 +343,7 @@ ARG XFS_DATA_PARTITION
 ARG EROFS_ROOT_PARTITION
 ARG UEFI_SECURE_BOOT
 ARG IN_PLACE_UPDATES
+ARG ENCRYPTED_STORAGE
 ARG PROJECT_VENDOR
 ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
     PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
@@ -380,7 +383,8 @@ RUN --mount=target=/host \
       ${XFS_DATA_PARTITION:+--with-xfs-data-partition=yes} \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
-      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} && \
+      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
+      ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} && \
     rm -rf /local/rpms && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -204,7 +204,6 @@ ARG VARIANT_PLATFORM
 ARG VARIANT_RUNTIME
 ARG VARIANT_FAMILY
 ARG VARIANT_FLAVOR
-ARG GRUB_SET_PRIVATE_VAR
 ARG UEFI_SECURE_BOOT
 ARG SYSTEMD_NETWORKD
 ARG XFS_DATA_PARTITION
@@ -229,7 +228,6 @@ RUN \
    && echo "%bcond_without $(V=${VARIANT_RUNTIME,,}; echo ${V//-/_})_runtime" >> "${RPM_BCONDS}" \
    && echo "%bcond_without $(V=${VARIANT_FAMILY,,}; echo ${V//-/_})_family" >> "${RPM_BCONDS}" \
    && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> "${RPM_BCONDS}" \
-   && echo -e -n "${GRUB_SET_PRIVATE_VAR:+%bcond_without grub_set_private_var\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${FIPS:+%bcond_without fips\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> "${RPM_BCONDS}" \
@@ -341,7 +339,6 @@ ARG PARTITION_PLAN
 ARG OS_IMAGE_PUBLISH_SIZE_GIB
 ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG KERNEL_PARAMETERS
-ARG GRUB_SET_PRIVATE_VAR
 ARG XFS_DATA_PARTITION
 ARG EROFS_ROOT_PARTITION
 ARG UEFI_SECURE_BOOT
@@ -384,7 +381,6 @@ RUN --mount=target=/host \
       --ovf-template="/bypass/variants/${VARIANT}/template.ovf" \
       ${XFS_DATA_PARTITION:+--with-xfs-data-partition=yes} \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
-      ${GRUB_SET_PRIVATE_VAR:+--with-grub-set-private-var=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
       ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} && \
     rm -rf /local/rpms && \

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -205,7 +205,6 @@ ARG VARIANT_RUNTIME
 ARG VARIANT_FAMILY
 ARG VARIANT_FLAVOR
 ARG UEFI_SECURE_BOOT
-ARG SYSTEMD_NETWORKD
 ARG XFS_DATA_PARTITION
 ARG EROFS_ROOT_PARTITION
 ARG IN_PLACE_UPDATES
@@ -230,7 +229,6 @@ RUN \
    && echo "%bcond_without $(V=${VARIANT_FLAVOR:-no}; V=${V,,}; echo ${V//-/_})_flavor" >> "${RPM_BCONDS}" \
    && echo -e -n "${FIPS:+%bcond_without fips\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${UEFI_SECURE_BOOT:+%bcond_without uefi_secure_boot\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${SYSTEMD_NETWORKD:+%bcond_without systemd_networkd\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${XFS_DATA_PARTITION:+%bcond_without xfs_data_partition\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${EROFS_ROOT_PARTITION:+%bcond_without erofs_root_partition\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${IN_PLACE_UPDATES:+%bcond_without in_place_updates\n}" >> "${RPM_BCONDS}" \

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -26,11 +26,7 @@ Provides: %{_cross_os}image-feature(host-containers)
 Provides: %{_cross_os}image-feature(no-host-containers)
 %endif
 
-%if %{with grub_set_private_var}
 Provides: %{_cross_os}image-feature(grub-set-private-var)
-%else
-Provides: %{_cross_os}image-feature(no-grub-set-private-var)
-%endif
 
 %if %{with uefi_secure_boot}
 Provides: %{_cross_os}image-feature(uefi-secure-boot)

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -59,6 +59,13 @@ Provides: %{_cross_os}image-feature(external-kmod-development)
 %else
 Provides: %{_cross_os}image-feature(no-external-kmod-development)
 %endif
+
+%if %{with encrypted_storage}
+Provides: %{_cross_os}image-feature(encrypted-storage)
+%else
+Provides: %{_cross_os}image-feature(no-encrypted-storage)
+%endif
+
 %description
 %{summary}.
 

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -34,11 +34,7 @@ Provides: %{_cross_os}image-feature(uefi-secure-boot)
 Provides: %{_cross_os}image-feature(no-uefi-secure-boot)
 %endif
 
-%if %{with systemd_networkd}
 Provides: %{_cross_os}image-feature(systemd-networkd)
-%else
-Provides: %{_cross_os}image-feature(no-systemd-networkd)
-%endif
 
 %if %{with xfs_data_partition}
 Provides: %{_cross_os}image-feature(xfs-data-partition)

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -10,6 +10,7 @@ XFS_DATA_PARTITION="no"
 EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
+ENCRYPTED_STORAGE="no"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -28,6 +29,7 @@ for opt in "$@"; do
   --with-erofs-root-partition=*) EROFS_ROOT_PARTITION="${optarg}" ;;
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
+  --with-encrypted-storage=*) ENCRYPTED_STORAGE="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -385,6 +387,13 @@ if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
   printf "%s\n" "DATA_PARTITION_FILESYSTEM=xfs" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 else
   printf "%s\n" "DATA_PARTITION_FILESYSTEM=ext4" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+fi
+
+# Set encrypted storage flag
+if [[ "${ENCRYPTED_STORAGE}" == "yes" ]]; then
+  printf "%s\n" "ENCRYPTED_STORAGE=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+else
+  printf "%s\n" "ENCRYPTED_STORAGE=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 fi
 
 # BOTTLEROCKET-ROOT-A

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -389,6 +389,13 @@ else
   printf "%s\n" "DATA_PARTITION_FILESYSTEM=ext4" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 fi
 
+# Set in-place updates flag
+if [[ "${IN_PLACE_UPDATES}" == "yes" ]]; then
+  printf "%s\n" "IN_PLACE_UPDATES=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+else
+  printf "%s\n" "IN_PLACE_UPDATES=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+fi
+
 # Set encrypted storage flag
 if [[ "${ENCRYPTED_STORAGE}" == "yes" ]]; then
   printf "%s\n" "ENCRYPTED_STORAGE=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -6,7 +6,6 @@ shopt -qs failglob
 OUTPUT_FMT="raw"
 OVF_TEMPLATE=""
 
-GRUB_SET_PRIVATE_VAR="no"
 XFS_DATA_PARTITION="no"
 EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
@@ -25,7 +24,6 @@ for opt in "$@"; do
   --data-image-publish-size-gib=*) DATA_IMAGE_PUBLISH_SIZE_GIB="${optarg}" ;;
   --partition-plan=*) PARTITION_PLAN="${optarg}" ;;
   --ovf-template=*) OVF_TEMPLATE="${optarg}" ;;
-  --with-grub-set-private-var=*) GRUB_SET_PRIVATE_VAR="${optarg}" ;;
   --with-xfs-data-partition=*) XFS_DATA_PARTITION="${optarg}" ;;
   --with-erofs-root-partition=*) EROFS_ROOT_PARTITION="${optarg}" ;;
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
@@ -419,14 +417,9 @@ generate_verity_root "${ROOT_IMAGE}" "${VERITY_IMAGE}" "${partsize["HASH-A"]}" \
 dd if="${VERITY_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff["HASH-A"]}"
 
 # write GRUB config
-# If GRUB_SET_PRIVATE_VAR is set, include the parameters that support Boot Config
-if [[ "${GRUB_SET_PRIVATE_VAR}" == "yes" ]]; then
-  BOOTCONFIG='bootconfig'
-  INITRD="initrd (\$private)/bootconfig.data"
-else
-  BOOTCONFIG=""
-  INITRD=""
-fi
+# Include the parameters that support Boot Config
+BOOTCONFIG='bootconfig'
+INITRD="initrd (\$private)/bootconfig.data"
 
 # If UEFI_SECURE_BOOT is set, disable interactive edits. Otherwise the intended
 # kernel command line parameters could be changed if the boot fails. Disable
@@ -479,19 +472,6 @@ if [[ -d "${BOOT_MOUNT}/boot-config.d" ]]; then
   find "${BOOT_MOUNT}/boot-config.d" -type f -mindepth 1 -maxdepth 1 -print0 |
     sort -Vz | xargs -0 cat >"${BOOTCONFIG_INPUT}"
   rm -rf "${BOOT_MOUNT}/boot-config.d"
-fi
-
-# This should never happen, but if the image isn't using "grub-set-private-var"
-# and we have some bootconfig input to render, then bail out because otherwise
-# the kernel command line may not be configured as expected.
-if [[ -s "${BOOTCONFIG_INPUT}" ]] && [[ "${GRUB_SET_PRIVATE_VAR}" == "no" ]]; then
-  cat <<EOF >&2
-Found bootconfig snippets but 'grub-set-private-var' isn't enabled for the variant.
-To fix this, add the following to the variant's Cargo.toml:"
-  [package.metadata.build-variant.image-features]
-  grub-set-private-var = true
-EOF
-  exit 1
 fi
 
 # Generate a no-op bootconfig if there weren't any snippets.


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4680

**Description of changes:**
Add an image feature for encrypted storage.

My plan is for this to cover both `/local` (using dm-crypt) and `/.bottlerocket/datastore` (using fscrypt). I'll post the related core kit changes soon.

Deprecate two image features that are no longer useful.

`aws-ecs-1` was the last variant where GRUB's `$private` variable wasn't set in the earliest version, and also the last one to use `wicked` instead of `systemd-networkd`. Since `aws-ecs-1` is gone, and `wicked` is gone, there's no need to keep these features around.


**Testing done:**
Confirmed that I could add the encrypted storage feature to a variant and trigger the install of supporting software.

Verified that software that requires the networkd image feature continues to install.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
