### PR TITLE
chore: prepare release candidate 0.13.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.12.0...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.13.0...HEAD
+
+## [0.13.0] - 2025-11-10
+
+### Changed
+* Remove experimental label from `erofs-root-partition` feature ([#586])
+* Sort bootconfig keys across all snippets for consistent output ([#596])
+
+### Added
+* Add experimental `encrypted-storage` image feature for encrypting local storage using TPM2 devices ([#589])
+* Record in-place updates enablement in `image-features.env` for runtime queries ([#589])
+* Emit `artifact-metadata.json` with disk utilization for ROOT and BOOT partitions ([#581])
+
+### Fixed
+* Fix pubsys to copy image tags when replicating AMIs ([#592])
+* Prevent re-packing non-erofs images with EROFS ([#576])
+
+### Deprecated
+* Deprecate `systemd-networkd` image feature ([#589])
+* Deprecate `grub-set-private-var` image feature ([#589])
+
+### Build
+* Update cargo dependencies ([#591])
+* Bump actions/checkout from 4.2.2 to 5.0.0 ([#569])
+* Fail the build if the go compiler fails in krane-bundle ([#568])
+* Update ecr-login to v0.11.0 ([#595])
+
+### Documentation
+* Document and add tests for AMI tagging behavior ([#590])
+* Update README ([#588], thanks @webern)
+
+### Improved
+* TestSys: Run workload tests for different NVIDIA flavors ([#594])
+
+[#568]: https://github.com/bottlerocket-os/twoliter/pull/568
+[#569]: https://github.com/bottlerocket-os/twoliter/pull/569
+[#576]: https://github.com/bottlerocket-os/twoliter/pull/576
+[#581]: https://github.com/bottlerocket-os/twoliter/pull/581
+[#586]: https://github.com/bottlerocket-os/twoliter/pull/586
+[#588]: https://github.com/bottlerocket-os/twoliter/pull/588
+[#589]: https://github.com/bottlerocket-os/twoliter/pull/589
+[#590]: https://github.com/bottlerocket-os/twoliter/pull/590
+[#591]: https://github.com/bottlerocket-os/twoliter/pull/591
+[#592]: https://github.com/bottlerocket-os/twoliter/pull/592
+[#594]: https://github.com/bottlerocket-os/twoliter/pull/594
+[#595]: https://github.com/bottlerocket-os/twoliter/pull/595
+[#596]: https://github.com/bottlerocket-os/twoliter/pull/596
+
+[0.13.0]: https://github.com/bottlerocket-os/twoliter/compare/v0.12.0...v0.13.0
 
 ## [0.12.0] - 2025-08-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.12.0"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" 
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
 
-twoliter = { version = "0.12.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.13.0-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
 twoliter-tool-buildsys = { version = "0.1", path = "twoliter/src/tool-crates/buildsys" }
 twoliter-tool-embedded-bundle = { version = "0.1", path = "twoliter/src/tool-crates/embedded-bundle" }
 twoliter-tool-pipesys = { version = "0.1", path = "twoliter/src/tool-crates/pipesys" }

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.12.0"
+version = "0.13.0-rc1"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
This is still waiting for the following:
* [x] #590 
* [x] #591 
* [x] #592 
* [x] #594 
* [x] #595

**Testing done:**
* [x] Kit build testing
* [x] AMI build testing


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
