### PR TITLE
twoliter: sort bootconfig keys across all snippets

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -485,8 +485,16 @@ fi
 
 # Combine any bootconfig snippets in /boot for later use, then clean up.
 if [[ -d "${BOOT_MOUNT}/boot-config.d" ]]; then
+  # Verify all bootconfig snippets are single-line key=value format
+  if grep -E '^\s*[^#].*([:+]=|[{]|[,]\s*$)' "${BOOT_MOUNT}/boot-config.d"/* 2>/dev/null; then
+    echo "ERROR: bootconfig snippets must be single-line 'key = value' format" >&2
+    echo "Unsupported: braces, multi-line arrays, := and += operators" >&2
+    exit 1
+  fi
+
+  # Concatenate and sort snippets to ensure consistent ordering
   find "${BOOT_MOUNT}/boot-config.d" -type f -mindepth 1 -maxdepth 1 -print0 |
-    sort -Vz | xargs -0 cat >"${BOOTCONFIG_INPUT}"
+    xargs -0 cat | sort >"${BOOTCONFIG_INPUT}"
   rm -rf "${BOOT_MOUNT}/boot-config.d"
 fi
 


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4680

**Description of changes:**
The property we would like is that, given the same input, `rpm2img` and `prairiedog` should produce the same bootconfig output.

On a running system, `prairiedog` handles reading bootconfig inputs from the settings API, by way of its TOML config file, which causes any existing ordering to be lost. However, `prairiedog` can sort its output; if `rpm2img` also sorts its output, then we can achieve the desired outcome.

Reject any complex bootconfig files that would be broken by sorting, then sort output lines so they appear in a consistent order.


**Testing done:**
See https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/735 for the `prairiedog` which has the prairiedog side of this change.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
