### PR TITLE
feat: add --quiet flag to reduce build output

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -52,7 +52,7 @@ PUBLISH_INFRA_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Infra.toml"
 # Default repo to read from PUBLISH_INFRA_CONFIG_PATH
 PUBLISH_REPO = "default"
 
-PUBLISH_LOG_LEVEL = "info"
+PUBLISH_LOG_LEVEL = { script = ["if [ \"${TWOLITER_QUIET}\" = \"1\" ]; then echo warn; else echo info; fi"], condition = { env_not_set = ["PUBLISH_LOG_LEVEL"] } }
 
 # This can be overridden with -e to change the path to the file containing SSM
 # parameter templates.  This file determines the parameter names and values
@@ -142,7 +142,7 @@ TESTSYS_STARTING_COMMIT = { script = ["git describe --tag ${TESTSYS_STARTING_VER
 TESTSYS_TESTS_DIR = "${BUILDSYS_ROOT_DIR}/tests"
 TESTSYS_TEST_CONFIG_PATH = "${BUILDSYS_ROOT_DIR}/Test.toml"
 
-TESTSYS_LOG_LEVEL = "info"
+TESTSYS_LOG_LEVEL = { script = ["if [ \"${TWOLITER_QUIET}\" = \"1\" ]; then echo warn; else echo info; fi"], condition = { env_not_set = ["TESTSYS_LOG_LEVEL"] } }
 
 [env.development]
 # Certain variables are defined here to allow us to override a component value

--- a/twoliter/src/cmd/build.rs
+++ b/twoliter/src/cmd/build.rs
@@ -1,4 +1,5 @@
 use super::build_clean::BuildClean;
+use super::GlobalOpts;
 use crate::cargo_make::CargoMake;
 use crate::common::fs;
 use crate::project::{self, Locked};
@@ -16,11 +17,11 @@ pub(crate) enum BuildCommand {
 }
 
 impl BuildCommand {
-    pub(crate) async fn run(self) -> Result<()> {
+    pub(crate) async fn run(self, global_opts: &GlobalOpts) -> Result<()> {
         match self {
             BuildCommand::Clean(command) => command.run().await,
-            BuildCommand::Kit(command) => command.run().await,
-            BuildCommand::Variant(command) => command.run().await,
+            BuildCommand::Kit(command) => command.run(global_opts).await,
+            BuildCommand::Variant(command) => command.run(global_opts).await,
         }
     }
 }
@@ -50,7 +51,7 @@ pub(crate) struct BuildKit {
 }
 
 impl BuildKit {
-    pub(super) async fn run(&self) -> Result<()> {
+    pub(super) async fn run(&self, global_opts: &GlobalOpts) -> Result<()> {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let project = project.load_lock::<Locked>().await?;
         project.fetch(self.arch.as_str()).await?;
@@ -76,6 +77,7 @@ impl BuildKit {
                 "BUILDSYS_UPSTREAM_SOURCE_FALLBACK",
                 self.upstream_source_fallback.to_string(),
             )
+            .env("TWOLITER_QUIET", if global_opts.quiet { "1" } else { "0" })
             .envs(optional_envs.into_iter())
             .makefile(makefile_path)
             .project_dir(project.project_dir())
@@ -113,7 +115,7 @@ pub(crate) struct BuildVariant {
 }
 
 impl BuildVariant {
-    pub(super) async fn run(&self) -> Result<()> {
+    pub(super) async fn run(&self, global_opts: &GlobalOpts) -> Result<()> {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let project = project.load_lock::<Locked>().await?;
         project.fetch(self.arch.as_str()).await?;
@@ -150,6 +152,7 @@ impl BuildVariant {
                 "BUILDSYS_UPSTREAM_SOURCE_FALLBACK",
                 self.upstream_source_fallback.to_string(),
             )
+            .env("TWOLITER_QUIET", if global_opts.quiet { "1" } else { "0" })
             .envs(optional_envs.into_iter())
             .makefile(makefile_path)
             .project_dir(project.project_dir())

--- a/twoliter/src/cmd/make.rs
+++ b/twoliter/src/cmd/make.rs
@@ -1,3 +1,4 @@
+use super::GlobalOpts;
 use crate::cargo_make::CargoMake;
 use crate::project::{self, Locked, SDKLocked, Unlocked};
 use crate::tools::install_tools;
@@ -52,7 +53,7 @@ pub(crate) struct Make {
 }
 
 impl Make {
-    pub(super) async fn run(&self) -> Result<()> {
+    pub(super) async fn run(&self, global_opts: &GlobalOpts) -> Result<()> {
         let project = project::load_or_find_project(self.project_path.clone()).await?;
         let sdk_source = self.lock_and_fetch(&project).await?;
         let toolsdir = project.project_dir().join("build/tools");
@@ -62,6 +63,7 @@ impl Make {
             .env("CARGO_HOME", self.cargo_home.display().to_string())
             .env("TWOLITER_TOOLS_DIR", toolsdir.display().to_string())
             .env("BUILDSYS_VERSION_IMAGE", project.release_version())
+            .env("TWOLITER_QUIET", if global_opts.quiet { "1" } else { "0" })
             .makefile(makefile_path)
             .project_dir(project.project_dir())
             .exec_with_args(&self.makefile_task, self.additional_args.clone())

--- a/twoliter/src/cmd/mod.rs
+++ b/twoliter/src/cmd/mod.rs
@@ -13,17 +13,27 @@ use crate::cmd::make::Make;
 use crate::cmd::publish_kit::PublishCommand;
 use crate::cmd::update::Update;
 use anyhow::Result;
-use clap::Parser;
+use clap::{Args as ClapArgs, Parser};
 use env_logger::Builder;
 use log::LevelFilter;
 
 const DEFAULT_LEVEL_FILTER: LevelFilter = LevelFilter::Info;
 
+#[derive(Debug, ClapArgs)]
+pub(crate) struct GlobalOpts {
+    /// Reduce output to essential status messages only
+    #[arg(short, long, global = true)]
+    pub(crate) quiet: bool,
+}
+
 /// A tool for building custom variants of Bottlerocket.
 #[derive(Debug, Parser)]
 #[clap(about, long_about = None, version)]
 pub(crate) struct Args {
-    /// Set the logging level. One of [off|error|warn|info|debug|trace]. Defaults to warn. You can
+    #[command(flatten)]
+    pub(crate) global: GlobalOpts,
+
+    /// Set the logging level. One of [off|error|warn|info|debug|trace]. Defaults to info. You can
     /// also leave this unset and use the RUST_LOG env variable. See
     /// https://github.com/rust-cli/env_logger/
     #[clap(long = "log-level")]
@@ -58,9 +68,9 @@ pub(crate) enum Subcommand {
 /// Entrypoint for the `twoliter` command line program.
 pub(super) async fn run(args: Args) -> Result<()> {
     match args.subcommand {
-        Subcommand::Build(build_command) => build_command.run().await,
+        Subcommand::Build(build_command) => build_command.run(&args.global).await,
         Subcommand::Fetch(fetch_args) => fetch_args.run().await,
-        Subcommand::Make(make_args) => make_args.run().await,
+        Subcommand::Make(make_args) => make_args.run(&args.global).await,
         Subcommand::Update(update_args) => update_args.run().await,
         Subcommand::Publish(publish_command) => publish_command.run().await,
         Subcommand::Debug(debug_action) => debug_action.run().await,
@@ -68,9 +78,16 @@ pub(super) async fn run(args: Args) -> Result<()> {
 }
 
 /// use `level` if present, or else use `RUST_LOG` if present, or else use a default.
-pub(super) fn init_logger(level: Option<LevelFilter>) {
+/// If `quiet` is true, use Warn level unless explicitly overridden.
+pub(super) fn init_logger(level: Option<LevelFilter>, quiet: bool) {
+    let effective_level = if quiet && level.is_none() {
+        LevelFilter::Warn
+    } else {
+        level.unwrap_or(DEFAULT_LEVEL_FILTER)
+    };
+
     match (std::env::var(env_logger::DEFAULT_FILTER_ENV).ok(), level) {
-        (Some(_), None) => {
+        (Some(_), None) if !quiet => {
             // RUST_LOG exists and level does not; use the environment variable.
             Builder::from_default_env().init();
         }
@@ -79,10 +96,7 @@ pub(super) fn init_logger(level: Option<LevelFilter>) {
             // use provided log level or default for this crate only.
             Builder::new()
                 .parse_default_env()
-                .filter(
-                    Some(env!("CARGO_CRATE_NAME")),
-                    level.unwrap_or(DEFAULT_LEVEL_FILTER),
-                )
+                .filter(Some(env!("CARGO_CRATE_NAME")), effective_level)
                 .init();
         }
     }
@@ -165,7 +179,7 @@ mod test {
             upstream_source_fallback: false,
         };
 
-        command.run().await.unwrap();
+        command.run(&GlobalOpts { quiet: false }).await.unwrap();
         expect_kit(project_dir, "core-kit", arch, &["pkg-a"]).await;
     }
 
@@ -188,7 +202,7 @@ mod test {
             upstream_source_fallback: false,
         };
 
-        command.run().await.unwrap();
+        command.run(&GlobalOpts { quiet: false }).await.unwrap();
         expect_kit(project_dir, "core-kit", arch, &["pkg-a"]).await;
         expect_kit(project_dir, "extra-1-kit", arch, &["pkg-b", "pkg-d"]).await;
     }
@@ -212,7 +226,7 @@ mod test {
             upstream_source_fallback: false,
         };
 
-        command.run().await.unwrap();
+        command.run(&GlobalOpts { quiet: false }).await.unwrap();
         expect_kit(project_dir, "core-kit", arch, &["pkg-a"]).await;
         expect_kit(project_dir, "extra-2-kit", arch, &["pkg-c"]).await;
     }
@@ -236,7 +250,7 @@ mod test {
             upstream_source_fallback: false,
         };
 
-        command.run().await.unwrap();
+        command.run(&GlobalOpts { quiet: false }).await.unwrap();
         expect_kit(project_dir, "core-kit", arch, &["pkg-a"]).await;
         expect_kit(project_dir, "extra-1-kit", arch, &["pkg-b", "pkg-d"]).await;
         expect_kit(project_dir, "extra-2-kit", arch, &["pkg-c"]).await;

--- a/twoliter/src/main.rs
+++ b/twoliter/src/main.rs
@@ -20,7 +20,7 @@ mod tools;
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    init_logger(args.log_level);
+    init_logger(args.log_level, args.global.quiet);
     preflight::preflight().await?;
     cmd::run(args).await
 }


### PR DESCRIPTION
Add a --quiet/-q flag that suppresses informational messages while preserving warnings and errors.

Changes:
- Add --quiet flag to CLI arguments
- Thread quiet parameter through build and make commands
- Conditionally add --quiet to cargo-make invocations
- Set TWOLITER_QUIET env var for embedded tools
- Adjust pubsys/testsys log levels based on quiet mode
- Update init_logger to respect quiet flag

In quiet mode:
- Suppresses cargo-make INFO messages
- Suppresses twoliter INFO logs
- Sets embedded tool log levels to warn
- Still shows all warnings and errors
- Completely silent on successful builds

Normal mode behavior is unchanged.

**Testing done:**
* [x] Ensure error messages still look right under various failure modes in `--quiet` mode
See [this gist](https://gist.github.com/cbgbt/b77a5883427ef00c3b51b9d907fd92a2) for a before/after comparison.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
