### PR TITLE
chore: prepare for release 0.17.1-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.17.0...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.17.1-rc1...HEAD
+
+## [0.17.1-rc-1] - 2026-03-18
+
+### Build
+* Bump actions/setup-go from 6.2.0 to 6.3.0 ([#644])
+* Bump aws-lc-sys from 0.37.1 to 0.38.0 ([#646])
+* Bump quinn-proto from 0.11.13 to 0.11.14 ([#648])
+
+[#644]: https://github.com/bottlerocket-os/twoliter/pull/644
+[#646]: https://github.com/bottlerocket-os/twoliter/pull/646
+[#648]: https://github.com/bottlerocket-os/twoliter/pull/648
+
+[0.17.1-rc1]: https://github.com/bottlerocket-os/twoliter/compare/v0.17.0...v0.17.1-rc1
 
 ## [0.17.0] - 2026-02-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.17.0"
+version = "0.17.1-rc1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" 
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
 
-twoliter = { version = "0.17.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.17.1-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
 twoliter-tool-advisory-checker = { version = "0.1", path = "twoliter/src/tool-crates/advisory-checker" }
 twoliter-tool-buildsys = { version = "0.1", path = "twoliter/src/tool-crates/buildsys" }
 twoliter-tool-embedded-bundle = { version = "0.1", path = "twoliter/src/tool-crates/embedded-bundle" }

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.17.0"
+version = "0.17.1-rc1"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
**Description of changes:**
- cargo update
- Create release candidate 0.17.1-rc1

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
