### PR TITLE
pubsys: increase AMI wait timeout for multi-region deployments

### DIFF
--- a/tools/pubsys/src/aws/ami/wait.rs
+++ b/tools/pubsys/src/aws/ami/wait.rs
@@ -17,9 +17,9 @@ pub(crate) async fn wait_for_ami(
     pubsys_aws_config: &PubsysAwsConfig,
 ) -> Result<()> {
     let mut successes = 0;
-    let max_attempts = 90;
+    let max_attempts = 255;
     let mut attempts = 0;
-    let seconds_between_attempts = 2;
+    let seconds_between_attempts = 3;
 
     loop {
         attempts += 1;


### PR DESCRIPTION
Increase max_attempts from 90 to 255 and seconds_between_attempts from 2 to 3 seconds to handle slower AMI registration when copying AMIs across regions.

The previous 3-minute timeout was insufficient for AMI registration in some regions, causing "Failed to reach desired state within 90 attempts" errors during AMI copying operations.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
