### PR TITLE
pubsys: add Debug-level error chain logging for target download failure

### DIFF
--- a/tools/pubsys/src/repo/validate_repo/mod.rs
+++ b/tools/pubsys/src/repo/validate_repo/mod.rs
@@ -5,7 +5,7 @@ use crate::repo::{error as repo_error, repo_urls};
 use crate::{read_stream, repo, Args};
 use clap::Parser;
 use futures::{stream, StreamExt};
-use log::{info, trace};
+use log::{error, info, trace};
 use pubsys_config::InfraConfig;
 use snafu::{OptionExt, ResultExt};
 use std::io::Cursor;
@@ -56,6 +56,19 @@ async fn retrieve_targets(repo: &Repository) -> Result<(), Error> {
     Ok(())
 }
 
+/// Walks an error's source chain, logging each cause with Debug formatting.
+/// This surfaces details (like HTTP status codes) that Display formatting hides.
+fn log_error_chain(err: &dyn std::error::Error) {
+    error!("Error details: {:?}", err);
+    let mut source = err.source();
+    let mut depth = 1;
+    while let Some(cause) = source {
+        error!("  Cause #{}: {:?}", depth, cause);
+        source = cause.source();
+        depth += 1;
+    }
+}
+
 async fn download_target(repo: Repository, target: TargetName) -> Result<u64, Error> {
     info!("Downloading target: {}", target.raw());
     let stream = match repo.read_target(&target).await {
@@ -67,12 +80,17 @@ async fn download_target(repo: Repository, target: TargetName) -> Result<u64, Er
             .fail()
         }
         Err(e) => {
+            log_error_chain(&e);
             return Err(e).context(error::TargetReadSnafu {
                 target: target.raw(),
-            })
+            });
         }
     };
-    let mut bytes = Cursor::new(read_stream(stream).await.context(error::StreamSnafu)?);
+    let stream_result = read_stream(stream).await;
+    if let Err(ref e) = stream_result {
+        log_error_chain(e);
+    }
+    let mut bytes = Cursor::new(stream_result.context(error::StreamSnafu)?);
     // tough's `Read` implementation validates the target as it's being downloaded
     io::copy(&mut bytes, &mut io::sink())
         .await


### PR DESCRIPTION
**Description of changes:**

Add Debug-level error chain logging for target download failures in validate_repo.

When target downloads fail, the error output only shows Display-formatted messages (e.g., "error decoding response body"), which hide actionable details like HTTP status codes and timeout flags. This is because `tough` stores inner errors as Box<dyn Error>, and snafu formats the chain using Display.

This change adds a log_error_chain helper that walks the .source() chain and logs each cause with Debug formatting ({:?}). Unlike Display, the &dyn Error reference returned by .source() reaches through the Box<dyn Error> to the
concrete type, exposing internal fields (e.g., reqwest status codes, error classifications) that Display omits.

Called at both error sites in download_target():
- TargetRead — when repo.read_target() fails
- Stream — when reading the target stream fails


**Testing done:**
build success


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
