### PR TITLE
twoliter: generate builder-group rpm to provide group(builder)

### DIFF
--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -71,6 +71,13 @@ RUN --mount=target=/host \
         echo "Advisories directory not found, skipping check."; \
     fi
 
+RUN --mount=target=/host \
+    cp /host/build/tools/builder-group.spec rpmbuild/SPECS/builder-group.spec \
+    && rpmbuild -bb --clean \
+         --undefine _auto_set_build_flags \
+         --define "_target_cpu ${ARCH}" \
+         rpmbuild/SPECS/builder-group.spec
+
 USER root
 ARG BYPASS_SOCKET
 RUN --mount=target=/host \
@@ -144,6 +151,7 @@ ARG OUTPUT_SOCKET
 RUN --mount=target=/host \
     /host/build/tools/pipesys link --fd-socket "${OUTPUT_SOCKET}" --target /output && \
     rm -rf /output/* && \
+    find /home/builder/rpmbuild/RPMS -type f -name 'bottlerocket-builder-group-*.rpm' -delete && \
     cp /home/builder/rpmbuild/RPMS/*/*.rpm /output/ && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm -f /home/builder/rpmbuild/RPMS/*/*.rpm && \

--- a/twoliter/embedded/builder-group.spec
+++ b/twoliter/embedded/builder-group.spec
@@ -1,0 +1,29 @@
+%global cross_generate_attribution %{nil}
+
+Name: %{_cross_os}builder-group
+Version: 1.0
+Release: 1%{?dist}
+Summary: Provides group(builder) for kernel-devel subpackages
+
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/twoliter
+
+# This is a dummy package that provides `builder(group)`. RPM 6.0 introduced
+# automatic user() and group() dependency generation from file ownership changes
+# declared in `%files` sections. In earlier versions the dependencies were weak
+# so they were ignored. In RPM 6.0 they are Required.
+
+Provides: group(builder)
+
+%description
+%{summary}.
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog

--- a/twoliter/src/tool-crates/embedded-bundle/build.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/build.rs
@@ -36,6 +36,7 @@ fn main() {
     paths.copy_file("rpm2kmodkit");
     paths.copy_file("rpm2migrations");
     paths.copy_file("metadata.spec");
+    paths.copy_file("builder-group.spec");
     paths.copy_file("ocihelper");
     paths.copy_file("waves/accelerated-waves.toml");
     paths.copy_file("waves/default-waves.toml");

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -152,6 +152,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("img2img").is_file());
     assert!(toolsdir.join("imghelper").is_file());
     assert!(toolsdir.join("metadata.spec").is_file());
+    assert!(toolsdir.join("builder-group.spec").is_file());
     assert!(toolsdir.join("partyplanner").is_file());
     assert!(toolsdir.join("rpm2img").is_file());
     assert!(toolsdir.join("rpm2kit").is_file());


### PR DESCRIPTION
**Description of changes:**
This is a dummy package that provides `group(builder)`. RPM 6.0 introduced automatic user() and group() dependency generation from file ownership changes declared in `%files` sections. In earlier versions the dependencies were weak, so they may be ignored. In RPM 6.0 they are Required.

This is safe because `group(builder)` is responsible for building bottlerocket. Its just that a package has to provide it to satisfy the requirement by the RPM.


**Testing done:**
Built Bottlerocket with a custom bottlerocket-sdk that carries Fedora-43 container.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
