### PR TITLE
chore: bump source package anchor version

### DIFF
--- a/tests/integration-tests/src/appinventory.rs
+++ b/tests/integration-tests/src/appinventory.rs
@@ -18,7 +18,7 @@ const EXPECTED_INVENTORY_PATH: &str =
 
 // Last Bottlerocket release that doesn't include source packages in application inventory.
 // For older releases, we check that reference inventory is a subset of current.
-const SOURCE_PACKAGE_INVENTORY_ANCHOR_VERSION: &str = "1.52.0";
+const SOURCE_PACKAGE_INVENTORY_ANCHOR_VERSION: &str = "1.55.0";
 
 #[derive(Serialize, Deserialize)]
 pub struct GithubRelease {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
https://github.com/bottlerocket-os/twoliter/issues/636

Closes #636

**Description of changes:**
Changes the `test_twoliter_application_inventory` test to verify that all packages in the reference inventory exist in the current inventory (subset check), rather than requiring exact equality. This catches regressions (missing packages) while allowing additions.


**Testing done:**
`cargo make test`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
