### PR TITLE
fix: re-enable all tests on `make test`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 resolver = "2"
 
-default-members = ["twoliter"]
 members = [
     "tools/amispec",
     "tools/bottlerocket-variant",

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ fmt:
 
 .PHONY: test
 test:
-	cargo test --release --locked
+	cargo test --workspace --release --locked
 
 .PHONY: integ
 integ:

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ fmt:
 
 .PHONY: test
 test:
-	cargo test --workspace --release --locked
+	cargo test --release --locked
 
 .PHONY: integ
 integ:

--- a/tools/amispec/src/lib.rs
+++ b/tools/amispec/src/lib.rs
@@ -167,13 +167,16 @@ impl AmiSpec {
                 vec![
                     aws_sdk_ec2::types::TagSpecification::builder()
                         .resource_type(aws_sdk_ec2::types::ResourceType::Image)
-                        .set_tags(Some(
-                            tags.iter()
+                        .set_tags(Some({
+                            let mut sorted_tags: Vec<_> = tags.iter().collect();
+                            sorted_tags.sort_by_key(|(k, _)| *k);
+                            sorted_tags
+                                .into_iter()
                                 .map(|(k, v)| {
                                     aws_sdk_ec2::types::Tag::builder().key(k).value(v).build()
                                 })
-                                .collect(),
-                        ))
+                                .collect()
+                        }))
                         .build(),
                 ]
             }))

--- a/tools/include-env-compressed/tests/include_build_script.rs
+++ b/tools/include-env-compressed/tests/include_build_script.rs
@@ -4,11 +4,15 @@ const BUILD_SCRIPT_CONTENTS: &str = include_str!("../build.rs");
 
 #[test]
 fn test_include_build_script() {
-    // tests run in debug mode, so this will be uncompressed
     let build_script = include_env_compressed::include_archive_from_env!("MY_BUILD_SCRIPT");
     let included_build_script = std::io::read_to_string(build_script.reader()).unwrap();
     assert_eq!(included_build_script.trim(), BUILD_SCRIPT_CONTENTS.trim());
+
+    // The macro uses cfg(debug_assertions) to decide compression
+    #[cfg(debug_assertions)]
     assert_eq!(build_script.kind(), ArchiveKind::Uncompressed);
+    #[cfg(not(debug_assertions))]
+    assert_eq!(build_script.kind(), ArchiveKind::Zstd);
 }
 
 #[test]

--- a/tools/pipesys/src/cmd/mod.rs
+++ b/tools/pipesys/src/cmd/mod.rs
@@ -113,7 +113,7 @@ fn fetch_fd(socket: &str) -> Result<OwnedFd> {
 fn duplicate_fd(fd: OwnedFd) -> Result<OwnedFd> {
     let bfd = fd.as_fd();
     let newfd = fcntl(bfd, F_DUPFD(MIN_FD))
-        .with_context(|| format!("failed to duplicate file descriptor"))?;
+        .with_context(|| "failed to duplicate file descriptor".to_string())?;
     // SAFETY: fcntl with F_DUPFD returns a new owned file descriptor
     Ok(unsafe { OwnedFd::from_raw_fd(newfd) })
 }

--- a/tools/testsys/src/aws_ecs.rs
+++ b/tools/testsys/src/aws_ecs.rs
@@ -237,7 +237,7 @@ pub(crate) fn workload_crd(region: &str, test_input: TestInput) -> Result<Test> 
         .crd_input
         .variant
         .variant_flavor()
-        .map_or(false, |flavor| flavor.starts_with("nvidia"));
+        .is_some_and(|flavor| flavor.starts_with("nvidia"));
     let plugins: Vec<_> = test_input
         .crd_input
         .config

--- a/tools/testsys/src/crds.rs
+++ b/tools/testsys/src/crds.rs
@@ -648,7 +648,7 @@ pub(crate) trait CrdCreator: Sync {
         crd_input: &CrdInput,
         override_crd_template: Option<PathBuf>,
     ) -> Result<Vec<Crd>> {
-        debug!("Creating custom CRDs for '{}' test", test_type);
+        debug!("Creating custom CRDs for '{test_type}' test");
         let crd_template_file_path = &override_crd_template
             .or_else(|| crd_input.custom_crd_template_file_path())
             .context(error::InvalidSnafu {

--- a/tools/testsys/src/sonobuoy.rs
+++ b/tools/testsys/src/sonobuoy.rs
@@ -115,7 +115,7 @@ pub(crate) fn workload_crd(test_input: TestInput) -> Result<Test> {
         .crd_input
         .variant
         .variant_flavor()
-        .map_or(false, |flavor| flavor.starts_with("nvidia"));
+        .is_some_and(|flavor| flavor.starts_with("nvidia"));
     let plugins: Vec<_> = test_input
         .crd_input
         .config


### PR DESCRIPTION
**Description of changes:**
Setting `twoliter` to the default member meant that tests for our other crates weren't being run by default.

This fixes the makefile to run all the tests, then fixes test failures that were masked by the bug.

You can't `cargo run` to get `twoliter` anymore, but I think `cargo run --bin twoliter` is a fine trade to make for test coverage.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
