### PR TITLE
fix(pubsys): copy image tags when replicating AMIs

### DIFF
--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -389,6 +389,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
             .set_name(Some(tentative_amispec.name.clone()))
             .set_source_image_id(Some(ids_of_image.image_id.clone()))
             .set_source_region(Some(base_region.as_ref().to_string()))
+            .set_copy_image_tags(Some(true))
             .send();
 
         // Store the region so we can output it to the user


### PR DESCRIPTION
**Issue number:**

Closes #579 
Closes #574

**Testing done:**
Registered and copied an image which used `amispec` to set tags. Noted that the replicated image also had the tags present (this was not true prior to this change).


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
