### PR TITLE
test(integ): ignore inventory integration test

### DIFF
--- a/tests/integration-tests/src/appinventory.rs
+++ b/tests/integration-tests/src/appinventory.rs
@@ -145,6 +145,7 @@ struct InventoryView {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_twoliter_application_inventory() {
     // We clone the latest release bob
     let bob_version = find_latest_version("bottlerocket").await;


### PR DESCRIPTION
This test takes a very long time to run.

This change continues to run the test on `make integ` (this is how we separate other integration tests in twoliter) but not on a bare `cargo test`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
