### PR TITLE
rpm2img: add support for aliases for packages

### DIFF
--- a/tests/integration-tests/src/appinventory.rs
+++ b/tests/integration-tests/src/appinventory.rs
@@ -76,6 +76,8 @@ async fn create_bob(version: &str) -> TempDir {
     cmd!(
         git,
         "clone",
+        "--depth",
+        "1",
         "-b",
         version,
         "https://github.com/bottlerocket-os/bottlerocket.git",
@@ -232,4 +234,76 @@ fn build_and_fetch_application_inventory(
         "twoliter did not generate application-inventory.json"
     );
     std::fs::read_to_string(&aif).expect("failed to read application-inventory.json file")
+}
+const SINGLE_OBSOLETE_PATCH: &str = include_str!("patches/single-obsolete.patch");
+const MULTIPLE_OBSOLETES_PATCH: &str = include_str!("patches/multiple-obsoletes.patch");
+
+fn apply_patch(bob_path: &Path, patch: &str) {
+    let git = which("git").expect("failed to find git");
+    cmd!(git, "-C", bob_path, "apply", "-")
+        .stdin_bytes(patch.as_bytes())
+        .run()
+        .expect("failed to apply patch");
+}
+
+#[tokio::test]
+async fn test_application_inventory_single_obsolete() {
+    // We clone v1.52.0 bob to ensure the patches are applied reliably
+    let bob_version = "v1.52.0";
+    let bob_src = create_bob(bob_version).await;
+
+    // To test aliases, we add a single obsoletes in settings-defaults package
+    apply_patch(bob_src.path(), SINGLE_OBSOLETE_PATCH);
+
+    // Build and get the application inventory file contents with this twoliter
+    let aif = build_and_fetch_application_inventory(TWOLITER_PATH, bob_src.path());
+    let inventory: InventoryView =
+        serde_json::from_str(&aif).expect("failed to deserialize inventory");
+
+    // In this case an extra entry is added in the application-inventory
+    assert!(
+        inventory
+            .content
+            .iter()
+            .any(|c| c.name == "bottlerocket-test-obsolete-pkg" && c.publisher == "Bottlerocket"),
+        "expected test-obsolete-pkg in inventory from Obsoletes"
+    );
+}
+
+#[tokio::test]
+async fn test_application_inventory_multiple_obsoletes() {
+    // We clone v1.52.0 bob to ensure the patches are applied reliably
+    let bob_version = "v1.52.0";
+    let bob_src = create_bob(bob_version).await;
+    apply_patch(bob_src.path(), MULTIPLE_OBSOLETES_PATCH);
+
+    // To test aliases, we add 2 obsoletes in settings-defaults package
+    let aif = build_and_fetch_application_inventory(TWOLITER_PATH, bob_src.path());
+    let inventory: InventoryView =
+        serde_json::from_str(&aif).expect("failed to deserialize inventory");
+
+    // In this case 2 extra entries are added in the application-inventory
+    let settings_defaults_publisher = inventory
+        .content
+        .iter()
+        .find(|c| c.name == "bottlerocket-settings-defaults")
+        .map(|c| c.publisher.clone())
+        .expect("expected bottlerocket-settings-defaults in inventory");
+
+    assert!(
+        inventory
+            .content
+            .iter()
+            .any(|c| c.name == "bottlerocket-test-obsolete-one"
+                && c.publisher == settings_defaults_publisher),
+        "expected test-obsolete-one in inventory from Obsoletes"
+    );
+    assert!(
+        inventory
+            .content
+            .iter()
+            .any(|c| c.name == "bottlerocket-test-obsolete-two"
+                && c.publisher == settings_defaults_publisher),
+        "expected test-obsolete-two in inventory from Obsoletes"
+    );
 }

--- a/tests/integration-tests/src/patches/multiple-obsoletes.patch
+++ b/tests/integration-tests/src/patches/multiple-obsoletes.patch
@@ -1,0 +1,12 @@
+diff --git a/packages/settings-defaults/settings-defaults.spec b/packages/settings-defaults/settings-defaults.spec
+--- a/packages/settings-defaults/settings-defaults.spec
++++ b/packages/settings-defaults/settings-defaults.spec
+@@ -36,6 +36,8 @@ Requires: (%{shrink:
+ Provides: %{_cross_os}settings-defaults(any)
+ Provides: %{_cross_os}settings-defaults(aws-ecs-2)
+ Provides: %{_cross_os}settings-defaults(aws-ecs-2-fips)
++Obsoletes: %{_cross_os}test-obsolete-one
++Obsoletes: %{_cross_os}test-obsolete-two
+ Conflicts: %{_cross_os}settings-defaults(any)
+ 
+ %description aws-ecs-2

--- a/tests/integration-tests/src/patches/single-obsolete.patch
+++ b/tests/integration-tests/src/patches/single-obsolete.patch
@@ -1,0 +1,11 @@
+diff --git a/packages/settings-defaults/settings-defaults.spec b/packages/settings-defaults/settings-defaults.spec
+--- a/packages/settings-defaults/settings-defaults.spec
++++ b/packages/settings-defaults/settings-defaults.spec
+@@ -36,6 +36,7 @@ Requires: (%{shrink:
+ Provides: %{_cross_os}settings-defaults(any)
+ Provides: %{_cross_os}settings-defaults(aws-ecs-2)
+ Provides: %{_cross_os}settings-defaults(aws-ecs-2-fips)
++Obsoletes: %{_cross_os}test-obsolete-pkg
+ Conflicts: %{_cross_os}settings-defaults(any)
+ 
+ %description aws-ecs-2

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -166,6 +166,8 @@ fi
 INSTALL_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 rpm -iv --ignorearch --root "${ROOT_MOUNT}" "${PACKAGE_DIR}"/*.rpm
 
+PKG_PREFIX="bottlerocket-"
+
 # Inventory installed packages.
 INVENTORY_QUERY="\{\"Name\":\"%{NAME}\"\
 ,\"SourcePackage\":\"%{SOURCERPM}\"\
@@ -177,7 +179,8 @@ INVENTORY_QUERY="\{\"Name\":\"%{NAME}\"\
 ,\"ApplicationType\":\"%{GROUP}\"\
 ,\"Architecture\":\"%{ARCH}\"\
 ,\"Url\":\"%{URL}\"\
-,\"Summary\":\"%{Summary}\"\}\n"
+,\"Summary\":\"%{Summary}\"\
+,\"Alias\":\"[%{Obsoletes},]\"\}\n"
 
 # shellcheck disable=SC2312 # Array is validated elsewhere.
 mapfile -t installed_rpms <<<"$(rpm -qa --root "${ROOT_MOUNT}" \
@@ -186,14 +189,18 @@ mapfile -t installed_rpms <<<"$(rpm -qa --root "${ROOT_MOUNT}" \
 # Wrap installed_rpms mapfile into json.
 INVENTORY_DATA="$(jq --raw-output . <<<"${installed_rpms[@]}")"
 # Sort by package name and add 'Content' as top-level.
-INVENTORY_DATA="$(jq --slurp 'sort_by(.Name)' <<<"${INVENTORY_DATA}" | jq '{"Content": .}')"
+# We convert comma separated Aliases to a json array.
+INVENTORY_DATA="$(jq --slurp '
+  map(.Alias |= (if . and . != "" then (split(",") | map(select(. != ""))) else [] end))
+  | sort_by(.Name)
+  | {Content: .}' <<<"${INVENTORY_DATA}")"
 
 INVENTORY_BEFORE_PARENTS="$(jq '.Content | length' <<<"${INVENTORY_DATA}")"
 INVENTORY_DATA="$(jq '
   .Content |= (
     . + map(
       (.Version) as $v | (.Release) as $r | (.SourcePackage | sub("-" + $v + "-" + $r + "\\.src\\.rpm$";"")) as $p |
-      . + {Name: $p, Summary: ($p + " (source package)")}
+      . + {Name: $p, Summary: ("Source Package for " + $p)}
     )
     | unique_by(.Name)
     | map(del(.SourcePackage))
@@ -223,12 +230,12 @@ for kit in "${kits[@]}"; do
   kit_path="${EXTERNAL_KITS_PATH}/${kit_vendor}/${kit}/${ARCH}"
 
   # Query the kit repo of RPMs for all package names.
-  kit_inventory_query="%{NAME}\n"
+  kit_inventory_query="%{NAME}\n%{Obsoletes}"
   # shellcheck disable=SC2312 # Array is validated elsewhere.
   mapfile -t KIT_PKGS <<<"$(dnf -q --repofrompath \
     kit,file://"${kit_path}" \
     --repo=kit repoquery \
-    --queryformat "${kit_inventory_query}" | grep -v "^$")"
+    --queryformat "${kit_inventory_query}" | grep -v "^$" | awk '{print $1}')"
   # Convert the bash array of kit packages to a JSON array.
   kit_list="$(\
     jq \
@@ -241,24 +248,65 @@ for kit in "${kits[@]}"; do
   # for search and replace in the installed application inventory.
   jq \
     --compact-output \
-    'map({ (.|tostring): (.|sub("^bottlerocket-";""))}) | add' <<<"${kit_list}" \
+    --arg prefix "${PKG_PREFIX}" \
+    'map({ (.|tostring): (.|sub("^" + $prefix;""))}) | add' <<<"${kit_list}" \
     > kit-replacements.json
 
   # For any packages in the installed app inventory that came from the kit, replace
   # the Publisher with the kit's vendor and replace the name with the unprefixed name.
   INVENTORY_DATA="$(jq \
-    --slurpfile replace kit-replacements.json \
-    --arg KIT "${kit}" \
-    '(.Content[] | select(.Name | $replace[][.] != null) | .Publisher) = $KIT |
-      .Content[].Name |= (if $replace[][.] then $replace[][.] else . end)' \
-    <<<"${INVENTORY_DATA}")"
+  --slurpfile replace kit-replacements.json \
+  --arg KIT "${kit}" \
+  '(.Content[] | select(.Name | $replace[][.] != null) | .Publisher) = $KIT |
+    .Content[].Name |= (if $replace[][.] then $replace[][.] else . end) |
+    .Content[].Alias |= map(if $replace[][.] then $replace[][.] else . end)' \
+  <<<"${INVENTORY_DATA}")"
 done
+
+# We ensured all names are unique before creating additional entries for Aliases. If this generated
+# duplicate entries then there exists 2 packages in a variant that do the same function, so we error out
+# We append an additional list of aliases with the prefix so that we test both {_cross_os}pkg and pkg since
+# they refer to the same packages.
+CONFLICT_CHECK=$(jq --arg prefix "${PKG_PREFIX}" '
+  [.Content[].Name] +
+  [.Content[].Alias[]] +
+  [.Content[].Alias[] | $prefix + .]
+' <<<"${INVENTORY_DATA}")
+
+TOTAL_COUNT=$(jq 'length' <<<"${CONFLICT_CHECK}")
+UNIQUE_COUNT=$(jq 'unique | length' <<<"${CONFLICT_CHECK}")
+
+if [[ "${TOTAL_COUNT}" -ne "${UNIQUE_COUNT}" ]]; then
+  echo "Package conflict detected - a package name or alias collides with another." >&2
+  jq -r 'group_by(.) | map(select(length > 1)) | .[][0]' <<<"${CONFLICT_CHECK}" >&2
+  exit 1
+fi
+
+# Add alias entries from Obsoletes field.
+INVENTORY_DATA=$(jq '
+  .Content |= (
+    . + [
+      .[] |
+      select(.Alias != null and (.Alias | length) > 0) |
+      . as $orig |
+      .Alias[] |
+      ($orig + {Name: ., Summary: ("Alias for " + $orig.Name)})
+    ] |
+    map(del(.Alias)) |
+    sort_by(.Name)
+  )
+' <<<"${INVENTORY_DATA}")
+
+ALIAS_COUNT=$(($(jq '.Content | length' <<<"${INVENTORY_DATA}") - INVENTORY_AFTER_PARENTS))
 
 # Verify we successfully inventoried some RPMs.
 INVENTORY_COUNT="$(jq '.Content | length' <<<"${INVENTORY_DATA}")"
 RPM_COUNT="$(find "${PACKAGE_DIR}" -maxdepth 1 -type f -name '*.rpm' | wc -l)"
-if [[ "${INVENTORY_COUNT}" -ne "$((RPM_COUNT + ADDED_PARENTS))" ]]; then
-  echo "Inventory of RPMs does not match what was expected: '${INVENTORY_COUNT}/$((RPM_COUNT + ADDED_PARENTS))'" >&2
+if [[ "${INVENTORY_COUNT}" -ne "$((RPM_COUNT + ADDED_PARENTS + ALIAS_COUNT))" ]]; then
+  echo "Inventory count mismatch: \
+  Inventory count: ${INVENTORY_COUNT} \
+  Expected Inventory count: $((RPM_COUNT + ADDED_PARENTS + ALIAS_COUNT)) \
+    (${RPM_COUNT} RPMs, ${ADDED_PARENTS} source packages, ${ALIAS_COUNT} aliases)" >&2
   exit 1
 fi
 if grep -q "bottlerocket-release" <<<"${INVENTORY_DATA}"; then


### PR DESCRIPTION
**Description of changes:**
This PR allows creation of aliases for packages whose name is changed so as to support multiple versions of the same package. For example: bottlerocket-core-kit supports `containerd-1.7`, `containerd-2.0` and `containerd-2.1`. With this change, we allow creation of aliases so that we get additional entries in the application-inventory.json which can ensure that compliance solutions are able to properly track the old packages with new names.

**Testing done:**
These changes may or may not be valid for the actual repo but attempts to test corner cases. 
I added the following Obsoletes in `containerd-2.0`
```
Obsoletes: %{_cross_os}%{gorepo}
Obsoletes: %{_cross_os}%{gorepo}-1.7
Obsoletes: %{_cross_os}%{gorepo} <= 1.7.15
```

This the output I got after making the above change for containerd-2.0, building the package and mounting the rpm in a bottlerocket-sdk container. 
```
bash-5.2$ rpm -qp --queryformat '[%{OBSOLETES}\n]' /containerd-2.0/bottlerocket-containerd-2.0-2.0.7-1.1764962845.9b3a8b3a.br1.x86_64.rpm
bottlerocket-containerd
bottlerocket-containerd
bottlerocket-containerd-1.7
```
I used the above to write the logic. I added Obsoletes for `systemd-257` and `containerd-2.1` (to bin sub-package) as well and built a aws-k8s-1.34 ami.

Additional entries in application-inventory.json
```
   {
      "Name": "containerd",
      "Publisher": "bottlerocket-core-kit",
      "Version": "2.1.6",
      "Release": "1.1767894444.d2ba7912.br1",
      "Epoch": "0",
      "InstalledTime": "2026-01-13T20:50:12Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://github.com/containerd/containerd",
      "Summary": "Alias for bottlerocket-containerd-2.1-bin"
    },
    {
      "Name": "containerd-1.7",
      "Publisher": "bottlerocket-core-kit",
      "Version": "2.1.6",
      "Release": "1.1767894444.d2ba7912.br1",
      "Epoch": "0",
      "InstalledTime": "2026-01-13T20:50:12Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://github.com/containerd/containerd",
      "Summary": "Alias for bottlerocket-containerd-2.1-bin"
    },
    {
      "Name": "containerd-2.1",
      "Publisher": "bottlerocket-core-kit",
      "Version": "2.1.6",
      "Release": "1.1767894444.d2ba7912.br1",
      "Epoch": "0",
      "InstalledTime": "2026-01-13T20:50:12Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://github.com/containerd/containerd",
      "Summary": "An industry-standard container runtime"
    },
    {
      "Name": "systemd",
      "Publisher": "bottlerocket-core-kit",
      "Version": "257.9",
      "Release": "1.1767894444.d2ba7912.br1",
      "Epoch": "0",
      "InstalledTime": "2026-01-13T20:50:12Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://www.freedesktop.org/wiki/Software/systemd",
      "Summary": "Alias for bottlerocket-systemd-257"
    },
    {
      "Name": "systemd-252",
      "Publisher": "bottlerocket-core-kit",
      "Version": "257.9",
      "Release": "1.1767894444.d2ba7912.br1",
      "Epoch": "0",
      "InstalledTime": "2026-01-13T20:50:12Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://www.freedesktop.org/wiki/Software/systemd",
      "Summary": "Alias for bottlerocket-systemd-257"
    },
    {
      "Name": "systemd-257",
      "Publisher": "bottlerocket-core-kit",
      "Version": "257.9",
      "Release": "1.1767894444.d2ba7912.br1",
      "Epoch": "0",
      "InstalledTime": "2026-01-13T20:50:12Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://www.freedesktop.org/wiki/Software/systemd",
      "Summary": "System and Service Manager"
    },
```

containerd-2.1
```
%package bin
Summary: An industry-standard container runtime's binaries
Provides: %{name}(binaries)
Requires: (%{_cross_os}image-feature(no-fips) and %{name})
Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
Obsoletes: %{_cross_os}%{gorepo}
Obsoletes: %{_cross_os}%{gorepo}-1.7
Obsoletes: %{_cross_os}%{gorepo} <= 1.7.15
```
systemd-257
```
Obsoletes: %{_cross_os}systemd
Obsoletes: %{_cross_os}systemd-252
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
