### PR TITLE
rpm2img: add source packages of sub-packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,6 +2274,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "tar",

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -16,6 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 tar.workspace = true
 tempfile.workspace = true
+semver.workspace = true
 tokio = { workspace = true, features = ["fs", "process", "rt-multi-thread"] }
 toml.workspace = true
 twoliter = { workspace = true }

--- a/tests/integration-tests/src/appinventory.rs
+++ b/tests/integration-tests/src/appinventory.rs
@@ -2,6 +2,7 @@ use std::{env, path::Path};
 
 use duct::cmd;
 use reqwest::Url;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{BufReader, Cursor};
@@ -14,6 +15,10 @@ use crate::{run_command, twoliter_build::copy_project_to_temp_dir, TWOLITER_PATH
 
 const EXPECTED_INVENTORY_PATH: &str =
     "build/images/x86_64-aws-ecs-2/latest/application-inventory.json";
+
+// Last Bottlerocket release that doesn't include source packages in application inventory.
+// For older releases, we check that reference inventory is a subset of current.
+const SOURCE_PACKAGE_INVENTORY_ANCHOR_VERSION: &str = "1.52.0";
 
 #[derive(Serialize, Deserialize)]
 pub struct GithubRelease {
@@ -57,6 +62,11 @@ async fn find_latest_version(repository: &str) -> String {
         .strip_prefix("refs/tags/")
         .unwrap_or(tag_name)
         .to_string()
+}
+
+fn parse_version(release: &str) -> Version {
+    let version = release.strip_prefix("v").unwrap_or(release);
+    Version::parse(version).expect("failed to parse")
 }
 
 async fn create_bob(version: &str) -> TempDir {
@@ -150,10 +160,28 @@ async fn test_twoliter_application_inventory() {
     let current_aif = build_and_fetch_application_inventory(TWOLITER_PATH, bob_src.path());
     let current_set: InventoryView = serde_json::from_str(current_aif.as_str())
         .expect("failed to deserialize current inventory file");
-    assert_eq!(
-        reference_set, current_set,
-        "twoliter generated different application inventory than last released twoliter"
-    );
+
+    // Last Bottlerocket release that doesn't include source packages in application inventory.
+    // For older releases, we check that reference inventory is a subset of current.
+    let anchor = parse_version(SOURCE_PACKAGE_INVENTORY_ANCHOR_VERSION);
+    let bob_ver = parse_version(&bob_version);
+
+    // For BOB versions before source package support, check that reference is a subset of current
+    // current may have additional source package entries
+    if bob_ver <= anchor {
+        for item in &reference_set.content {
+            assert!(
+                current_set.content.contains(item),
+                "current inventory missing package from reference: {:?}",
+                item
+            );
+        }
+    } else {
+        assert_eq!(
+            reference_set, current_set,
+            "twoliter generated different application inventory than last released twoliter"
+        );
+    }
 }
 
 fn build_and_fetch_application_inventory(

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -168,6 +168,7 @@ rpm -iv --ignorearch --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
 
 # Inventory installed packages.
 INVENTORY_QUERY="\{\"Name\":\"%{NAME}\"\
+,\"SourcePackage\":\"%{SOURCERPM}\"\
 ,\"Publisher\":\"Bottlerocket\"\
 ,\"Version\":\"%{Version}\"\
 ,\"Release\":\"%{Release}\"\
@@ -186,6 +187,22 @@ mapfile -t installed_rpms <<<"$(rpm -qa --root "${ROOT_MOUNT}" \
 INVENTORY_DATA="$(jq --raw-output . <<<"${installed_rpms[@]}")"
 # Sort by package name and add 'Content' as top-level.
 INVENTORY_DATA="$(jq --slurp 'sort_by(.Name)' <<<"${INVENTORY_DATA}" | jq '{"Content": .}')"
+
+INVENTORY_BEFORE_PARENTS="$(jq '.Content | length' <<<"${INVENTORY_DATA}")"
+INVENTORY_DATA="$(jq '
+  .Content |= (
+    . + map(
+      (.Version) as $v | (.Release) as $r | (.SourcePackage | sub("-" + $v + "-" + $r + "\\.src\\.rpm$";"")) as $p |
+      . + {Name: $p, Summary: ($p + " (source package)")}
+    )
+    | unique_by(.Name)
+    | map(del(.SourcePackage))
+    | sort_by(.Name)
+  )
+' <<<"${INVENTORY_DATA}")"
+
+INVENTORY_AFTER_PARENTS="$(jq '.Content | length' <<<"${INVENTORY_DATA}")"
+ADDED_PARENTS=$((INVENTORY_AFTER_PARENTS - INVENTORY_BEFORE_PARENTS))
 
 # Iterate through all kits used to build this variant.
 EXTERNAL_KIT_METADATA_PATH="${EXTERNAL_KITS_PATH}/external-kit-metadata.json"
@@ -240,8 +257,8 @@ done
 # Verify we successfully inventoried some RPMs.
 INVENTORY_COUNT="$(jq '.Content | length' <<<"${INVENTORY_DATA}")"
 RPM_COUNT="$(find "${PACKAGE_DIR}" -maxdepth 1 -type f -name '*.rpm' | wc -l)"
-if [[ "${INVENTORY_COUNT}" -ne "${RPM_COUNT}" ]]; then
-  echo "Inventory of RPMs does not match what was expected: '${INVENTORY_COUNT}/${RPM_COUNT}'" >&2
+if [[ "${INVENTORY_COUNT}" -ne "$((RPM_COUNT + ADDED_PARENTS))" ]]; then
+  echo "Inventory of RPMs does not match what was expected: '${INVENTORY_COUNT}/$((RPM_COUNT + ADDED_PARENTS))'" >&2
   exit 1
 fi
 if grep -q "bottlerocket-release" <<<"${INVENTORY_DATA}"; then


### PR DESCRIPTION
**Description of changes:**
Add source packages of sub-packages if the names don't match.

**Testing**
New entries added to application-inventory.json for ecs-2 variant:
1. `amazon-ssm-agent` for `amazon-ssm-agent-plugin` and `amazon-ssm-agent-plugin-bin`
```
    {
      "Name": "amazon-ssm-agent",
      "Publisher": "bottlerocket-core-kit",
      "Version": "3.3.3185.0",
      "Release": "1.1764962845.9b3a8b3a.br1",
      "Epoch": "0",
      "InstalledTime": "2025-12-12T23:05:49Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://github.com/aws/amazon-ssm-agent",
      "Summary": "bottlerocket-amazon-ssm-agent (source package)"
    },
```
2. `microcode` for `microcode-amd-license`
```
    {
      "Name": "microcode",
      "Publisher": "bottlerocket-kernel-kit",
      "Version": "0.0",
      "Release": "1.1762999032.6bbcd107.br1",
      "Epoch": "1",
      "InstalledTime": "2025-12-12T23:05:49Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/LICENSE.amd-ucode",
      "Summary": "bottlerocket-microcode (source package)"
    },
```

Making sure that we don't change the format of the Content
```
[fedora@ip-172-31-57-102 bottlerocket]$ ls -lia tools/twoliter/
total 4
10761064 drwxr-xr-x. 1 fedora fedora  16 Nov 21 01:06 .
10760894 drwxr-xr-x. 1 fedora fedora 170 Nov 14 00:37 ..
11433898 lrwxrwxrwx. 1 fedora fedora  58 Nov 21 01:06 twoliter -> /home/fedora/Repositories/twoliter/target/release/twoliter
[fedora@ip-172-31-57-102 bottlerocket]$ cat build/images/x86_64-aws-ecs-2/1.51.0-47438798-dirty/a
application-inventory.json                artifact-metadata.json                    aws-ecs-2-x86_64-kmod-kit-v1.51.0.tar.xz  
[fedora@ip-172-31-57-102 bottlerocket]$ cat build/images/x86_64-aws-ecs-2/1.51.0-47438798-dirty/application-inventory.json | grep "amazon-ssm-agent"
      "Name": "amazon-ssm-agent",
      "Url": "https://github.com/aws/amazon-ssm-agent",
      "Summary": "bottlerocket-amazon-ssm-agent (source package)"
      "Name": "amazon-ssm-agent-plugin",
      "Url": "https://github.com/aws/amazon-ssm-agent",
      "Name": "amazon-ssm-agent-plugin-bin",
      "Url": "https://github.com/aws/amazon-ssm-agent",
[fedora@ip-172-31-57-102 bottlerocket]$ cat build/images/x86_64-aws-ecs-2/1.51.0-47438798-dirty/application-inventory.json | grep "SourcePackage"
```

I took a backup of above and used the current twoliter to diff the application-inventory for aws-ecs-2 variant and this is what I got which is expected. I got rid of the InstalledTime diffs which is also expected.

```
[fedora@ip-172-31-57-102 bottlerocket]$ diff build/images/x86_64-aws-ecs-2/1.51.0-47438798-dirty/application-inventory.json backup.json
*********************************************************************
>       "Name": "amazon-ssm-agent",
>       "Publisher": "bottlerocket-core-kit",
>       "Version": "3.3.3185.0",
>       "Release": "1.1764185537.b598233b.br1",
>       "Epoch": "0",
>       "InstalledTime": "2025-12-19T21:06:32Z",
>       "ApplicationType": "Unspecified",
>       "Architecture": "x86_64",
>       "Url": "https://github.com/aws/amazon-ssm-agent",
>       "Summary": "bottlerocket-amazon-ssm-agent (source package)"
>     },
**********************************************************************
>       "Name": "microcode",
>       "Publisher": "bottlerocket-kernel-kit",
>       "Version": "0.0",
>       "Release": "1.1762999032.6bbcd107.br1",
>       "Epoch": "1",
>       "InstalledTime": "2025-12-19T21:06:32Z",
>       "ApplicationType": "Unspecified",
>       "Architecture": "x86_64",
>       "Url": "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/LICENSE.amd-ucode",
>       "Summary": "bottlerocket-microcode (source package)"
>     },
>     {
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
