### PR TITLE
fix: sbom_package_dir optional in imghelper

### DIFF
--- a/tests/integration-tests/src/imghelper.rs
+++ b/tests/integration-tests/src/imghelper.rs
@@ -1,0 +1,77 @@
+use crate::run_command;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn imghelper_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("twoliter/embedded/imghelper")
+}
+
+fn test_sanity_checks(sbom_arg: Option<&str>, expect_success: bool) {
+    let temp_dir = TempDir::new().unwrap();
+    let ovf_template = temp_dir.path().join("test.ovf");
+    std::fs::write(&ovf_template, "dummy ovf content").unwrap();
+
+    let imghelper = imghelper_path();
+    let mut script = format!(
+        r#"
+        source "{}"
+        sanity_checks "raw" "split" "{}" "no" {}
+        "#,
+        imghelper.display(),
+        ovf_template.display(),
+        sbom_arg.map(|s| format!("\"{}\"", s)).unwrap_or_default()
+    );
+
+    let output = run_command(
+        "bash",
+        ["-c", &script],
+        [
+            ("IMAGE_NAME", "test"),
+            ("VARIANT", "test"),
+            ("ARCH", "x86_64"),
+            ("VERSION_ID", "1.0.0"),
+            ("BUILD_ID", "1"),
+        ],
+    );
+
+    if expect_success {
+        assert!(output.status.success(), "sanity_checks should succeed");
+    } else {
+        assert!(!output.status.success(), "sanity_checks should fail");
+    }
+}
+
+// Tests for optional sbom_package_dir argument
+// sanity_checks is called by rpm2img and img2img
+// rpm2img requires calling it with 5 args, while
+// img2img requires calling it with 4 args.
+
+#[test]
+fn test_sanity_checks_without_sbom_dir() {
+    // Omitting sbom_package_dir should succeed (optional arg)
+    test_sanity_checks(None, true);
+}
+
+#[test]
+fn test_sanity_checks_with_empty_sbom_dir() {
+    // Empty string should succeed (treated as unset)
+    test_sanity_checks(Some(""), true);
+}
+
+#[test]
+fn test_sanity_checks_with_valid_sbom_dir() {
+    // Valid directory arg should succeed
+    let temp_dir = TempDir::new().unwrap();
+    test_sanity_checks(Some(temp_dir.path().to_str().unwrap()), true);
+}
+
+#[test]
+fn test_sanity_checks_with_nonexistent_sbom_dir() {
+    // Non-existent path should fail (validation still works when provided)
+    test_sanity_checks(Some("/nonexistent/path"), false);
+}

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use tempfile::TempDir;
 
 mod appinventory;
+mod imghelper;
 mod twoliter_build;
 mod twoliter_update;
 

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -33,9 +33,9 @@ sanity_checks() {
   partition_plan="${2:?}"
   ovf_template="${3:?}"
   uefi_secure_boot="${4:?}"
-  sbom_package_dir="${5:?}"
+  sbom_package_dir="${5:-}"
 
-  if [[ ! -d "${sbom_package_dir}" ]]; then
+  if [[ -n "${sbom_package_dir}" ]] && [[ ! -d "${sbom_package_dir}" ]]; then
     echo "SBOM package directory does not exist: ${sbom_package_dir}" >&2
     exit 1
   fi


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue:**
https://github.com/bottlerocket-os/twoliter/issues/619

[This PR](https://github.com/bottlerocket-os/twoliter/pull/583) added a 5th argument to `sanity_checks` in `imghelper` and is handled by `rpm2img` but not `img2img`, which breaks when running the `repack-variant` target.

**Description of changes:**
Make the `sbom_package_dir` arg optional in `imghelper`

Created new integration tests, which fail without the changes in `imghelper`.

**Testing done:**
```
cargo make -e BUILDSYS_VARIANT=aws-k8s-1.33 build-variant
cargo make -e BUILDSYS_VARIANT=aws-k8s-1.33 repack-variant  <-- fails without these changes
```
Verified all SBOM packages remain intact:
```
[fedora@ip-172-31-4-193 bottlerocket]$ ls -la  /mnt/br/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/
total 328
drwxr-xr-x.  3 root root     176 Dec 16 22:21 .
drwxr-xr-x. 23 root root     439 Dec 16 22:21 ..
-rw-r--r--.  1 root root   63939 Dec 16 22:21 application-inventory.json
-rw-r--r--.  1 root root  606878 Dec 16 22:21 cyclonedx-sbom.json
-rw-r--r--.  1 root root      76 Dec 16 22:21 image-features.env
drwxr-xr-x.  3 root root      46 Dec 16 22:21 kernel-devel
-rw-r--r--.  1 root root 2634023 Dec 16 22:21 spdx-sbom.json
```

Additionally:
```
cargo test
```

Reverted changes in `imghelper` and confirmed the tests would catch the bug:
```
failures:
    imghelper::test_sanity_checks_with_empty_sbom_dir
    imghelper::test_sanity_checks_without_sbom_dir
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
