### PR TITLE
tools: use latest go version in 'docker-go'

### DIFF
--- a/twoliter/embedded/docker-go
+++ b/twoliter/embedded/docker-go
@@ -79,9 +79,14 @@ for i in http_proxy https_proxy no_proxy HTTP_PROXY HTTPS_PROXY NO_PROXY ; do
   fi
 done
 
+# Find highest Go version installed in SDK_IMAGE
+LATEST_GO=$(docker run --rm "${SDK_IMAGE}" \
+  ls /usr/libexec | grep '^go-1\.[0-9]*$' | sort -V | tail -n 1)
+
 docker run --rm \
   -e GOCACHE='/tmp/.cache' \
   -e GOPATH="${GOPATH}" \
+  -e PATH="/usr/libexec/${LATEST_GO}/bin:${PATH}" \
   "${go_env[@]}" \
   "${proxy_env[@]}" \
   --user "$(id -u):$(id -g)" \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Find the latest go version available in the sdk and set that as the first option in the path when executing the command in the `docker-go` script. 


**Testing done:**
Before this change:

```bash
% make twoliter fetch
.
.
.
go: downloading github.com/sasha-s/go-deadlock v0.3.6
go: downloading github.com/petermattis/goid v0.0.0-20250904145737-900bdf8bb490
go: downloading github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
go: downloading github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
go: host-ctr/cmd/host-ctr imports
        github.com/containerd/containerd/pkg/cri/server imports
        github.com/opencontainers/selinux/go-selinux imports
        github.com/cyphar/filepath-securejoin/pathrs-lite imports
        cyphar.com/go-pathrs: unrecognized import path "cyphar.com/go-pathrs": parse https://cyphar.com/go-pathrs?go-get=1: no go-import meta tags ()
go: host-ctr/cmd/host-ctr imports
        github.com/containerd/containerd/pkg/cri/server imports
        github.com/opencontainers/selinux/go-selinux imports
        github.com/cyphar/filepath-securejoin/pathrs-lite/procfs imports
        cyphar.com/go-pathrs/procfs: unrecognized import path "cyphar.com/go-pathrs": parse https://cyphar.com/go-pathrs?go-get=1: no go-import meta tags ()
Error while executing command, exit code: 1
Error: Command was unsuccessful, exit code 105
make: *** [Makefile:65: twoliter] Error 1
```

After the change:
```bash
% % make -e TWOLITER_ALLOW_SOURCE_INSTALL=false -e TWOLITER_ALLOW_BINARY_INSTALL=false -e TWOLITER_SKIP_VERSION_CHECK=true twoliter fetch
go: downloading github.com/containerd/errdefs/pkg v0.3.0
go: downloading github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
go: downloading cyphar.com/go-pathrs v0.2.1 <--------No failures on this package
go: downloading github.com/sasha-s/go-deadlock v0.3.6
go: downloading github.com/petermattis/goid v0.0.0-20250904145737-900bdf8bb490
go: downloading github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
go: downloading github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
