### PR TITLE
chore: prepare for release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.20.0-rc1...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.20.0...HEAD
 
-## [0.20.0-rc1] - 2026-05-27
+## [0.20.0] - 2026-05-27
 
 ### Added
 * Generate builder-group RPM to provide group(builder) ([#661])
 
 [#661]: https://github.com/bottlerocket-os/twoliter/pull/661
 
-[0.20.0-rc1]: https://github.com/bottlerocket-os/twoliter/compare/v0.19.0...v0.20.0-rc1
+[0.20.0]: https://github.com/bottlerocket-os/twoliter/compare/v0.19.0...v0.20.0
 
 
 ## [0.19.0] - 2026-05-12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,7 +5515,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.20.0-rc1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ testsys = { version = "0.1", path = "tools/testsys", artifact = [ "bin:testsys" 
 testsys-config = { version = "0.1", path = "tools/testsys-config" }
 testsys-model = { version = "0.0.16", git = "https://github.com/bottlerocket-os/bottlerocket-test-system", tag = "v0.0.16" }
 
-twoliter = { version = "0.20.0-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.20.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
 twoliter-tool-advisory-checker = { version = "0.1", path = "twoliter/src/tool-crates/advisory-checker" }
 twoliter-tool-buildsys = { version = "0.1", path = "twoliter/src/tool-crates/buildsys" }
 twoliter-tool-embedded-bundle = { version = "0.1", path = "twoliter/src/tool-crates/embedded-bundle" }

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.20.0-rc1"
+version = "0.20.0"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION

**Description of changes:**

Prepare release to v0.20.0

**Testing done:**

For both architectures `x86_64` and `aarch64`, I built:
* ecs-3 AMI where the kits and bottlerocket use 0.20.0-rc1
* ecs-3 AMI where kits built with 0.20.0-rc1, bottlerocket on 0.19.0

All instances boot fine, `systemctl status` all modules loaded no failures, `find / -name "*builder-group*"` no results

See PRs across projects with the 0.20.0-rc1 build results:

* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/936
* https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/450
* https://github.com/bottlerocket-os/bottlerocket/pull/4847


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
