### PR TITLE
Run workload tests for different NVIDIA flavors

### DIFF
--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -233,7 +233,11 @@ pub(crate) fn workload_crd(region: &str, test_input: TestInput) -> Result<Test> 
             test_input.name_suffix.unwrap_or("test")
         ),
     });
-    let gpu = test_input.crd_input.variant.variant_flavor() == Some("nvidia");
+    let gpu = test_input
+        .crd_input
+        .variant
+        .variant_flavor()
+        .map_or(false, |flavor| flavor.starts_with("nvidia"));
     let plugins: Vec<_> = test_input
         .crd_input
         .config

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -111,7 +111,11 @@ pub(crate) fn workload_crd(test_input: TestInput) -> Result<Test> {
             test_input.name_suffix.unwrap_or("test")
         ),
     });
-    let gpu = test_input.crd_input.variant.variant_flavor() == Some("nvidia");
+    let gpu = test_input
+        .crd_input
+        .variant
+        .variant_flavor()
+        .map_or(false, |flavor| flavor.starts_with("nvidia"));
     let plugins: Vec<_> = test_input
         .crd_input
         .config


### PR DESCRIPTION
**Description of changes:**

Allow testsys execute NVIDIA workload tests for other NVIDIA flavors (e.g. `nvidia-fips`).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
