### PR TITLE
tools: include AWS SDK code and message in errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-utils"
+version = "0.1.0"
+dependencies = [
+ "aws-sdk-ssm",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,6 +3213,7 @@ dependencies = [
  "clap",
  "coldsnap",
  "duct",
+ "error-utils",
  "futures",
  "governor",
  "indicatif",
@@ -4331,6 +4341,7 @@ dependencies = [
  "bottlerocket-variant",
  "clap",
  "env_logger",
+ "error-utils",
  "fastrand",
  "futures",
  "handlebars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "tools/amispec",
     "tools/bottlerocket-variant",
+    "tools/error-utils",
     "tools/buildsys",
     "tools/buildsys-config",
     "tools/include-env-compressed",
@@ -58,6 +59,7 @@ bottlerocket-types = { version = "0.0.16", git = "https://github.com/bottlerocke
 bottlerocket-variant = { version = "0.1", path = "tools/bottlerocket-variant" }
 buildsys = { version = "0.1", path = "tools/buildsys", lib = true, artifact = [ "bin:buildsys" ] }
 buildsys-config = { version = "0.1", path = "tools/buildsys-config" }
+error-utils = { version = "0.1", path = "tools/error-utils" }
 include-env-compressed = { version = "0.1", path = "tools/include-env-compressed" }
 include-env-compressed-macro = { version = "0.1", path = "tools/include-env-compressed/include-env-compressed-macro" }
 krane-bundle = { version = "0.1", path = "tools/krane" }
@@ -99,6 +101,7 @@ aws-sdk-ec2 = { version = "1", default-features = false, features = ["default-ht
 aws-sdk-kms = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-ssm = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-sts = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-smithy-runtime-api = { version = "1", features = ["client"] }
 aws-smithy-types = "1"
 aws-types = "1"
 base64 = "0.22"

--- a/clippy.toml
+++ b/clippy.toml
@@ -10,3 +10,27 @@ reason = "Twoliter usually does not want to resolve symlinks. Use path_absolutiz
 path = "tokio::fs::canonicalize"
 reason = "Twoliter usually does not want to resolve symlinks. Use path_absolutize instead"
 
+[[disallowed-types]]
+path = "aws_sdk_ec2::error::SdkError"
+reason = "Use error_utils::AwsSdkError wrapper instead to ensure consistent error formatting"
+
+[[disallowed-types]]
+path = "aws_sdk_ssm::error::SdkError"
+reason = "Use error_utils::AwsSdkError wrapper instead to ensure consistent error formatting"
+
+[[disallowed-types]]
+path = "aws_smithy_runtime_api::client::result::SdkError"
+reason = "Use error_utils::AwsSdkError wrapper instead to ensure consistent error formatting"
+
+[[disallowed-types]]
+path = "aws_sdk_ebs::error::SdkError"
+reason = "Use error_utils::AwsSdkError wrapper instead to ensure consistent error formatting"
+
+[[disallowed-types]]
+path = "aws_sdk_kms::error::SdkError"
+reason = "Use error_utils::AwsSdkError wrapper instead to ensure consistent error formatting"
+
+[[disallowed-types]]
+path = "aws_sdk_sts::error::SdkError"
+reason = "Use error_utils::AwsSdkError wrapper instead to ensure consistent error formatting"
+

--- a/tools/error-utils/Cargo.toml
+++ b/tools/error-utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "error-utils"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+aws-smithy-runtime-api.workspace = true
+aws-smithy-types.workspace = true
+
+[dev-dependencies]
+aws-sdk-ssm.workspace = true
+aws-smithy-types.workspace = true

--- a/tools/error-utils/src/lib.rs
+++ b/tools/error-utils/src/lib.rs
@@ -1,0 +1,114 @@
+#![allow(clippy::disallowed_types)]
+
+use aws_smithy_types::error::display::DisplayErrorContext;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Shadow the AWS SDK error type.
+pub type SdkError<E, R = ::aws_smithy_runtime_api::client::orchestrator::HttpResponse> =
+    ::aws_smithy_runtime_api::client::result::SdkError<E, R>;
+
+/// Wrapper around AWS SDK errors that ensures consistent formatting
+pub struct AwsSdkError<E, R = ::aws_smithy_runtime_api::client::orchestrator::HttpResponse>(
+    pub SdkError<E, R>,
+)
+where
+    E: ProvideErrorMetadata + StdError + 'static;
+
+impl<E> fmt::Display for AwsSdkError<E>
+where
+    E: ProvideErrorMetadata + StdError + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", format_aws_sdk_error(&self.0))
+    }
+}
+
+impl<E> fmt::Debug for AwsSdkError<E>
+where
+    E: ProvideErrorMetadata + StdError + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl<E> StdError for AwsSdkError<E>
+where
+    E: ProvideErrorMetadata + StdError + 'static,
+{
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl<E> From<SdkError<E>> for AwsSdkError<E>
+where
+    E: ProvideErrorMetadata + StdError + 'static,
+{
+    fn from(error: SdkError<E>) -> Self {
+        AwsSdkError(error)
+    }
+}
+
+impl<E> AwsSdkError<E>
+where
+    E: ProvideErrorMetadata + StdError + 'static,
+{
+    /// Get the service error from the SDK error, if available
+    pub fn as_service_error(&self) -> Option<&E> {
+        self.0.as_service_error()
+    }
+}
+
+/// Helper function to format AWS SDK errors as "code: message" or fall back to full context
+///
+/// # Examples
+///
+/// With code only: "AccessDenied"
+/// With message only: "Request timeout occurred"
+/// With neither: Falls back to DisplayErrorContext for full error details
+pub fn format_aws_sdk_error<E>(sdk_error: &SdkError<E>) -> String
+where
+    E: ProvideErrorMetadata + StdError + 'static,
+{
+    match (sdk_error.code(), sdk_error.message()) {
+        (Some(code), Some(message)) => format!("{code}: {message}"),
+        (Some(code), None) => code.to_string(),
+        (None, Some(message)) => message.to_string(),
+        (None, None) => format!("{}", DisplayErrorContext(sdk_error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_ssm::operation::get_parameters::GetParametersError;
+    use aws_smithy_types::error::metadata::ErrorMetadata;
+
+    #[test]
+    fn test_error_metadata_extraction() {
+        // Test that our logic works with error metadata
+        let error_metadata = ErrorMetadata::builder()
+            .code("InvalidParameter")
+            .message("Parameter is invalid")
+            .build();
+
+        let service_error = GetParametersError::generic(error_metadata);
+
+        // Verify the error has the expected code and message
+        assert_eq!(service_error.code(), Some("InvalidParameter"));
+        assert_eq!(service_error.message(), Some("Parameter is invalid"));
+    }
+
+    #[test]
+    fn test_aws_sdk_error_wrapper_display() {
+        let sdk_error: SdkError<GetParametersError> = SdkError::timeout_error("request timeout");
+        let wrapper = AwsSdkError(sdk_error);
+
+        // The wrapper should use our format_aws_sdk_error function
+        let result = wrapper.to_string();
+        assert_eq!(result, "request has timed out: request timeout (TimeoutError(TimeoutError { source: \"request timeout\" }))");
+    }
+}

--- a/tools/pubsys/Cargo.toml
+++ b/tools/pubsys/Cargo.toml
@@ -25,6 +25,7 @@ chrono = { workspace = true, features = ["clock", "std"] }
 clap = { workspace = true, features = ["derive"] }
 coldsnap = { workspace = true, features = ["aws-sdk-rust-rustls"] }
 duct.workspace = true
+error-utils.workspace = true
 futures.workspace = true
 governor.workspace = true
 indicatif.workspace = true

--- a/tools/pubsys/src/aws/ami/launch_permissions.rs
+++ b/tools/pubsys/src/aws/ami/launch_permissions.rs
@@ -2,6 +2,7 @@ use aws_sdk_ec2::{
     types::{ImageAttributeName, LaunchPermission},
     Client as Ec2Client,
 };
+use error_utils::AwsSdkError;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
@@ -17,6 +18,7 @@ pub(crate) async fn get_launch_permissions(
         .attribute(ImageAttributeName::LaunchPermission)
         .send()
         .await
+        .map_err(AwsSdkError::from)
         .context(error::DescribeImageAttributeSnafu {
             ami_id,
             region: region.to_string(),
@@ -75,9 +77,9 @@ impl TryFrom<LaunchPermission> for LaunchPermissionDef {
 }
 
 mod error {
-    use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::describe_image_attribute::DescribeImageAttributeError;
     use aws_sdk_ec2::types::LaunchPermission;
+    use error_utils::AwsSdkError;
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
@@ -87,8 +89,8 @@ mod error {
         DescribeImageAttribute {
             ami_id: String,
             region: String,
-            #[snafu(source(from(SdkError<DescribeImageAttributeError>, Box::new)))]
-            source: Box<SdkError<DescribeImageAttributeError>>,
+            #[snafu(source(from(AwsSdkError<DescribeImageAttributeError>, Box::new)))]
+            source: Box<AwsSdkError<DescribeImageAttributeError>>,
         },
 
         #[snafu(display("Invalid launch permission: {:?}", launch_permission))]

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -15,7 +15,7 @@ use crate::aws::{client::build_client_config, region_from_string};
 use crate::frompath::FromPath;
 use crate::Args;
 use aws_sdk_ebs::Client as EbsClient;
-use aws_sdk_ec2::error::{ProvideErrorMetadata, SdkError};
+use aws_sdk_ec2::error::ProvideErrorMetadata;
 use aws_sdk_ec2::operation::copy_image::{CopyImageError, CopyImageOutput};
 use aws_sdk_ec2::types::OperationType;
 use aws_sdk_ec2::{config::Region, Client as Ec2Client};
@@ -25,8 +25,10 @@ use aws_sdk_sts::operation::get_caller_identity::{
 use aws_sdk_sts::Client as StsClient;
 use buildsys::manifest::ManifestInfo;
 use clap::Parser;
+use error_utils::AwsSdkError;
 use futures::future::{join, lazy, ready, FutureExt};
 use futures::stream::{self, StreamExt};
+use futures::TryFutureExt;
 use log::{error, info, trace, warn};
 use pubsys_config::{AwsConfig as PubsysAwsConfig, InfraConfig};
 use register::{get_ami_id, register_image, RegisteredIds};
@@ -271,11 +273,14 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     let client_config = build_client_config(&base_region, &base_region, &aws).await;
     let base_sts_client = StsClient::new(&client_config);
 
-    let response = base_sts_client.get_caller_identity().send().await.context(
-        error::GetCallerIdentitySnafu {
+    let response = base_sts_client
+        .get_caller_identity()
+        .send()
+        .await
+        .map_err(AwsSdkError::from)
+        .context(error::GetCallerIdentitySnafu {
             region: base_region.as_ref(),
-        },
-    )?;
+        })?;
     let base_account_id = response.account.context(error::MissingInResponseSnafu {
         request_type: "GetCallerIdentity",
         missing: "account",
@@ -391,7 +396,8 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
             .set_source_image_id(Some(ids_of_image.image_id.clone()))
             .set_source_region(Some(base_region.as_ref().to_string()))
             .set_copy_image_tags(Some(true))
-            .send();
+            .send()
+            .map_err(AwsSdkError::from);
 
         // Store the region so we can output it to the user
         let region_future = ready(region.clone());
@@ -414,7 +420,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     // Run through the stream and collect results into a list.
     let copy_responses: Vec<(
         Region,
-        std::result::Result<CopyImageOutput, SdkError<CopyImageError>>,
+        std::result::Result<CopyImageOutput, AwsSdkError<CopyImageError>>,
     )> = request_stream.collect().await;
 
     // Report on successes and errors; don't fail immediately if we see an error so we can report
@@ -450,7 +456,9 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
                 error!(
                     "Copy to {} failed: {}",
                     region,
-                    e.into_service_error().code().unwrap_or("unknown")
+                    e.as_service_error()
+                        .and_then(|err| err.code())
+                        .unwrap_or("unknown")
                 );
             }
         }
@@ -508,7 +516,10 @@ async fn get_account_ids(
     let mut requests = Vec::with_capacity(regions.len());
     for region in regions.iter() {
         let sts_client = &sts_clients[region];
-        let response_future = sts_client.get_caller_identity().send();
+        let response_future = sts_client
+            .get_caller_identity()
+            .send()
+            .map_err(AwsSdkError::from);
 
         // Store the region so we can include it in any errors
         let region_future = ready(region.clone());
@@ -519,7 +530,7 @@ async fn get_account_ids(
     // Run through the stream and collect results into a list.
     let responses: Vec<(
         Region,
-        std::result::Result<GetCallerIdentityOutput, SdkError<GetCallerIdentityError>>,
+        std::result::Result<GetCallerIdentityOutput, AwsSdkError<GetCallerIdentityError>>,
     )> = request_stream.collect().await;
 
     for (region, response) in responses {
@@ -567,10 +578,10 @@ pub(crate) fn parse_uefi_data(filepath: &str) -> Result<FromPath<String>> {
 mod error {
     use super::register::mk_amispec;
     use crate::aws::{ami, publish_ami};
-    use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::modify_image_attribute::ModifyImageAttributeError;
     use aws_sdk_sts::operation::get_caller_identity::GetCallerIdentityError;
     use buildsys::manifest;
+    use error_utils::AwsSdkError;
     use snafu::Snafu;
     use std::path::PathBuf;
 
@@ -613,8 +624,8 @@ mod error {
         #[snafu(display("Error getting account ID in {}: {}", region, source))]
         GetCallerIdentity {
             region: String,
-            #[snafu(source(from(SdkError<GetCallerIdentityError>, Box::new)))]
-            source: Box<SdkError<GetCallerIdentityError>>,
+            #[snafu(source(from(AwsSdkError<GetCallerIdentityError>, Box::new)))]
+            source: Box<AwsSdkError<GetCallerIdentityError>>,
         },
 
         #[snafu(display(
@@ -642,8 +653,8 @@ mod error {
         GrantImageAccess {
             thing: String,
             region: String,
-            #[snafu(source(from(SdkError<ModifyImageAttributeError>, Box::new)))]
-            source: Box<SdkError<ModifyImageAttributeError>>,
+            #[snafu(source(from(AwsSdkError<ModifyImageAttributeError>, Box::new)))]
+            source: Box<AwsSdkError<ModifyImageAttributeError>>,
         },
 
         #[snafu(display(

--- a/tools/pubsys/src/aws/ami/public.rs
+++ b/tools/pubsys/src/aws/ami/public.rs
@@ -12,10 +12,8 @@ pub(crate) async fn ami_is_public(
         .image_ids(ami_id.to_string())
         .send()
         .await
-        .context(error::DescribeImagesSnafu {
-            ami_id: ami_id.to_string(),
-            region: region.to_string(),
-        })?;
+        .map_err(error_utils::AwsSdkError::from)
+        .context(error::DescribeImagesSnafu { ami_id, region })?;
 
     let returned_images = ec2_response.images();
 
@@ -38,8 +36,8 @@ pub(crate) async fn ami_is_public(
 }
 
 mod error {
-    use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::describe_images::DescribeImagesError;
+    use error_utils::AwsSdkError;
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
@@ -49,8 +47,8 @@ mod error {
         DescribeImages {
             ami_id: String,
             region: String,
-            #[snafu(source(from(SdkError<DescribeImagesError>, Box::new)))]
-            source: Box<SdkError<DescribeImagesError>>,
+            #[snafu(source(from(AwsSdkError<DescribeImagesError>, Box::new)))]
+            source: Box<AwsSdkError<DescribeImagesError>>,
         },
 
         #[snafu(display("AMI {} not found in {}", ami_id, region))]

--- a/tools/pubsys/src/aws/ami/register/mod.rs
+++ b/tools/pubsys/src/aws/ami/register/mod.rs
@@ -50,6 +50,7 @@ async fn _register_image(
         .as_register_image_call()
         .send_with(ec2_client)
         .await
+        .map_err(error_utils::AwsSdkError)
         .context(error::RegisterImageSnafu {
             region: region.as_ref(),
         })?;
@@ -258,6 +259,7 @@ where
         ]))
         .send()
         .await
+        .map_err(error_utils::AwsSdkError)
         .context(error::DescribeImagesSnafu {
             region: region.as_ref(),
         })?;
@@ -288,10 +290,10 @@ where
 
 mod error {
     use super::mk_amispec;
-    use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::{
         describe_images::DescribeImagesError, register_image::RegisterImageError,
     };
+    use error_utils::AwsSdkError;
     use snafu::Snafu;
     use std::path::PathBuf;
 
@@ -307,7 +309,7 @@ mod error {
         #[snafu(display("Failed to describe images in {}: {}", region, source))]
         DescribeImages {
             region: String,
-            source: SdkError<DescribeImagesError>,
+            source: AwsSdkError<DescribeImagesError>,
         },
 
         #[snafu(display("Image response in {} did not include image ID", region))]
@@ -319,7 +321,7 @@ mod error {
         #[snafu(display("Failed to register image in {}: {}", region, source))]
         RegisterImage {
             region: String,
-            source: SdkError<RegisterImageError>,
+            source: AwsSdkError<RegisterImageError>,
         },
 
         #[snafu(display("Failed to create progress bar: {}", source))]

--- a/tools/pubsys/src/aws/ami/wait.rs
+++ b/tools/pubsys/src/aws/ami/wait.rs
@@ -42,6 +42,7 @@ pub(crate) async fn wait_for_ami(
             .set_image_ids(Some(vec![id.to_string()]))
             .send()
             .await
+            .map_err(error_utils::AwsSdkError::from)
             .context(error::DescribeImagesSnafu {
                 region: region.as_ref(),
             })?;
@@ -100,8 +101,8 @@ pub(crate) async fn wait_for_ami(
 }
 
 mod error {
-    use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::describe_images::DescribeImagesError;
+    use error_utils::AwsSdkError;
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
@@ -111,7 +112,7 @@ mod error {
         #[snafu(display("Failed to describe images in {}: {}", region, source))]
         DescribeImages {
             region: String,
-            source: SdkError<DescribeImagesError>,
+            source: AwsSdkError<DescribeImagesError>,
         },
 
         #[snafu(display(

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -7,7 +7,7 @@ use crate::aws::ami::Image;
 use crate::aws::client::build_client_config;
 use crate::aws::region_from_string;
 use crate::Args;
-use aws_sdk_ec2::error::{ProvideErrorMetadata, SdkError};
+use aws_sdk_ec2::error::ProvideErrorMetadata;
 use aws_sdk_ec2::operation::{
     modify_image_attribute::{ModifyImageAttributeError, ModifyImageAttributeOutput},
     modify_snapshot_attribute::{ModifySnapshotAttributeError, ModifySnapshotAttributeOutput},
@@ -17,8 +17,10 @@ use aws_sdk_ec2::types::{
 };
 use aws_sdk_ec2::{config::Region, Client as Ec2Client};
 use clap::{Args as ClapArgs, Parser};
+use error_utils::AwsSdkError;
 use futures::future::{join, ready};
 use futures::stream::{self, StreamExt};
+use futures::TryFutureExt;
 use log::{debug, error, info, trace};
 use pubsys_config::InfraConfig;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -246,6 +248,7 @@ pub(crate) async fn get_snapshots(
         .set_image_ids(Some(vec![image_id.to_string()]))
         .send()
         .await
+        .map_err(error_utils::AwsSdkError::from)
         .context(error::DescribeImagesSnafu {
             region: region.as_ref(),
         })?;
@@ -359,7 +362,8 @@ pub(crate) async fn modify_snapshots(
             )
             .set_operation_type(Some(operation.clone()))
             .set_snapshot_id(Some(snapshot_id.clone()))
-            .send();
+            .send()
+            .map_err(AwsSdkError::from);
         // Store the snapshot_id so we can include it in any errors
         let info_future = ready(snapshot_id.to_string());
         requests.push(join(info_future, response_future));
@@ -369,7 +373,10 @@ pub(crate) async fn modify_snapshots(
     let request_stream = stream::iter(requests).buffer_unordered(4);
     let responses: Vec<(
         String,
-        std::result::Result<ModifySnapshotAttributeOutput, SdkError<ModifySnapshotAttributeError>>,
+        std::result::Result<
+            ModifySnapshotAttributeOutput,
+            AwsSdkError<ModifySnapshotAttributeError>,
+        >,
     )> = request_stream.collect().await;
 
     for (snapshot_id, response) in responses {
@@ -428,7 +435,9 @@ pub(crate) async fn modify_regional_snapshots(
                         "Failed to modify permissions in {} for snapshots [{}]: {:?}",
                         region.as_ref(),
                         snapshot_ids.join(", "),
-                        err.into_service_error().code().unwrap_or("unknown"),
+                        err.as_service_error()
+                            .and_then(|e| e.code())
+                            .unwrap_or("unknown"),
                     );
                 }
             }
@@ -453,7 +462,7 @@ pub(crate) async fn modify_image(
     operation: &OperationType,
     image_id: &str,
     ec2_client: &Ec2Client,
-) -> std::result::Result<ModifyImageAttributeOutput, SdkError<ModifyImageAttributeError>> {
+) -> std::result::Result<ModifyImageAttributeOutput, AwsSdkError<ModifyImageAttributeError>> {
     ec2_client
         .modify_image_attribute()
         .set_attribute(Some(
@@ -474,6 +483,7 @@ pub(crate) async fn modify_image(
         .set_operation_type(Some(operation.clone()))
         .set_image_id(Some(image_id.to_string()))
         .send()
+        .map_err(AwsSdkError::from)
         .await
 }
 
@@ -502,7 +512,7 @@ pub(crate) async fn modify_regional_images(
     #[allow(clippy::type_complexity)]
     let responses: Vec<(
         (String, String),
-        std::result::Result<ModifyImageAttributeOutput, SdkError<ModifyImageAttributeError>>,
+        std::result::Result<ModifyImageAttributeOutput, AwsSdkError<ModifyImageAttributeError>>,
     )> = request_stream.collect().await;
 
     // Count up successes and failures so we can give a clear total in the final error message.
@@ -545,7 +555,9 @@ pub(crate) async fn modify_regional_images(
                     "Modifying permissions of {} in {} failed: {}",
                     image_id,
                     region,
-                    e.into_service_error().code().unwrap_or("unknown"),
+                    e.as_service_error()
+                        .and_then(|err| err.code())
+                        .unwrap_or("unknown"),
                 );
             }
         }
@@ -564,11 +576,11 @@ pub(crate) async fn modify_regional_images(
 
 mod error {
     use crate::aws::ami;
-    use aws_sdk_ec2::error::SdkError;
     use aws_sdk_ec2::operation::{
         describe_images::DescribeImagesError,
         modify_snapshot_attribute::ModifySnapshotAttributeError,
     };
+    use error_utils::AwsSdkError;
     use snafu::Snafu;
     use std::io;
     use std::path::PathBuf;
@@ -594,7 +606,7 @@ mod error {
         #[snafu(display("Failed to describe images in {}: {}", region, source))]
         DescribeImages {
             region: String,
-            source: SdkError<DescribeImagesError>,
+            source: AwsSdkError<DescribeImagesError>,
         },
 
         #[snafu(display("Failed to deserialize input from '{}': {}", path.display(), source))]
@@ -637,7 +649,7 @@ mod error {
         ModifyImageAttribute {
             snapshot_id: String,
             region: String,
-            source: SdkError<ModifySnapshotAttributeError>,
+            source: AwsSdkError<ModifySnapshotAttributeError>,
         },
 
         #[snafu(display(

--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -305,7 +305,7 @@ async fn check_public_namespace_amis_are_public(
         let is_public = ami_is_public(&update.ec2_client, region.as_ref(), ami_id)
             .await
             .context(error::CheckAmiPublicSnafu {
-                ami_id: ami_id.to_string(),
+                ami_id,
                 region: region.to_string(),
             });
 

--- a/tools/pubsys/src/aws/ssm/ssm.rs
+++ b/tools/pubsys/src/aws/ssm/ssm.rs
@@ -2,15 +2,17 @@
 
 use super::{SsmKey, SsmParameters};
 use async_stream::stream;
-use aws_sdk_ssm::error::{ProvideErrorMetadata, SdkError};
+use aws_sdk_ssm::error::ProvideErrorMetadata;
 use aws_sdk_ssm::operation::{
     get_parameters::{GetParametersError, GetParametersOutput},
     put_parameter::{PutParameterError, PutParameterOutput},
 };
 use aws_sdk_ssm::{config::Region, types::ParameterType, Client as SsmClient};
+use error_utils::AwsSdkError;
 use futures::future::{join, ready};
 use futures::pin_mut;
 use futures::stream::{self, FuturesUnordered, StreamExt};
+use futures::TryFutureExt;
 use governor::Jitter;
 use governor::{
     clock::DefaultClock, middleware::NoOpMiddleware, state::keyed::DefaultKeyedStateStore, Quota,
@@ -103,6 +105,7 @@ where
                         .get_parameters()
                         .set_names((!names_chunk.is_empty()).then_some(names_chunk))
                         .send()
+                        .map_err(AwsSdkError::from)
                         .await
                 }
             };
@@ -118,7 +121,7 @@ where
     #[allow(clippy::type_complexity)]
     let responses: Vec<(
         (Region, usize),
-        std::result::Result<GetParametersOutput, SdkError<GetParametersError>>,
+        std::result::Result<GetParametersOutput, AwsSdkError<GetParametersError>>,
     )> = request_stream.collect().await;
 
     // If you're checking parameters in a region you haven't pushed to before, you can get an
@@ -234,7 +237,7 @@ pub(crate) async fn get_parameters_by_prefix_in_region(
             rate_limit_ssm_get_parameters(region).await;
             paginated_request.next().await
         } {
-            yield page;
+            yield page.map_err(AwsSdkError::from);
         }
     };
     pin_mut!(paginated_response_stream);
@@ -343,7 +346,8 @@ pub(crate) async fn set_parameters(
                 .set_value(Some(context.value.to_string()))
                 .set_overwrite(Some(true))
                 .set_type(Some(ParameterType::String))
-                .send();
+                .send()
+                .map_err(AwsSdkError::from);
 
             let regional_list = regional_requests
                 .entry(context.region)
@@ -367,7 +371,7 @@ pub(crate) async fn set_parameters(
         let parallel_requests = stream::select_all(throttled_streams).buffer_unordered(4);
         let responses: Vec<(
             RequestContext<'_>,
-            std::result::Result<PutParameterOutput, SdkError<PutParameterError>>,
+            std::result::Result<PutParameterOutput, AwsSdkError<PutParameterError>>,
         )> = parallel_requests.collect().await;
 
         // For each error response, check if we should retry or bail.
@@ -375,8 +379,8 @@ pub(crate) async fn set_parameters(
             if let Err(e) = response {
                 // Throttling errors are not currently surfaced in AWS SDK Rust, doing a string match is best we can do
                 let error_type = e
-                    .into_service_error()
-                    .code()
+                    .as_service_error()
+                    .and_then(|err| err.code())
                     .unwrap_or("unknown")
                     .to_owned();
                 if error_type.contains("ThrottlingException") {
@@ -489,26 +493,25 @@ async fn validate_parameters_inner(
 }
 
 pub(crate) mod error {
-    use aws_sdk_ssm::error::SdkError;
     use aws_sdk_ssm::operation::{
         get_parameters::GetParametersError, get_parameters_by_path::GetParametersByPathError,
     };
+    use error_utils::AwsSdkError;
     use snafu::Snafu;
-    use std::error::Error as _;
     use std::time::Duration;
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
     #[allow(clippy::large_enum_variant)]
     pub enum Error {
-        #[snafu(display("Failed to fetch SSM parameters in {}: {}", region, source.source().map(|x| x.to_string()).unwrap_or("unknown".to_string())))]
+        #[snafu(display("Failed to fetch SSM parameters in {}: {}", region, source))]
         GetParameters {
             region: String,
-            source: SdkError<GetParametersError>,
+            source: AwsSdkError<GetParametersError>,
         },
 
         #[snafu(display(
-            "Failed to fetch SSM parameters by path {} in {}: {}",
+            "Failed to fetch SSM parameters by path '{}' in {}: {}",
             path,
             region,
             source
@@ -516,7 +519,7 @@ pub(crate) mod error {
         GetParametersByPath {
             path: String,
             region: String,
-            source: SdkError<GetParametersByPathError>,
+            source: AwsSdkError<GetParametersByPathError>,
         },
 
         #[snafu(display("Missing field in parameter in {}: {}", region, field))]

--- a/tools/pubsys/src/aws/validate_ami/ami.rs
+++ b/tools/pubsys/src/aws/validate_ami/ami.rs
@@ -1,6 +1,7 @@
 //! The ami module owns the describing of images in EC2.
 
 use aws_sdk_ec2::{config::Region, types::Image, Client as Ec2Client};
+use error_utils::AwsSdkError;
 use futures::future::{join, ready};
 use futures::stream::{FuturesUnordered, StreamExt};
 use log::{info, trace};
@@ -132,6 +133,7 @@ pub(crate) async fn describe_images_in_region(
     // Iterate over the retrieved images
     while let Some(page) = get_future.next().await {
         let retrieved_images = page
+            .map_err(AwsSdkError::from)
             .context(error::DescribeImagesSnafu {
                 region: region.to_string(),
             })?
@@ -181,22 +183,17 @@ pub(crate) async fn describe_images_in_region(
 
 pub(crate) mod error {
     use aws_sdk_ec2::operation::describe_images::DescribeImagesError;
-    use aws_sdk_ssm::error::SdkError;
-    use aws_smithy_types::error::display::DisplayErrorContext;
+    use error_utils::AwsSdkError;
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
     #[allow(clippy::large_enum_variant)]
     pub(crate) enum Error {
-        #[snafu(display(
-            "Failed to describe images in {}: {}",
-            region,
-            DisplayErrorContext(source)
-        ))]
+        #[snafu(display("Failed to describe images in {}: {}", region, source))]
         DescribeImages {
             region: String,
-            source: SdkError<DescribeImagesError>,
+            source: AwsSdkError<DescribeImagesError>,
         },
 
         #[snafu(display(

--- a/tools/testsys/Cargo.toml
+++ b/tools/testsys/Cargo.toml
@@ -18,6 +18,7 @@ bottlerocket-types.workspace = true
 bottlerocket-variant.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 env_logger.workspace = true
+error-utils.workspace = true
 futures.workspace = true
 handlebars.workspace = true
 log.workspace = true

--- a/tools/testsys/src/aws_resources.rs
+++ b/tools/testsys/src/aws_resources.rs
@@ -77,7 +77,8 @@ where
                 .build(),
         )
         .send()
-        .await?
+        .await
+        .map_err(|e| Box::new(error_utils::AwsSdkError(e)))?
         .images;
     let images: Vec<&Image> = describe_images.iter().flatten().collect();
     // Make sure there is exactly 1 image that matches the parameters.

--- a/tools/testsys/src/error.rs
+++ b/tools/testsys/src/error.rs
@@ -1,5 +1,5 @@
-use aws_sdk_ec2::error::SdkError;
 use aws_sdk_ec2::operation::describe_images::DescribeImagesError;
+use error_utils::AwsSdkError;
 use snafu::Snafu;
 use std::path::PathBuf;
 
@@ -28,8 +28,7 @@ pub enum Error {
 
     #[snafu(context(false), display("{}", source))]
     DescribeImages {
-        #[snafu(source(from(SdkError<DescribeImagesError>, Box::new)))]
-        source: Box<SdkError<DescribeImagesError>>,
+        source: Box<AwsSdkError<DescribeImagesError>>,
     },
 
     #[snafu(display("Unable to read file '{}': {}", path.display(), source))]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Wrap all AWS SDK errors in DisplayErrorContext to provide the full call chain. Some of the existing errors, such as the ssm module's GetParametersSnafu, will provide the source error as "ServiceError" with no additional details or unwrapping of the error chain. See https://docs.aws.amazon.com/sdk-for-rust/latest/dg/error-handling.html#displayErrorContext

**Testing done:**

`make build`

Runtime test:

Here's a test with the new change:

```
./target/release/pubsys --infra-config-path /tmp/test-infra.toml validate-ssm --expected-parameters-path /tmp/expected-params.json
19:22:29 [INFO] Parsing Infra.toml file
19:22:29 [INFO] Found infra config at path: /tmp/test-infra.toml
19:22:29 [INFO] Parsing expected parameters file
19:22:29 [INFO] Parsed expected parameters file
19:22:29 [INFO] Retrieving SSM parameters
19:22:29 [INFO] Retrieving SSM parameters in us-west-2
19:22:29 [ERROR] Failed to retrieve images in region us-west-2: Failed to fetch SSM parameters by path  in us-west-2: ValidationException: 1 validation error detected: Value '' at 'path' failed to satisfy constraint: Member must have length greater than or equal to 1
19:22:29 [INFO] Validating SSM parameters
+-----------+---------+-----------+---------+------------+-------------+
| String    | correct | incorrect | missing | unexpected | unreachable |
+-----------+---------+-----------+---------+------------+-------------+
| us-west-2 | 0       | 0         | 0       | 0          | 1           |
+-----------+---------+-----------+---------+------------+-------------+
```

That same test with 0.14.0 pubsys:

```
 ./target/release/pubsys --infra-config-path /tmp/test-infra.toml validate-ssm --expected-parameters-path /tmp/expected-params.json
19:23:38 [INFO] Parsing Infra.toml file
19:23:38 [INFO] Found infra config at path: /tmp/test-infra.toml
19:23:38 [INFO] Parsing expected parameters file
19:23:38 [INFO] Parsed expected parameters file
19:23:38 [INFO] Retrieving SSM parameters
19:23:38 [INFO] Retrieving SSM parameters in us-west-2
19:23:39 [ERROR] Failed to retrieve images in region us-west-2: Failed to fetch SSM parameters by path  in us-west-2: service error
19:23:39 [INFO] Validating SSM parameters
+-----------+---------+-----------+---------+------------+-------------+
| String    | correct | incorrect | missing | unexpected | unreachable |
+-----------+---------+-----------+---------+------------+-------------+
| us-west-2 | 0       | 0         | 0       | 0          | 1           |
+-----------+---------+-----------+---------+------------+-------------+
```

where I have as these test input files:

```
# /tmp/expected-params.json
{
  "us-west-2": {
    "/aws/service/bottlerocket/test-param": "expected-value"
  }
}
```

and

```
# /tmp/test-infra.toml
[aws]
regions = ["us-west-2"]
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
