### PR TITLE
Add ability to override variant properties

### DIFF
--- a/docs/design/custom-variant-considerations.md
+++ b/docs/design/custom-variant-considerations.md
@@ -1,0 +1,105 @@
+# Custom Variant Names and Variant Attribute Overrides
+
+### Background
+
+Bottlerocket variants can override attributes like `platform` and `runtime` to inherit build-time behavior from standard variant families. For example, a custom variant named `foo-k8s-1.35` might override:
+
+```toml
+[package.metadata.build-variant]
+platform = "vmware"
+runtime = "k8s"
+```
+
+This results in `family = aws-k8s`, which affects build-time behavior such as:
+- Conditional compilation via `cfg` attributes
+- AMI naming conventions
+- Platform-specific package inclusion
+
+However, these overrides do **not** automatically configure the settings-defaults RPM resolution.
+
+## The Settings-Defaults Problem
+
+The `settings-defaults` RPM package uses exact variant name matching via RPM dependencies. When the variant build runs:
+
+1. The `bottlerocket-metadata` RPM provides `variant(NAME)` based on your literal variant name (e.g., `variant(foo-k8s-1.35)`)
+2. The RPM resolver looks for a `settings-defaults` subpackage with a matching `Requires: variant(foo-k8s-1.35)`
+3. If no match exists, the build fails with: `Unable to find a match: bottlerocket-settings-defaults`
+
+Variant attribute overrides affect build-time behavior but do **not** affect RPM dependency resolution.
+
+## Required Steps for Custom Variants
+
+### 1. Create a Settings-Defaults Directory
+
+You must create a settings-defaults directory named after your **actual variant name**, not the family you're inheriting from.
+
+In the Bottlerocket repository under `sources/settings-defaults/`, create:
+
+```
+foo-k8s-1.35/
+├── Cargo.toml
+└── defaults.d/
+    ├── 10-defaults.toml → ../../shared-defaults/defaults.toml
+    ├── 15-aws-tuf.toml → ../../shared-defaults/aws-tuf.toml
+    ├── 20-aws-host-containers.toml → ../../shared-defaults/aws-host-containers.toml
+    └── 50-kubernetes-aws.toml → ../../shared-defaults/kubernetes-aws.toml
+```
+
+The `Cargo.toml` should define the crate name using underscores (dots are not allowed in crate names):
+
+```toml
+[package]
+name = "settings-defaults-foo-k8s-1_35"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[build-dependencies]
+gensettings = { path = "../../gensettings" }
+```
+
+### 2. Use Symlinks to Inherit Shared Defaults
+
+The `defaults.d/` directory should contain numbered symlinks to files in `shared-defaults/`. The numbered prefix controls merge order (lower numbers are applied first).
+
+Choose symlinks based on your target family:
+
+| Family | Required Symlinks |
+|--------|------------------|
+| aws-k8s | `defaults.toml`, `aws-tuf.toml`, `aws-host-containers.toml`, `kubernetes-aws.toml` |
+| vmware-k8s | `defaults.toml`, `public-tuf.toml`, `public-host-containers.toml`, `kubernetes-vmware.toml` |
+| metal-k8s | `defaults.toml`, `public-tuf.toml`, `public-host-containers.toml`, `kubernetes-metal.toml` |
+| aws-ecs | `defaults.toml`, `aws-tuf.toml`, `aws-host-containers.toml`, `ecs.toml` |
+
+### 3. Update the RPM Spec
+
+Add your variant to `packages/settings-defaults/settings-defaults.spec`. You can either:
+
+**Option A: Create a new subpackage**:
+
+```spec
+%package foo-k8s-1.35
+Summary: Settings defaults for foo-k8s-1.35 variant
+Requires: %{_cross_os}variant(foo-k8s-1.35)
+Provides: %{_cross_os}settings-defaults(any)
+
+%description foo-k8s-1.35
+%{summary}.
+
+%files foo-k8s-1.35
+%{_cross_factorydir}/%{_cross_os}defaults.d/*
+```
+
+**Option B: Add to an existing subpackage** (if settings are compatible):
+
+```spec
+%package aws-k8s-1.35
+...
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.35)      or
+           %{_cross_os}variant(aws-k8s-1.35-fips) or
+           %{_cross_os}variant(foo-k8s-1.35) # Add your variant here
+           %{nil}})
+
+```

--- a/tools/bottlerocket-variant/Cargo.toml
+++ b/tools/bottlerocket-variant/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 snafu.workspace = true
 

--- a/tools/bottlerocket-variant/src/lib.rs
+++ b/tools/bottlerocket-variant/src/lib.rs
@@ -191,6 +191,50 @@ impl Variant {
         );
     }
 
+    /// Apply overrides to create a new Variant with the specified attributes replaced.
+    ///
+    /// If an override is `Some`, it replaces the original value. If `None`, the original is kept.
+    /// Family is recomputed from final platform/runtime UNLESS family was explicitly overridden.
+    pub fn with_overrides(&self, overrides: &VariantOverrides) -> Self {
+        let platform = overrides
+            .platform
+            .clone()
+            .unwrap_or_else(|| self.platform.clone());
+        let runtime = overrides
+            .runtime
+            .clone()
+            .unwrap_or_else(|| self.runtime.clone());
+        let family = overrides
+            .family
+            .clone()
+            .unwrap_or_else(|| format!("{platform}-{runtime}"));
+        let version = overrides.version.clone().or_else(|| self.version.clone());
+        let variant_flavor = overrides
+            .flavor
+            .clone()
+            .or_else(|| self.variant_flavor.clone());
+
+        // Reconstruct variant string from final attributes: platform-runtime[-version][-flavor]
+        let mut variant = format!("{platform}-{runtime}");
+        if let Some(ref v) = version {
+            variant.push('-');
+            variant.push_str(v);
+        }
+        if let Some(ref f) = variant_flavor {
+            variant.push('-');
+            variant.push_str(f);
+        }
+
+        Self {
+            variant,
+            platform,
+            runtime,
+            family,
+            version,
+            variant_flavor,
+        }
+    }
+
     fn parse<S: Into<String>>(value: S) -> Result<Self> {
         let variant = value.into();
         let mut parts = variant.split('-');
@@ -438,5 +482,136 @@ fn parse_err() {
             "Expected Variant::new(\"{}\") to return an error",
             test
         );
+    }
+}
+
+/// Overrides for variant attributes that can be specified in a package's Cargo.toml.
+///
+/// These overrides are read from `[package.metadata.bottlerocket-variant]` and allow
+/// packages to override the variant attributes derived from the variant string.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+pub struct VariantOverrides {
+    pub platform: Option<String>,
+    pub runtime: Option<String>,
+    pub family: Option<String>,
+    pub version: Option<String>,
+    pub flavor: Option<String>,
+}
+
+impl VariantOverrides {
+    /// Returns true if no overrides are set.
+    pub fn is_empty(&self) -> bool {
+        self.platform.is_none()
+            && self.runtime.is_none()
+            && self.family.is_none()
+            && self.version.is_none()
+            && self.flavor.is_none()
+    }
+}
+
+#[cfg(test)]
+mod with_overrides_tests {
+    use super::*;
+
+    #[test]
+    fn test_with_overrides_platform_only() {
+        let variant = Variant::new("aws-k8s-1.32").unwrap();
+        let overrides = VariantOverrides {
+            platform: Some("metal".to_string()),
+            ..Default::default()
+        };
+        let result = variant.with_overrides(&overrides);
+        assert_eq!(result.platform(), "metal");
+        assert_eq!(result.runtime(), "k8s");
+        assert_eq!(result.family(), "metal-k8s");
+        assert_eq!(result.version(), Some("1.32"));
+    }
+
+    #[test]
+    fn test_with_overrides_runtime_only() {
+        let variant = Variant::new("aws-k8s-1.32").unwrap();
+        let overrides = VariantOverrides {
+            runtime: Some("ecs".to_string()),
+            ..Default::default()
+        };
+        let result = variant.with_overrides(&overrides);
+        assert_eq!(result.platform(), "aws");
+        assert_eq!(result.runtime(), "ecs");
+        assert_eq!(result.family(), "aws-ecs");
+        assert_eq!(result.version(), Some("1.32"));
+    }
+
+    #[test]
+    fn test_with_overrides_family_explicit() {
+        let variant = Variant::new("aws-k8s-1.32").unwrap();
+        let overrides = VariantOverrides {
+            platform: Some("metal".to_string()),
+            family: Some("custom-family".to_string()),
+            ..Default::default()
+        };
+        let result = variant.with_overrides(&overrides);
+        assert_eq!(result.platform(), "metal");
+        assert_eq!(result.runtime(), "k8s");
+        assert_eq!(result.family(), "custom-family");
+    }
+
+    #[test]
+    fn test_with_overrides_family_computed() {
+        let variant = Variant::new("aws-k8s-1.32").unwrap();
+        let overrides = VariantOverrides {
+            platform: Some("vmware".to_string()),
+            runtime: Some("dev".to_string()),
+            ..Default::default()
+        };
+        let result = variant.with_overrides(&overrides);
+        assert_eq!(result.family(), "vmware-dev");
+    }
+
+    #[test]
+    fn test_with_overrides_all_fields() {
+        let variant = Variant::new("aws-k8s-1.32").unwrap();
+        let overrides = VariantOverrides {
+            platform: Some("metal".to_string()),
+            runtime: Some("dev".to_string()),
+            family: Some("custom".to_string()),
+            version: Some("2.0".to_string()),
+            flavor: Some("nvidia".to_string()),
+        };
+        let result = variant.with_overrides(&overrides);
+        assert_eq!(result.platform(), "metal");
+        assert_eq!(result.runtime(), "dev");
+        assert_eq!(result.family(), "custom");
+        assert_eq!(result.version(), Some("2.0"));
+        assert_eq!(result.variant_flavor(), Some("nvidia"));
+    }
+
+    #[test]
+    fn test_with_overrides_none() {
+        let variant = Variant::new("aws-k8s-1.32-nvidia").unwrap();
+        let overrides = VariantOverrides::default();
+        let result = variant.with_overrides(&overrides);
+        assert_eq!(result.platform(), "aws");
+        assert_eq!(result.runtime(), "k8s");
+        assert_eq!(result.family(), "aws-k8s");
+        assert_eq!(result.version(), Some("1.32"));
+        assert_eq!(result.variant_flavor(), Some("nvidia"));
+    }
+
+    #[test]
+    fn test_existing_parsing_unchanged() {
+        // Ensure original parsing still works correctly
+        let variant = Variant::new("aws-k8s-1.32-nvidia").unwrap();
+        assert_eq!(variant.platform(), "aws");
+        assert_eq!(variant.runtime(), "k8s");
+        assert_eq!(variant.family(), "aws-k8s");
+        assert_eq!(variant.version(), Some("1.32"));
+        assert_eq!(variant.variant_flavor(), Some("nvidia"));
+
+        let variant2 = Variant::new("metal-dev").unwrap();
+        assert_eq!(variant2.platform(), "metal");
+        assert_eq!(variant2.runtime(), "dev");
+        assert_eq!(variant2.family(), "metal-dev");
+        assert_eq!(variant2.version(), None);
+        assert_eq!(variant2.variant_flavor(), None);
     }
 }

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -224,6 +224,7 @@ struct VariantBuildArgs {
     partition_plan: String,
     pretty_name: String,
     variant: String,
+    variant_name: String,
     variant_family: String,
     variant_flavor: String,
     variant_platform: String,
@@ -257,6 +258,7 @@ impl VariantBuildArgs {
         args.build_arg("PARTITION_PLAN", &self.partition_plan);
         args.build_arg("PRETTY_NAME", &self.pretty_name);
         args.build_arg("VARIANT", &self.variant);
+        args.build_arg("VARIANT_NAME", &self.variant_name);
         args.build_arg("VARIANT_FAMILY", &self.variant_family);
         args.build_arg("VARIANT_FLAVOR", &self.variant_flavor);
         args.build_arg("VARIANT_PLATFORM", &self.variant_platform);
@@ -281,6 +283,7 @@ struct RepackVariantBuildArgs {
     os_image_size_gib: String,
     partition_plan: String,
     variant: String,
+    variant_name: String,
     variant_platform: String,
     version_build: String,
     version_image: String,
@@ -302,6 +305,7 @@ impl RepackVariantBuildArgs {
         args.build_arg("OS_IMAGE_SIZE_GIB", &self.os_image_size_gib);
         args.build_arg("PARTITION_PLAN", &self.partition_plan);
         args.build_arg("VARIANT", &self.variant);
+        args.build_arg("VARIANT_NAME", &self.variant_name);
         args.build_arg("VARIANT_PLATFORM", &self.variant_platform);
         args.build_arg("BUILD_ID", &self.version_build);
         args.build_arg("VERSION_ID", &self.version_image);
@@ -445,6 +449,10 @@ impl DockerBuild {
         let variant = filename(args.common.cargo_manifest_dir);
 
         let v = Variant::new(&variant).context(error::VariantParseSnafu)?;
+        let overrides = manifest.info().variant_overrides();
+        let v = v.with_overrides(&overrides);
+        let variant_name = variant.clone();
+        let variant: String = v.as_ref().into();
         let variant_platform = v.platform().into();
         let variant_runtime = v.runtime().into();
         let variant_family = v.family().into();
@@ -457,15 +465,18 @@ impl DockerBuild {
             context: args.common.root_dir.clone(),
             target: "variant".to_string(),
             tag: append_token(
-                format!("buildsys-var-{variant}-{arch}", arch = args.common.arch),
+                format!(
+                    "buildsys-var-{variant_name}-{arch}",
+                    arch = args.common.arch
+                ),
                 &args.common.root_dir,
             ),
             root_dir: args.common.root_dir.clone(),
             artifacts_dirs: vec![args
                 .image_dir
-                .join(format!("{}-{}", args.common.arch, variant))],
+                .join(format!("{}-{}", args.common.arch, variant_name))],
             state_dir: args.common.state_dir,
-            artifact_name: variant.clone(),
+            artifact_name: variant_name.clone(),
             common_build_args: CommonBuildArgs::new(
                 &args.common.root_dir,
                 args.common.sdk_image,
@@ -508,6 +519,7 @@ impl DockerBuild {
                 .to_string(),
                 pretty_name: args.pretty_name,
                 variant,
+                variant_name,
                 variant_family,
                 variant_flavor,
                 variant_platform,
@@ -534,6 +546,10 @@ impl DockerBuild {
 
         let variant = filename(args.common.cargo_manifest_dir);
         let v = Variant::new(&variant).context(error::VariantParseSnafu)?;
+        let overrides = manifest.info().variant_overrides();
+        let v = v.with_overrides(&overrides);
+        let variant_name = variant.clone();
+        let variant: String = v.as_ref().into();
         let variant_platform = v.platform().into();
 
         Ok(Self {
@@ -575,6 +591,7 @@ impl DockerBuild {
                 }
                 .to_string(),
                 variant,
+                variant_name,
                 variant_platform,
                 version_build: args.version_build,
                 version_image: args.version_image,

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -573,6 +573,19 @@ impl ManifestInfo {
             .as_ref()
             .and_then(|m| m.build_variant.as_ref())
     }
+
+    /// Returns variant attribute overrides from `[package.metadata.build-variant]`.
+    pub fn variant_overrides(&self) -> bottlerocket_variant::VariantOverrides {
+        self.build_variant()
+            .map(|bv| bottlerocket_variant::VariantOverrides {
+                platform: bv.platform.clone(),
+                runtime: bv.runtime.clone(),
+                family: bv.family.clone(),
+                version: bv.version.clone(),
+                flavor: bv.flavor.clone(),
+            })
+            .unwrap_or_default()
+    }
 }
 
 /// For the "top-level manifest", i.e. the thing that `buildsys` is building, only
@@ -697,6 +710,12 @@ pub struct BuildVariant {
     pub supported_arches: Option<HashSet<SupportedArch>>,
     pub kernel_parameters: Option<Vec<String>>,
     pub image_features: Option<HashMap<ImageFeature, bool>>,
+    // Variant attribute overrides
+    pub platform: Option<String>,
+    pub runtime: Option<String>,
+    pub family: Option<String>,
+    pub version: Option<String>,
+    pub flavor: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -340,6 +340,7 @@ ARG BYPASS_SOCKET
 ARG OUTPUT_SOCKET
 ARG BUILDER_UID
 ARG VARIANT
+ARG VARIANT_NAME=${VARIANT}
 ARG VARIANT_PLATFORM
 ARG PRETTY_NAME
 ARG IMAGE_NAME
@@ -356,7 +357,7 @@ ARG UEFI_SECURE_BOOT
 ARG IN_PLACE_UPDATES
 ARG ENCRYPTED_STORAGE
 ARG PROJECT_VENDOR
-ENV VARIANT=${VARIANT} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
+ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
     PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
     KERNEL_PARAMETERS=${KERNEL_PARAMETERS}
@@ -393,7 +394,7 @@ RUN --mount=target=/host \
       --os-image-publish-size-gib="${OS_IMAGE_PUBLISH_SIZE_GIB}" \
       --data-image-publish-size-gib="${DATA_IMAGE_PUBLISH_SIZE_GIB}" \
       --partition-plan="${PARTITION_PLAN}" \
-      --ovf-template="/bypass/variants/${VARIANT}/template.ovf" \
+      --ovf-template="/bypass/variants/${VARIANT_NAME}/template.ovf" \
       ${XFS_DATA_PARTITION:+--with-xfs-data-partition=yes} \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
@@ -413,11 +414,12 @@ ARG VERSION_ID
 ARG BUILD_ID
 ARG NOCACHE
 ARG VARIANT
+ARG VARIANT_NAME=${VARIANT}
 ARG BYPASS_SOCKET
 ARG OUTPUT_SOCKET
 ARG BUILDER_UID
 ARG IN_PLACE_UPDATES
-ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
+ENV VARIANT=${VARIANT_NAME} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 WORKDIR /root
 
 USER root
@@ -453,7 +455,8 @@ ARG VERSION_ID
 ARG BUILD_ID
 ARG NOCACHE
 ARG VARIANT
-ENV VARIANT=${VARIANT} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
+ARG VARIANT_NAME=${VARIANT}
+ENV VARIANT=${VARIANT_NAME} VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 ARG BYPASS_SOCKET
 ARG OUTPUT_SOCKET
 ARG BUILDER_UID
@@ -504,6 +507,7 @@ ARG BYPASS_SOCKET
 ARG OUTPUT_SOCKET
 ARG BUILDER_UID
 ARG VARIANT
+ARG VARIANT_NAME=${VARIANT}
 ARG VARIANT_PLATFORM
 ARG IMAGE_NAME
 ARG IMAGE_FORMAT
@@ -515,7 +519,7 @@ ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG UEFI_SECURE_BOOT
 ARG EROFS_ROOT_PARTITION
 ARG IN_PLACE_UPDATES
-ENV VARIANT=${VARIANT} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
+ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 WORKDIR /root
 
@@ -541,7 +545,7 @@ RUN --mount=target=/host \
     /host/build/tools/pipesys link --fd-socket "${OUTPUT_SOCKET}" --target /output && \
     rm -rf /output/* && \
     /host/build/tools/img2img \
-      --input-dir="/bypass/build/images/${ARCH}-${VARIANT}/${VERSION_ID}-${BUILD_ID}" \
+      --input-dir="/bypass/build/images/${ARCH}-${VARIANT_NAME}/${VERSION_ID}-${BUILD_ID}" \
       --output-dir=/output \
       --output-fmt="${IMAGE_FORMAT}" \
       --os-image-size-gib="${OS_IMAGE_SIZE_GIB}" \
@@ -549,7 +553,7 @@ RUN --mount=target=/host \
       --os-image-publish-size-gib="${OS_IMAGE_PUBLISH_SIZE_GIB}" \
       --data-image-publish-size-gib="${DATA_IMAGE_PUBLISH_SIZE_GIB}" \
       --partition-plan="${PARTITION_PLAN}" \
-      --ovf-template="/bypass/variants/${VARIANT}/template.ovf" \
+      --ovf-template="/bypass/variants/${VARIANT_NAME}/template.ovf" \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
       ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} && \


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/twoliter/issues/641

**Description of changes:**
Adds VariantOverrides struct with Option<String> fields for platform, runtime, family, version, and flavor. Includes from_cargo_toml() function to parse overrides from [package.metadata.build-variant] section. This enables the ability to set your variant name to nearly anything you'd like but retain attributes like platform, runtime, family, version, or flavor.


**Testing done:**
Built several different combinations to ensure the end to end workflow is intact:
## End-to-End Testing Results: Variant Attribute Overrides

### Setup
Created settings-defaults symlinks for custom variants:
```
yeazelm-fancy-1.33 -> vmware-k8s-1.33
yeazelm-neat-1.35 -> aws-k8s-1.35
```

### Test Variant builds to prove out existing still build and new ones can be overridden

| Variant | Type | Overrides | Expected Family |
|---------|------|-----------|-----------------|
| aws-ecs-3 | Standard | None | aws-ecs |
| aws-k8s-1.32 | Standard | None | aws-k8s |
| aws-k8s-1.34-nvidia-fips | Standard | None | aws-k8s |
| vmware-k8s-1.32 | Standard | None | vmware-k8s |
| yeazelm-fancy-1.33 | Custom | platform=vmware, runtime=k8s | vmware-k8s |
| yeazelm-neat-1.35 | Custom | platform=aws, runtime=k8s | aws-k8s |

### Build Results

| Variant | Cargo Build | Full Image Build | Notes |
|---------|-------------|------------------|-------|
| aws-ecs-3 | ✅ Success | ✅ | Standard variant |
| aws-k8s-1.32 | ✅ Success | ✅  | Standard variant |
| aws-k8s-1.34-nvidia-fips | ✅ Success | ✅  | Standard variant |
| vmware-k8s-1.32 | ✅ Success | ✅ .vmdk created | Full rebuild, 3m40s |
| yeazelm-fancy-1.33 | ✅ Success | ✅ | Custom variant with vmware overrides |
| yeazelm-neat-1.35 | ✅ Success | ❌ DNF error | Package resolution issue because the rpm for aws-k8s-1.35 doesn't include it|


The symlink in sources/settings-defaults/ only helps with building the settings content, but the RPM spec file (packages/settings-defaults/settings-defaults.spec) needs to have the custom variant name added to an existing subpackage's Requires list.

For yeazelm-neat-1.35 to work, I would need to add it to the aws-k8s-1.35 subpackage in the spec:

```spec
%package aws-k8s-1.35
Requires: (%{shrink:
           %{_cross_os}variant(aws-k8s-1.35) or
           %{_cross_os}variant(aws-k8s-1.35-fips) or
           %{_cross_os}variant(yeazelm-neat-1.35)    # <-- ADD THIS
           %{nil}})
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
