### PR TITLE
chore: bump aws-lc-sys from 0.38.0 to 0.39.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",

--- a/clarify.toml
+++ b/clarify.toml
@@ -8,8 +8,8 @@ ignore-licenses = [
 [clarify.aws-lc-sys]
 expression = "ISC AND (Apache-2.0 OR ISC) AND OpenSSL AND MIT"
 license-files = [
-  { path = "aws-lc/LICENSE", hash = 0x2ff829bc },
-  { path = "LICENSE", hash = 0xf308ccd7 },
+  { path = "aws-lc/LICENSE", hash = 0xc884acb6 },
+  { path = "LICENSE", hash = 0x6cb0b0bb },
   { path = "aws-lc/third_party/fiat/LICENSE", hash = 0x75829ee2 },
 ]
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
bump aws-lc-sys from 0.38.0 to 0.39.0


**Testing done:**
build Twoliter
```
cargo make -e BUILDSYS_VARIANT=aws-k8s-1.35 -e PUBLISH_REGIONS=us-west-2

[cargo-make][1] INFO - Running Task: build-variant
   Compiling settings-defaults v0.1.0 (/home/jweiw/workplace/repos/bottlerocket/packages/settings-defaults)
   Compiling settings-migrations v0.1.0 (/home/jweiw/workplace/repos/bottlerocket/packages/settings-migrations)
   Compiling settings-plugins v0.1.0 (/home/jweiw/workplace/repos/bottlerocket/packages/settings-plugins)
   Compiling aws-k8s-1_35 v0.1.0 (/home/jweiw/workplace/repos/bottlerocket/variants/aws-k8s-1.35)
warning: aws-k8s-1_35@0.1.0: Image feature GRUB_SET_PRIVATE_VAR is deprecated and will be removed in a future release!
warning: aws-k8s-1_35@0.1.0: Image feature SYSTEMD_NETWORKD is deprecated and will be removed in a future release!
    Finished `dev` profile [optimized] target(s) in 2m 14s
[cargo-make][1] INFO - Build Done in 137.31 seconds.
[cargo-make] INFO - Build Done in 147.51 seconds.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
