### PR TITLE
feat: add check-advisories to check BRSA fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "advisory-checker"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "nutype",
+ "regex",
+ "rpm",
+ "serde",
+ "snafu",
+ "test-case",
+ "toml",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1507,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enum-display-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ef37b2a9b242295d61a154ee91ae884afff6b8b933b486b12481cc58310ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
+dependencies = [
+ "num-traits",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,12 +2461,14 @@ dependencies = [
 name = "integration-tests"
 version = "0.1.0"
 dependencies = [
+ "advisory-checker",
  "duct",
  "flate2",
  "libc",
  "lzma-rs",
  "once_cell",
  "rand 0.9.2",
+ "regex",
  "reqwest",
  "semver",
  "serde",
@@ -2559,6 +2597,15 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2769,6 +2816,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,10 +2903,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2878,10 +2958,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
 
 [[package]]
 name = "num-integer"
@@ -2916,6 +3016,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
 dependencies = [
  "num-modular",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2966,6 +3077,7 @@ dependencies = [
  "kinded",
  "proc-macro2",
  "quote",
+ "regex",
  "rustc_version",
  "syn 2.0.113",
  "urlencoding",
@@ -3815,6 +3927,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpm"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834393db3afd30c31d6ecde41d8dad7f081ac692f82c5a7a05fc0a0915343e6b"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "digest",
+ "enum-display-derive",
+ "enum-primitive-derive",
+ "hex",
+ "itertools",
+ "log",
+ "md-5",
+ "nom",
+ "num",
+ "num-derive",
+ "num-traits",
+ "sha1",
+ "sha2",
+ "sha3",
+ "thiserror 2.0.17",
+ "zeroize",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4266,6 +4404,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -5257,6 +5405,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "twoliter-tool-advisory-checker",
  "twoliter-tool-buildsys",
  "twoliter-tool-embedded-bundle",
  "twoliter-tool-pcrsys",
@@ -5269,6 +5418,14 @@ dependencies = [
  "uuid",
  "which",
  "zstd",
+]
+
+[[package]]
+name = "twoliter-tool-advisory-checker"
+version = "0.1.0"
+dependencies = [
+ "advisory-checker",
+ "include-env-compressed",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "tools/testsys-config",
     "tools/unplug",
     "tools/update-metadata",
+    "tools/advisory-checker",
 
     "twoliter",
     "twoliter/src/tool-crates/*",
@@ -55,6 +56,7 @@ pre-build = [
 ]
 
 [workspace.dependencies]
+advisory-checker = { version = "0.1", path = "tools/advisory-checker", artifact = [ "bin:advisory-checker" ] }
 amispec = { version = "0.1", path = "tools/amispec" }
 bottlerocket-types = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
 bottlerocket-variant = { version = "0.1", path = "tools/bottlerocket-variant" }
@@ -80,6 +82,7 @@ testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
 
 twoliter = { version = "0.16.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter-tool-advisory-checker = { version = "0.1", path = "twoliter/src/tool-crates/advisory-checker" }
 twoliter-tool-buildsys = { version = "0.1", path = "twoliter/src/tool-crates/buildsys" }
 twoliter-tool-embedded-bundle = { version = "0.1", path = "twoliter/src/tool-crates/embedded-bundle" }
 twoliter-tool-pcrsys = { version = "0.1", path = "twoliter/src/tool-crates/pcrsys" }
@@ -157,6 +160,7 @@ quote = "1"
 rand = { version = "0.9", default-features = false }
 regex = "1"
 reqwest = { version = "0.12", default-features = false }
+rpm = { version = "0.18", default-features = false }
 seccompiler = "0.5"
 semver = "1"
 serde = "1"

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -11,6 +11,7 @@ libc.workspace = true
 lzma-rs.workspace = true
 once_cell.workspace = true
 rand.workspace = true
+regex.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -20,4 +21,5 @@ semver.workspace = true
 tokio = { workspace = true, features = ["fs", "process", "rt-multi-thread"] }
 toml.workspace = true
 twoliter = { workspace = true }
+advisory-checker = { workspace = true }
 which.workspace = true

--- a/tests/integration-tests/src/advisory_checker.rs
+++ b/tests/integration-tests/src/advisory_checker.rs
@@ -1,0 +1,210 @@
+use crate::run_command;
+use std::fs::{create_dir, create_dir_all, remove_dir, write};
+use std::process::Output;
+use tempfile::TempDir;
+
+const ADVISORY_CHECKER_PATH: &str = env!("CARGO_BIN_FILE_ADVISORY_CHECKER");
+const PACKAGES_DIR: &str = "packages";
+const ADVISORIES_DIR: &str = "advisories";
+
+fn create_spec(name: &str, version: &str) -> String {
+    format!(
+        r#"Name: {name}
+Version: {version}
+Release: 1
+Summary: Test package
+License: MIT
+
+%description
+Test package
+"#
+    )
+}
+
+fn create_advisory(id: &str, cve: &str, severity: &str, pkg: &str, version: &str) -> String {
+    format!(
+        r#"[advisory]
+id = "{id}"
+title = "Test Advisory"
+cve = "{cve}"
+severity = "{severity}"
+description = "Test vulnerability"
+
+[[advisory.products]]
+package-name = "{pkg}"
+patched-version = "{version}"
+patched-epoch = "0"
+
+[updateinfo]
+issue-date = 2026-01-01
+version = "1"
+"#
+    )
+}
+
+// This function creates a dummy kit. As input we provide packages as tuples
+// (package name, version) and advisories as a tuple (advisory path, advisory toml).
+// The output is the temporary directory where the kit is created.
+fn create_test_kit(packages: &[(&str, &str)], advisories: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().unwrap();
+
+    let packages_dir = dir.path().join(PACKAGES_DIR);
+    let advisories_dir = dir.path().join(ADVISORIES_DIR);
+    create_dir(&packages_dir).unwrap();
+    create_dir(&advisories_dir).unwrap();
+
+    for (name, version) in packages {
+        let pkg_dir = packages_dir.join(name);
+        create_dir_all(&pkg_dir).unwrap();
+        let content = create_spec(name, version);
+        write(pkg_dir.join("test.spec"), content).unwrap();
+    }
+
+    for (filename, content) in advisories {
+        let path = advisories_dir.join(filename);
+        create_dir_all(path.parent().unwrap()).unwrap();
+        write(&path, content).unwrap();
+    }
+
+    dir
+}
+
+fn run_advisory_checker(kit: &TempDir) -> Output {
+    run_command(
+        ADVISORY_CHECKER_PATH,
+        [
+            "--packages-dir",
+            kit.path().join(PACKAGES_DIR).to_str().unwrap(),
+            "--advisories-dir",
+            kit.path().join(ADVISORIES_DIR).to_str().unwrap(),
+        ],
+        [],
+    )
+}
+
+#[test]
+#[ignore]
+fn test_missing_advisories_dir_succeeds() {
+    // Given a kit with a package but no advisories directory
+    let kit = create_test_kit(&[("testpkg", "1.0.0")], &[]);
+    remove_dir(kit.path().join(ADVISORIES_DIR)).unwrap();
+
+    // When we run the advisory checker
+    let output = run_advisory_checker(&kit);
+
+    // Then it succeeds and reports that advisory checks were skipped
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("skipping"));
+}
+
+#[test]
+#[ignore]
+fn test_empty_advisories_dir_succeeds() {
+    // Given a kit with a package and an empty advisories directory
+    let kit = create_test_kit(&[("testpkg", "1.0.0")], &[]);
+
+    // When we run the advisory checker
+    let output = run_advisory_checker(&kit);
+
+    // Then it succeeds with no violations
+    assert!(output.status.success());
+}
+
+#[test]
+#[ignore]
+fn test_ignores_non_toml_files() {
+    // Given a kit whose advisories directory contains only non-toml files
+    let kit = create_test_kit(&[("testpkg", "1.0.0")], &[("staging/.gitkeep", "")]);
+
+    // When we run the advisory checker
+    let output = run_advisory_checker(&kit);
+
+    // Then it succeeds since non-toml files are ignored
+    assert!(output.status.success());
+}
+
+#[test]
+#[ignore]
+fn test_advisory_violation_fails() {
+    // Given a package at version 1.0.0 and an advisory requiring 2.0.0
+    let advisory = create_advisory("BRSA-test123", "CVE-2024-12345", "high", "testpkg", "2.0.0");
+    let kit = create_test_kit(
+        &[("testpkg", "1.0.0")],
+        &[("v01/BRSA-test.toml", &advisory)],
+    );
+
+    // When we run the advisory checker
+    let output = run_advisory_checker(&kit);
+
+    // Then it fails and reports the advisory violation
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Advisory violations found"));
+}
+
+#[test]
+#[ignore]
+fn test_advisory_satisfied_succeeds() {
+    // Given a package at version 3.0.0 and an advisory requiring 2.0.0
+    let advisory = create_advisory(
+        "BRSA-test456",
+        "CVE-2024-67890",
+        "moderate",
+        "testpkg",
+        "2.0.0",
+    );
+    let kit = create_test_kit(
+        &[("testpkg", "3.0.0")],
+        &[("v01/BRSA-test.toml", &advisory)],
+    );
+
+    // When we run the advisory checker
+    let output = run_advisory_checker(&kit);
+
+    // Then it succeeds
+    assert!(output.status.success());
+}
+
+#[test]
+#[ignore]
+fn test_advisory_for_removed_package_fails() {
+    // Given an advisory for "testpkg" but only "otherpkg" exists in the kit
+    let advisory = create_advisory(
+        "BRSA-test789",
+        "CVE-2024-11111",
+        "critical",
+        "testpkg",
+        "2.0.0",
+    );
+    let kit = create_test_kit(
+        &[("otherpkg", "1.0.0")],
+        &[("v01/BRSA-test.toml", &advisory)],
+    );
+
+    // When we run the advisory checker
+    let output = run_advisory_checker(&kit);
+
+    // Then it fails because the advisory's package has no end-of-life marker
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("not end-of-life"));
+}
+
+#[test]
+#[ignore]
+fn test_parse_advisory_error_invalid_toml() {
+    // Given a kit with an advisory file containing invalid TOML
+    let kit = create_test_kit(
+        &[("testpkg", "1.0.0")],
+        &[("v01/BRSA-invalid.toml", "not valid toml {{{")],
+    );
+
+    // When we run the advisory checker
+    let output = run_advisory_checker(&kit);
+
+    // Then it fails with a parse error
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to parse advisory"));
+}

--- a/tests/integration-tests/src/appinventory.rs
+++ b/tests/integration-tests/src/appinventory.rs
@@ -18,7 +18,7 @@ const EXPECTED_INVENTORY_PATH: &str =
 
 // Last Bottlerocket release that doesn't include source packages in application inventory.
 // For older releases, we check that reference inventory is a subset of current.
-const SOURCE_PACKAGE_INVENTORY_ANCHOR_VERSION: &str = "1.55.0";
+const SOURCE_PACKAGE_INVENTORY_ANCHOR_VERSION: &str = "1.56.0";
 
 #[derive(Serialize, Deserialize)]
 pub struct GithubRelease {

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
+mod advisory_checker;
 mod appinventory;
 mod imghelper;
 mod twoliter_build;

--- a/tools/advisory-checker/Cargo.toml
+++ b/tools/advisory-checker/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "advisory-checker"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+nutype = { workspace = true, features = ["regex", "serde"] }
+regex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
+snafu.workspace = true
+toml.workspace = true
+rpm.workspace = true
+
+[dev-dependencies]
+test-case.workspace = true
+
+[lints]
+workspace = true

--- a/tools/advisory-checker/src/error.rs
+++ b/tools/advisory-checker/src/error.rs
@@ -1,0 +1,44 @@
+use snafu::Snafu;
+use std::path::PathBuf;
+use std::process::Output;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub), module)]
+pub enum Error {
+    #[snafu(display("Failed to execute command: {}", source))]
+    ExecutionFailure { source: std::io::Error },
+
+    #[snafu(display("Command '{}' failed: {}", bin_path, String::from_utf8_lossy(&output.stderr)))]
+    CommandFailure { bin_path: String, output: Output },
+
+    #[snafu(display("Failed to read '{}'", path.display()))]
+    ReadFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse advisory '{}'", path.display()))]
+    ParseAdvisory {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[snafu(display(
+        "Incorrect output format for rpmspec command. Expected name|epoch|version. Got '{spec_output}'"
+    ))]
+    RpmSpecFormat { spec_output: String },
+
+    #[snafu(display("Failed to read directory '{}'", path.display()))]
+    ReadDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to read directory entry"))]
+    ReadDirEntry { source: std::io::Error },
+
+    #[snafu(display("{} Advisory violations found.", violations.len()))]
+    AdvisoryViolations { violations: Vec<String> },
+}

--- a/tools/advisory-checker/src/main.rs
+++ b/tools/advisory-checker/src/main.rs
@@ -1,0 +1,359 @@
+//! Validates rpmspec files against security advisories to ensure packages meet
+//! minimum version requirements for known vulnerabilities.
+
+mod error;
+mod models;
+
+use clap::Parser;
+use error::{error::*, Result};
+use models::{Advisory, Args, Epoch, PackageName, PackageVersionManifest, EV};
+use rpm::rpm_evr_compare;
+use snafu::{ensure, ResultExt};
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+// This is the last time when we removed a package from the kits without an
+// EOL advisory. We make sure that any advisory published post this date
+// either has a corresponding package or an EOL advisory.
+const LAST_UNTRACKED_PACKAGE_REMOVAL_DATE: &str = "2025-07-26";
+
+fn command<I, S>(bin_path: &str, args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut cmd = Command::new(bin_path);
+    cmd.args(args);
+    let output = cmd.output().context(ExecutionFailureSnafu)?;
+
+    ensure!(
+        output.status.success(),
+        CommandFailureSnafu { bin_path, output }
+    );
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn get_rpm_metadata(spec_path: &Path) -> Result<PackageVersionManifest> {
+    let pkg_prefix = command("rpm", ["--eval", "%{_cross_os}"])?
+        .trim()
+        .to_string();
+    let spec_path_str = spec_path.to_string_lossy();
+
+    let rpm_metadata = command(
+        "rpmspec",
+        [
+            "-q",
+            "--qf",
+            "%{Name}|%{Epoch}|%{Version}\n",
+            &spec_path_str,
+        ],
+    )?;
+
+    parse_rpm_metadata(pkg_prefix, rpm_metadata)
+}
+
+fn parse_rpm_metadata(pkg_prefix: String, rpm_metadata: String) -> Result<PackageVersionManifest> {
+    let mut manifest = PackageVersionManifest::new();
+    for metadata in rpm_metadata.lines() {
+        let parts: Vec<&str> = metadata.split('|').collect();
+        ensure!(
+            parts.len() == 3,
+            RpmSpecFormatSnafu {
+                spec_output: metadata
+            }
+        );
+
+        let name = parts[0].strip_prefix(&pkg_prefix).unwrap_or(parts[0]);
+        let epoch_str = if parts[1] == "(none)" { "0" } else { parts[1] };
+        let epoch = Epoch::try_new(epoch_str).expect("epoch should be valid integer");
+        let version = parts[2];
+
+        manifest.insert(PackageName::new(name), EV::new(&epoch, version));
+    }
+
+    Ok(manifest)
+}
+
+fn find_spec_file(package_dir: &Path) -> Option<std::path::PathBuf> {
+    fs::read_dir(package_dir).ok()?.find_map(|entry| {
+        let path = entry.ok()?.path();
+        if path.extension() == Some(OsStr::new("spec")) {
+            Some(path)
+        } else {
+            None
+        }
+    })
+}
+
+fn build_all_package_metadata(packages_dir: &Path) -> Result<PackageVersionManifest> {
+    let mut manifest = PackageVersionManifest::new();
+    if !packages_dir.exists() {
+        return Ok(manifest);
+    }
+
+    for entry in fs::read_dir(packages_dir).context(ReadDirSnafu { path: packages_dir })? {
+        let entry = entry.context(ReadDirEntrySnafu)?;
+        if entry.path().is_dir() {
+            // Inside the package directory, we extract metadata from the spec file
+            if let Some(spec_path) = find_spec_file(&entry.path()) {
+                let pkg_manifest = get_rpm_metadata(&spec_path)?;
+                manifest.merge(pkg_manifest);
+            }
+        }
+    }
+
+    Ok(manifest)
+}
+
+fn collect_advisories(advisories_dir: &Path) -> Result<HashMap<PackageName, Vec<Advisory>>> {
+    let mut advisories_by_product: HashMap<PackageName, Vec<Advisory>> = HashMap::new();
+
+    if !advisories_dir.exists() {
+        return Ok(advisories_by_product);
+    }
+
+    for entry in fs::read_dir(advisories_dir).context(ReadDirSnafu {
+        path: advisories_dir,
+    })? {
+        let version_dir = entry.context(ReadDirEntrySnafu)?;
+        if version_dir.path().is_dir() {
+            // Inside the version directory, we read the advisories and store them
+            for brsa in fs::read_dir(version_dir.path()).context(ReadDirSnafu {
+                path: advisories_dir,
+            })? {
+                let brsa = brsa.context(ReadDirEntrySnafu)?;
+                if brsa.path().extension() == Some(OsStr::new("toml")) {
+                    let content = fs::read_to_string(brsa.path())
+                        .context(ReadFileSnafu { path: brsa.path() })?;
+                    let advisory: Advisory = toml::from_str(&content)
+                        .context(ParseAdvisorySnafu { path: brsa.path() })?;
+                    for product in &advisory.advisory_info.products {
+                        advisories_by_product
+                            .entry(product.package_name.clone())
+                            .or_default()
+                            .push(advisory.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(advisories_by_product)
+}
+
+fn validate_advisories(advisories_dir: &Path, packages_dir: &Path) -> Result<()> {
+    // We go through all the packages in package directory and create a map with
+    // package as key and Epoch:Version as value. We create a separate map from
+    // the advisories with package as key and an array of advisories as value.
+    let pkg_metadata = build_all_package_metadata(packages_dir)?;
+    let advisories_by_product = collect_advisories(advisories_dir)?;
+
+    let mut violations = Vec::new();
+
+    // For each advisory, we check if the corresponding package exists and the
+    // package is patched or if its an end of life advisory.
+    for (package_name, mut advisories) in advisories_by_product {
+        advisories.sort_by(|a, b| a.update_info.cmp(&b.update_info));
+
+        if let Some(spec_ev) = pkg_metadata.get(&package_name) {
+            // Package exists - check version compliance
+            for advisory in &advisories {
+                for product in &advisory.advisory_info.products {
+                    if product.package_name != package_name {
+                        continue;
+                    }
+                    let advisory_ev = EV::new(&product.patched_epoch, &product.patched_version);
+                    if rpm_evr_compare(&spec_ev.to_string(), &advisory_ev.to_string()).is_lt() {
+                        violations.push(format!(
+                            "BRSA ID: {}\n package name: {}\n package version: {spec_ev}\n min. expected version: {advisory_ev}",
+                            advisory.advisory_info.id, package_name
+                        ));
+                    }
+                }
+            }
+        } else {
+            // Package missing - check end-of-life
+            if let Some(latest) = advisories.last() {
+                let issue_date = latest.update_info.issue_date.to_string();
+
+                // If an advisory is created after LAST_UNTRACKED_PACKAGE_REMOVAL_DATE we make sure that
+                // either a package exists in the kit for that advisory or there is an end of life
+                // advisory. If this test fails, it indicates that there is a typo in the package name.
+                if issue_date.as_str() > LAST_UNTRACKED_PACKAGE_REMOVAL_DATE
+                    && !latest.advisory_info.end_of_life
+                {
+                    violations.push(format!(
+                        "Advisory Product '{}' has no package and latest advisory '{}' is not end-of-life",
+                        package_name, latest.advisory_info.id
+                    ));
+                }
+            }
+        }
+    }
+
+    if !violations.is_empty() {
+        println!("Advisory violations found:\n{}", violations.join("\n"));
+        return Err(error::Error::AdvisoryViolations { violations });
+    }
+
+    println!("All advisories validated. No errors were found.");
+    Ok(())
+}
+
+#[snafu::report]
+fn main() -> Result<()> {
+    let args = Args::parse();
+    if !args.advisories_dir.exists() || !args.advisories_dir.is_dir() {
+        println!(
+            "Advisories directory '{}' not found, skipping advisory check",
+            args.advisories_dir.display()
+        );
+        return Ok(());
+    }
+    validate_advisories(&args.advisories_dir, &args.packages_dir)?;
+    println!(
+        "Advisory validation passed for {}",
+        args.advisories_dir.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use models::CveId;
+    use test_case::test_case;
+
+    fn make_advisory_toml(id_field: &str, id_value: &str) -> String {
+        format!(
+            r#"
+[advisory]
+id = "TEST-001"
+title = "Test Advisory"
+severity = "high"
+description = "Test description"
+{id_field} = "{id_value}"
+[[advisory.products]]
+package-name = "test"
+patched-version = "1.0"
+
+[updateinfo]
+issue-date = 2024-01-01
+version = "1"
+"#
+        )
+    }
+
+    #[test_case("CVE-2024-1234"; "basic 4 digit")]
+    #[test_case("CVE-2024-12345"; "5 digit")]
+    #[test_case("CVE-2025-472688"; "6 digit")]
+    #[test_case("CVE-1999-0001"; "old year")]
+    fn valid_cve(cve: &str) {
+        let toml = make_advisory_toml("cve", cve);
+        assert!(
+            toml::from_str::<Advisory>(&toml).is_ok(),
+            "Failed to parse valid CVE: {cve}"
+        );
+    }
+
+    #[test_case("CVE-2024-001"; "too few digits")]
+    #[test_case("CVE-2024-INVALID"; "non numeric")]
+    #[test_case("CVE-24-1234"; "year too short")]
+    #[test_case("CVE-2024-0"; "single digit")]
+    #[test_case("CVE–2024–1234"; "en dash")]
+    #[test_case("CVE—2024—1234"; "em dash")]
+    #[test_case("GHSA-xxxx-xxxx-xxxx"; "wrong format")]
+    fn invalid_cve(cve: &str) {
+        let toml = make_advisory_toml("cve", cve);
+        assert!(
+            toml::from_str::<Advisory>(&toml).is_err(),
+            "Should reject invalid CVE: {cve}"
+        );
+    }
+
+    #[test_case("GHSA-23fg-6c23-wxrv"; "standard")]
+    #[test_case("GHSA-2222-3333-4444"; "all numeric")]
+    #[test_case("GHSA-cfgh-jmpq-rvwx"; "all alpha")]
+    fn valid_ghsa(ghsa: &str) {
+        let toml = make_advisory_toml("ghsa", ghsa);
+        assert!(
+            toml::from_str::<Advisory>(&toml).is_ok(),
+            "Failed to parse valid GHSA: {ghsa}"
+        );
+    }
+
+    #[test_case("GHSA-123-456-789"; "too short")]
+    #[test_case("GHSA-12345-67890-12345"; "too long")]
+    #[test_case("CVE-2024-1234"; "wrong format")]
+    fn invalid_ghsa(ghsa: &str) {
+        let toml = make_advisory_toml("ghsa", ghsa);
+        assert!(
+            toml::from_str::<Advisory>(&toml).is_err(),
+            "Should reject invalid GHSA: {ghsa}"
+        );
+    }
+
+    #[test]
+    fn complete_advisory() {
+        let toml = make_advisory_toml("cve", "CVE-2025-12345");
+        let advisory: Advisory = toml::from_str(&toml).expect("Failed to parse complete advisory");
+        assert_eq!(advisory.advisory_info.id, "TEST-001");
+        assert_eq!(
+            advisory.advisory_info.cve,
+            CveId::try_new("CVE-2025-12345").ok()
+        );
+        assert_eq!(advisory.advisory_info.products.len(), 1);
+        assert_eq!(
+            advisory.advisory_info.products[0].package_name,
+            PackageName::new("test")
+        );
+        assert_eq!(
+            advisory.advisory_info.products[0].patched_epoch,
+            Epoch::try_new("0").unwrap()
+        );
+    }
+
+    #[test_case("testpkg|0|1.0.0\n"; "Epoch present")]
+    #[test_case("testpkg|(none)|1.0.0\n"; "Epoch not present")]
+    #[test_case("testpkg|(none)|1.0.0\ntestpkg-bin|(none)|1.0.0\ntestpkg-lib|(none)|1.0.0\n"; "Multiple sub-packages")]
+    fn parse_rpm_metadata_basic(rpm_metadata: &str) {
+        let output = rpm_metadata.to_string();
+        let result = parse_rpm_metadata("".to_string(), output).unwrap();
+        let evr = result.get(&PackageName::new("testpkg")).unwrap();
+        assert_eq!(evr.to_string(), "0:1.0.0");
+    }
+
+    #[test_case("testpkg\n"; "invalid output 1")]
+    #[test_case("testpkg|(none)\n"; "invalid output 2")]
+    fn parse_invalid_rpm_metadata(rpm_metadata: &str) {
+        let result = parse_rpm_metadata("".to_string(), rpm_metadata.to_string());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_rpm_metadata_with_prefix() {
+        let output = "bottlerocket-testpkg|1|3.0.0\n".to_string();
+        let result = parse_rpm_metadata("bottlerocket-".to_string(), output).unwrap();
+        let evr = result.get(&PackageName::new("testpkg")).unwrap();
+        assert_eq!(evr.to_string(), "1:3.0.0");
+    }
+
+    #[test]
+    fn parse_rpm_metadata_multiple_packages() {
+        let output = "pkg1|0|1.0\npkg2|1|2.0\n".to_string();
+        let result = parse_rpm_metadata("".to_string(), output).unwrap();
+
+        assert_eq!(
+            result.get(&PackageName::new("pkg1")).unwrap().to_string(),
+            "0:1.0"
+        );
+        assert_eq!(
+            result.get(&PackageName::new("pkg2")).unwrap().to_string(),
+            "1:2.0"
+        );
+    }
+}

--- a/tools/advisory-checker/src/models.rs
+++ b/tools/advisory-checker/src/models.rs
@@ -1,0 +1,182 @@
+//! Advisory data models and deserialization logic.
+
+use clap::Parser;
+use nutype::nutype;
+use regex::Regex;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+const DEFAULT_EPOCH: &str = "0";
+
+static CVE_ID_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^CVE-[0-9]{4}-[0-9]{4,19}$"#).expect("Failed to compile CVE_ID_REGEX")
+});
+
+static GHSA_ID_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^GHSA(-[23456789cfghjmpqrvwx]{4}){3}$").expect("Failed to compile GHSA_ID_REGEX")
+});
+
+fn is_integer(s: &str) -> bool {
+    s.parse::<i64>().is_ok()
+}
+
+#[nutype(
+    validate(predicate = is_integer),
+    default = DEFAULT_EPOCH,
+    derive(Debug, Clone, Deserialize, PartialEq, Display, AsRef, Default)
+)]
+pub struct Epoch(String);
+
+/// Short for Epoch, Version. We don't use Release from EVR versioning scheme because every
+/// package update aims at upgrading the version and BRSAs do not include Release field.
+#[derive(Debug, Clone)]
+pub struct EV {
+    pub epoch: Epoch,
+    pub version: String,
+}
+
+impl EV {
+    pub fn new(epoch: &Epoch, version: impl Into<String>) -> Self {
+        Self {
+            epoch: epoch.clone(),
+            version: version.into(),
+        }
+    }
+}
+
+impl Display for EV {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.epoch, self.version)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+pub struct PackageName(String);
+
+impl Display for PackageName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl PackageName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+#[derive(Debug)]
+pub struct PackageVersionManifest {
+    packages: HashMap<PackageName, EV>,
+}
+
+impl PackageVersionManifest {
+    pub fn new() -> Self {
+        Self {
+            packages: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, name: PackageName, evr: EV) {
+        self.packages.insert(name, evr);
+    }
+
+    pub fn get(&self, name: &PackageName) -> Option<&EV> {
+        self.packages.get(name)
+    }
+
+    pub fn merge(&mut self, other: PackageVersionManifest) {
+        self.packages.extend(other.packages);
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Advisory {
+    #[serde(rename = "advisory")]
+    pub advisory_info: AdvisoryInfo,
+    #[serde(rename = "updateinfo")]
+    pub update_info: UpdateInfo,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[expect(dead_code)]
+pub struct AdvisoryInfo {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub end_of_life: bool,
+    pub cve: Option<CveId>,
+    pub ghsa: Option<GhsaId>,
+    pub severity: Severity,
+    pub description: String,
+    pub products: Vec<Product>,
+}
+
+#[nutype(
+    validate(regex = CVE_ID_REGEX),
+    derive(Debug, Clone, Deserialize, PartialEq)
+)]
+pub struct CveId(String);
+
+#[nutype(
+    validate(regex = GHSA_ID_REGEX),
+    derive(Debug, Clone, Deserialize, PartialEq)
+)]
+pub struct GhsaId(String);
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct UpdateInfo {
+    pub issue_date: toml::value::Datetime,
+    pub version: String,
+}
+
+impl Ord for UpdateInfo {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.issue_date
+            .to_string()
+            .cmp(&other.issue_date.to_string())
+    }
+}
+
+impl PartialOrd for UpdateInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Low,
+    #[serde(alias = "medium")]
+    Moderate,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Product {
+    pub package_name: PackageName,
+    pub patched_version: String,
+    #[serde(default = "default_epoch")]
+    pub patched_epoch: Epoch,
+}
+
+fn default_epoch() -> Epoch {
+    Epoch::default()
+}
+
+#[derive(Debug, Parser)]
+#[clap(about, long_about = None, version)]
+pub(crate) struct Args {
+    #[arg(long)]
+    pub(crate) advisories_dir: PathBuf,
+    #[arg(long)]
+    pub(crate) packages_dir: PathBuf,
+}

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -43,6 +43,7 @@ zstd.workspace = true
 maplit.workspace = true
 
 # Binary dependencies. These are binaries that we want to embed in the Twoliter binary
+twoliter-tool-advisory-checker.workspace = true
 twoliter-tool-buildsys.workspace = true
 twoliter-tool-embedded-bundle.workspace = true
 twoliter-tool-pcrsys.workspace = true

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -62,6 +62,15 @@ RUN \
    && find . -maxdepth 1 -not -path '*/\.*' -type f -exec mv {} rpmbuild/SOURCES/ \; \
    && echo ${NOCACHE}
 
+RUN --mount=target=/host \
+    if [ -d "/host/advisories/" ]; then \
+        /host/build/tools/advisory-checker \
+            --packages-dir /host/packages/ \
+            --advisories-dir /host/advisories/; \
+    else \
+        echo "Advisories directory not found, skipping check."; \
+    fi
+
 USER root
 ARG BYPASS_SOCKET
 RUN --mount=target=/host \

--- a/twoliter/embedded/build.Dockerfile.dockerignore
+++ b/twoliter/embedded/build.Dockerfile.dockerignore
@@ -12,5 +12,8 @@
 # Include everything under sources.
 !/sources
 
+# Include everything under advisories.
+!/advisories
+
 # Exclude "target" directories everywhere.
 */target/*

--- a/twoliter/src/tool-crates/advisory-checker/Cargo.toml
+++ b/twoliter/src/tool-crates/advisory-checker/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "twoliter-tool-advisory-checker"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+advisory-checker.workspace = true
+include-env-compressed.workspace = true
+
+[lints]
+workspace = true

--- a/twoliter/src/tool-crates/advisory-checker/src/lib.rs
+++ b/twoliter/src/tool-crates/advisory-checker/src/lib.rs
@@ -1,0 +1,3 @@
+use include_env_compressed::{include_archive_from_env, Archive};
+
+pub const ADVISORY_CHECKER: Archive = include_archive_from_env!("CARGO_BIN_FILE_ADVISORY_CHECKER");

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -36,6 +36,12 @@ pub(crate) async fn install_tools(tools_dir: impl AsRef<Path>) -> Result<()> {
 
     let write_tasks = vec![
         write_bin(
+            "advisory-checker",
+            twoliter_tool_advisory_checker::ADVISORY_CHECKER.reader(),
+            &dir,
+            mtime,
+        ),
+        write_bin(
             "buildsys",
             twoliter_tool_buildsys::BUILDSYS.reader(),
             &dir,
@@ -153,6 +159,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("rpm2migrations").is_file());
 
     // Check that binaries were copied.
+    assert!(toolsdir.join("advisory-checker").is_file());
     assert!(toolsdir.join("buildsys").is_file());
     assert!(toolsdir.join("pcrsys").is_file());
     assert!(toolsdir.join("pipesys").is_file());


### PR DESCRIPTION
**Description of changes:**
  * Validate CVE ID/GHSA ID in the Rust crate. Moves implementation of this (#467) into the Rust crate.
  * Validate BRSA's package-metadata and make sure the included package is at a higher version.
  * Make sure End of Life BRSA is present if the BRSA package doesn't exist.

How it works?
We implement a `advisory-checker` rust crate that takes 2 arguments - The packages and advisories directory. The binary is called during build by the upper level build.Dockerfile. Since, its already in the sdk context and the rpm macros are loaded, we can use `rpmspec` and `rpm --eval` macros to extract package name and versions. We deserialize the advisory files to extract the expected version and then compare the Epoch, Version and Release to their respective packages to find out if we are in a newer version and if package doesn't exist, we make sure that the last BRSA for the package is an End of Life BRSA.

**Testing done:**
Cropping output for brevity. 

Testing it on `bottlerocket-core-kit`. I removed the recently published EOL BRSAs and changed the epoch for an `aws-iam-authenticator` BRSA. This is the error that's generated.
```
  #10 ERROR: process "/bin/sh -c if [ -d \"/host/advisories/\" ]; then         /host/build/tools/advisory-checker             --packages-dir /host/packages/             --advisories-dir /host/advisories/;     else         echo \"Advisories directory not found, skipping check.\";     fi" did not complete successfully: exit code: 1
  ------
   > [rpmbuild 4/7] RUN --mount=target=/host     if [ -d "/host/advisories/" ]; then         /host/build/tools/advisory-checker             --packages-dir /host/packages/             --advisories-dir /host/advisories/;     else         echo "Advisories directory not found, skipping check.";     fi:
  2.684 Error: 3 Advisory violations found.
  2.684 
  2.684 Advisory violations found:
  2.684 Advisory Product 'libexpat' has no package and latest advisory 'BRSA-ja1ptrrpkcey' is not end-of-life
  2.684 BRSA ID: BRSA-ng7athla9aog
  2.684  package name: aws-iam-authenticator
  2.684  package version: 1:0.7.10
  2.684  min. expected version: 2:0.7.5
  2.684 Advisory Product 'containerd-2.0' has no package and latest advisory 'BRSA-s6xothqqu5vw' is not end-of-life
 ```
 
 No issues when run on latest `bottlerocket`, `bottlerocket-core-kit` and `bottlerocket-kernel-kit`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
