### PR TITLE
tools: move fetch-vendored to use go-latest

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -403,11 +403,13 @@ script = [
 go_fetch() {
   local module
   module="${1:?}"
+  GO_CMD=$(docker run --rm ${TLPRIVATE_SDK_IMAGE} bash -c "go-latest version" >/dev/null 2>&1 \
+         && echo "go-latest" || echo "go")
   ${TWOLITER_TOOLS_DIR}/docker-go \
     --module-path "${BUILDSYS_SOURCES_DIR}/${module}" \
     --sdk-image ${TLPRIVATE_SDK_IMAGE} \
     --go-mod-cache ${GO_MOD_CACHE} \
-    --command "go list -mod=readonly ./... >/dev/null && go mod vendor"
+    --command "${GO_CMD} list -mod=readonly ./... >/dev/null && ${GO_CMD} mod vendor"
 }
 
 for m in ${GO_MODULES}; do


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #600

**Description of changes:**

- Move to using `go-latest` to fetch Go dependencies. 

- Depends on https://github.com/bottlerocket-os/bottlerocket-sdk/pull/310

**Testing done:**

Before this change (But using the new sdk):
```
go: host-ctr/cmd/host-ctr imports
        github.com/containerd/containerd/pkg/cri/server imports
        github.com/opencontainers/selinux/go-selinux imports
        github.com/cyphar/filepath-securejoin/pathrs-lite imports
        cyphar.com/go-pathrs: unrecognized import path "cyphar.com/go-pathrs": parse https://cyphar.com/go-pathrs?go-get=1: no go-import meta tags ()
go: host-ctr/cmd/host-ctr imports
        github.com/containerd/containerd/pkg/cri/server imports
        github.com/opencontainers/selinux/go-selinux imports
        github.com/cyphar/filepath-securejoin/pathrs-lite/procfs imports
        cyphar.com/go-pathrs/procfs: unrecognized import path "cyphar.com/go-pathrs": parse https://cyphar.com/go-pathrs?go-get=1: no go-import meta tags ()
Error while executing command, exit code: 1
Error: Command was unsuccessful, exit code 105
make: *** [Makefile:65: twoliter] Error 1
```
With this change:
```
% cp ../twoliter/target/release/twoliter ./tools/twoliter
% make twoliter fetch
Makefile:59: warning: overriding recipe for target 'fetch'
Makefile:42: warning: ignoring old recipe for target 'fetch'
Found Twoliter v0.13.0 installed.
Skipping installation.
[2025-11-26T21:04:17Z INFO  twoliter::project::lock] Resolving SDK project reference to check against lock file
[2025-11-26T21:04:17Z INFO  twoliter::project::lock::image] Resolving dependency image dependency 'beta-sdk-0.65.1@739573345415.dkr.ecr.us-west-2.amazonaws.com/beta-sdk:v0.65.1'.
[cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO -
[cargo-make] INFO - Build File: /home/ec2-user/brck-rsync/bottlerocket-core-kit/build/tools/Makefile.toml
[cargo-make] INFO - Task: fetch
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: setup
[cargo-make] INFO - Running Task: setup-build
[cargo-make] INFO - Running Task: fetch-sdk
[cargo-make] INFO - Running Task: fetch-sources
[cargo-make] INFO - Running Task: fetch-vendored
go: downloading cyphar.com/go-pathrs v0.2.1
[cargo-make] INFO - Build Done in 11.62 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
