### PR TITLE
feat: add sbomtool generate for variant RPMs during image build

### DIFF
--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -272,25 +272,32 @@ if [[ ${#sbom_rpms[@]} -gt 1 ]]; then
   ln -rs "${usr_dir}" "${SBOM_MOUNT}/usr"
 fi
 
+# Generate SBOM for variant RPMs
+RPM_SBOM_DIR=$(mktemp -d)
+sbomtool generate --name variant-rpms --build-dir "${PACKAGE_DIR}" --out-dir "${RPM_SBOM_DIR}" --spdx --cyclonedx
+
 # Merge SBOMs into a single json file
 KIT_SBOMS_DIR="${SBOM_MOUNT}/usr/share/sboms"
-if [ -d "${KIT_SBOMS_DIR}" ]; then
-  IMAGE_SBOM_DIR="${ROOT_MOUNT}/usr/share/bottlerocket"
-  mkdir -p "${IMAGE_SBOM_DIR}"
-  for format in "spdx" "cyclonedx"; do
-    image_sbom="${format}-sbom.json"
-    image_sbom_path="${IMAGE_SBOM_DIR}/${image_sbom}"
-    find "${KIT_SBOMS_DIR}" -name "*-${format}.json" -type f -exec sbomtool merge --output "${image_sbom_path}" {} \+
-    if [[ ! -f "${image_sbom_path}" ]]; then
-      echo "Could not find image SBOM path: ${image_sbom_path}" >&2
-      exit 1
-    fi
-    cp "${image_sbom_path}" "${OUTPUT_DIR}/${image_sbom}"
-    if [[ "${EROFS_ROOT_PARTITION}" == "no" ]]; then
-      lz4 -z -f "${image_sbom_path}" "${image_sbom_path}.lz4"
-    fi
-  done
-fi
+IMAGE_SBOM_DIR="${ROOT_MOUNT}/usr/share/bottlerocket"
+mkdir -p "${IMAGE_SBOM_DIR}"
+for format in "spdx" "cyclonedx"; do
+  image_sbom="${format}-sbom.json"
+  image_sbom_path="${IMAGE_SBOM_DIR}/${image_sbom}"
+  rpm_sbom="${RPM_SBOM_DIR}/variant-rpms-${format}.json"
+  if [ -d "${KIT_SBOMS_DIR}" ]; then
+    find "${KIT_SBOMS_DIR}" -name "*-${format}.json" -type f -exec sbomtool merge --output "${image_sbom_path}" "${rpm_sbom}" {} \+
+  else
+    cp "${rpm_sbom}" "${image_sbom_path}"
+  fi
+  if [[ ! -f "${image_sbom_path}" ]]; then
+    echo "Could not find image SBOM path: ${image_sbom_path}" >&2
+    exit 1
+  fi
+  cp "${image_sbom_path}" "${OUTPUT_DIR}/${image_sbom}"
+  if [[ "${EROFS_ROOT_PARTITION}" == "no" ]]; then
+    lz4 -z -f "${image_sbom_path}" "${image_sbom_path}.lz4"
+  fi
+done
 
 # Regenerate module dependencies, if possible.
 KMOD_DIR="${ROOT_MOUNT}/lib/modules"

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -296,6 +296,7 @@ for format in "spdx" "cyclonedx"; do
   cp "${image_sbom_path}" "${OUTPUT_DIR}/${image_sbom}"
   if [[ "${EROFS_ROOT_PARTITION}" == "no" ]]; then
     lz4 -z -f "${image_sbom_path}" "${image_sbom_path}.lz4"
+    rm "${image_sbom_path}"
   fi
 done
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #626 

Closes #

**Description of changes:**
Generates an SBOM of installed RPMS and merges it with the kit source SBOMs if they are available.


**Testing done:**
Built an AMI with the change, validated that rpms are now included in the SBOM output


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
