### PR TITLE
fix(tests): fetch kits for host architecture

### DIFF
--- a/tests/integration-tests/src/variant_build.rs
+++ b/tests/integration-tests/src/variant_build.rs
@@ -56,7 +56,7 @@ fn twoliter_make(
 async fn test_twoliter_build_variant() {
     let bob_src = create_test_project().await;
     let project_path = bob_src.path().join("Twoliter.toml");
-    let arch = "x86_64";
+    let arch = std::env::consts::ARCH;
     let variant = "aws-ecs-2";
 
     // Update
@@ -97,7 +97,7 @@ async fn test_twoliter_build_variant() {
 async fn test_twoliter_repack_variant() {
     let bob_src = create_test_project().await;
     let project_path = bob_src.path().join("Twoliter.toml");
-    let arch = "x86_64";
+    let arch = std::env::consts::ARCH;
     let variant = "aws-ecs-2";
 
     // Update


### PR DESCRIPTION
**Description of changes:**
`make build` was failing on my aarch64 host. It turns out this is because we would fetch for x86_64 but then call twoliter without providing an arch later, which would cause it to default to the host architecture.


**Testing done:**
* `make build` now passes on my aarch64 dev host


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
