### PR TITLE
chore: add e2e test for build-variant and repack-variant build targets

### DIFF
--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -10,6 +10,7 @@ mod appinventory;
 mod imghelper;
 mod twoliter_build;
 mod twoliter_update;
+mod variant_build;
 
 pub const TWOLITER_PATH: &str = env!("CARGO_BIN_FILE_TWOLITER");
 

--- a/tests/integration-tests/src/variant_build.rs
+++ b/tests/integration-tests/src/variant_build.rs
@@ -1,0 +1,140 @@
+use crate::{run_command, TWOLITER_PATH};
+use duct::cmd;
+use std::path::Path;
+use tempfile::TempDir;
+use which::which;
+
+/// Create a test project by cloning bottlerocket
+async fn create_test_project() -> TempDir {
+    let tmp_dir = TempDir::new().expect("failed to create temporary directory");
+    let git = which("git").expect("failed to find git");
+    let inside = tmp_dir.path().to_str().unwrap();
+
+    cmd!(
+        git,
+        "clone",
+        "--depth",
+        "1",
+        "https://github.com/bottlerocket-os/bottlerocket.git",
+        inside
+    )
+    .run()
+    .expect("failed to clone bottlerocket");
+
+    tmp_dir
+}
+
+/// Run twoliter make with a specific target
+fn twoliter_make(
+    project_dir: &Path,
+    target: &str,
+    variant: &str,
+    arch: &str,
+) -> std::process::Output {
+    let cargo_home = project_dir.join(".cargo");
+    std::fs::create_dir_all(&cargo_home).unwrap();
+
+    run_command(
+        TWOLITER_PATH,
+        [
+            "make",
+            "--project-path",
+            project_dir.join("Twoliter.toml").to_str().unwrap(),
+            "--cargo-home",
+            cargo_home.to_str().unwrap(),
+            "--arch",
+            arch,
+            target,
+        ],
+        [("BUILDSYS_VARIANT", variant)],
+    )
+}
+
+/// Test that build-variant runs successfully via twoliter make.
+#[tokio::test]
+#[ignore]
+async fn test_twoliter_build_variant() {
+    let bob_src = create_test_project().await;
+    let project_path = bob_src.path().join("Twoliter.toml");
+    let arch = "x86_64";
+    let variant = "aws-ecs-2";
+
+    // Update
+    let output = run_command(
+        TWOLITER_PATH,
+        ["update", "--project-path", project_path.to_str().unwrap()],
+        [],
+    );
+    assert!(output.status.success(), "twoliter update failed");
+
+    // Fetch
+    let output = run_command(
+        TWOLITER_PATH,
+        [
+            "fetch",
+            "--project-path",
+            project_path.to_str().unwrap(),
+            "--arch",
+            arch,
+        ],
+        [],
+    );
+    assert!(output.status.success(), "twoliter fetch failed");
+
+    // Build variant
+    let output = twoliter_make(bob_src.path(), "build-variant", variant, arch);
+    assert!(
+        output.status.success(),
+        "twoliter make build-variant failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Test that repack-variant runs successfully via twoliter make.
+/// This requires a previously built variant image to repack.
+#[tokio::test]
+#[ignore]
+async fn test_twoliter_repack_variant() {
+    let bob_src = create_test_project().await;
+    let project_path = bob_src.path().join("Twoliter.toml");
+    let arch = "x86_64";
+    let variant = "aws-ecs-2";
+
+    // Update
+    let output = run_command(
+        TWOLITER_PATH,
+        ["update", "--project-path", project_path.to_str().unwrap()],
+        [],
+    );
+    assert!(output.status.success(), "twoliter update failed");
+
+    // Fetch
+    let output = run_command(
+        TWOLITER_PATH,
+        [
+            "fetch",
+            "--project-path",
+            project_path.to_str().unwrap(),
+            "--arch",
+            arch,
+        ],
+        [],
+    );
+    assert!(output.status.success(), "twoliter fetch failed");
+
+    // First build the variant
+    let output = twoliter_make(bob_src.path(), "build-variant", variant, arch);
+    assert!(
+        output.status.success(),
+        "twoliter make build-variant failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Then repack it
+    let output = twoliter_make(bob_src.path(), "repack-variant", variant, arch);
+    assert!(
+        output.status.success(),
+        "twoliter make repack-variant failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
https://github.com/bottlerocket-os/twoliter/issues/622

Closes #
https://github.com/bottlerocket-os/twoliter/issues/622

**Description of changes:**
Add integration tests for the `build-variant` and `repack-variant` make targets in `twoliter`.

### Changes
-  Added new test module `variant_build.rs` with two integration tests:
   - `test_twoliter_build_variant()` - validates the complete `build-variant `workflow (update → fetch → `build-variant`)
   - `test_twoliter_repack_variant()` - validates the `repack-variant` workflow (update → fetch → `build-variant` → `repack-variant`)

**Testing done:**
```
cargo make test
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
