### PR TITLE
feat(buildsys): add no-data-partitions and no-private-partition image features

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -460,6 +460,14 @@ impl DockerBuild {
         let external_kit_metadata_view =
             ExternalKitMetadataView::load(&args.common.root_dir).context(error::GraphSnafu)?;
 
+        // Validate image-feature combinations up-front so misconfigured
+        // variants fail before any container build is dispatched.
+        manifest
+            .info()
+            .validate_image_features()
+            .context(error::GraphSnafu)?;
+        let image_features = manifest.info().image_features().unwrap_or_default();
+
         Ok(Self {
             dockerfile: args.common.tools_dir.join("build.Dockerfile"),
             context: args.common.root_dir.clone(),
@@ -490,7 +498,7 @@ impl DockerBuild {
                 project_vendor: external_kit_metadata_view.get_project_vendor().to_owned(),
                 data_image_publish_size_gib,
                 data_image_size_gib: data_image_size_gib.to_string(),
-                image_features: manifest.info().image_features().unwrap_or_default(),
+                image_features,
                 image_format: match manifest.info().image_format() {
                     Some(ImageFormat::Raw) | None => "raw",
                     Some(ImageFormat::Qcow2) => "qcow2",
@@ -552,6 +560,14 @@ impl DockerBuild {
         let variant: String = v.as_ref().into();
         let variant_platform = v.platform().into();
 
+        // Validate image-feature combinations up-front so misconfigured
+        // variants fail before any container build is dispatched.
+        manifest
+            .info()
+            .validate_image_features()
+            .context(error::GraphSnafu)?;
+        let image_features = manifest.info().image_features().unwrap_or_default();
+
         Ok(Self {
             dockerfile: args.common.tools_dir.join("build.Dockerfile"),
             context: args.common.root_dir.clone(),
@@ -575,7 +591,7 @@ impl DockerBuild {
             target_build_args: TargetBuildArgs::Repack(RepackVariantBuildArgs {
                 data_image_publish_size_gib,
                 data_image_size_gib: data_image_size_gib.to_string(),
-                image_features: manifest.info().image_features().unwrap_or_default(),
+                image_features,
                 image_format: match manifest.info().image_format() {
                     Some(ImageFormat::Raw) | None => "raw",
                     Some(ImageFormat::Qcow2) => "qcow2",

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -254,6 +254,28 @@ only be enabled for variants that can guarantee that a TPM 2.0 device will be pr
 encrypted-storage = true
 ```
 
+`no-data-partitions` skips creation of the `BOTTLEROCKET-DATA-A` and `BOTTLEROCKET-DATA-B`
+filesystems in `rpm2img`, and suppresses the separate data-image artifact for the `split`
+partition plan. The partition layout itself is unchanged; only the `mkfs` and `dd` steps for
+the data partitions are skipped. This is intended for advanced/opt-in callers that supply
+data persistence externally (e.g. EIF/Firecracker images). Defaults to `false`.
+
+```ignore
+[package.metadata.build-variant.image-features]
+no-data-partitions = true
+```
+
+`no-private-partition` skips `bootconfig` generation and creation of the `BOTTLEROCKET-PRIVATE`
+filesystem in `rpm2img`. The partition layout itself is unchanged; only the `mkfs` and `dd`
+steps for the private partition are skipped. Enabling this flag produces an image that cannot
+boot via the in-tree grub flow — it is intended for callers that supply an external
+bootloader (e.g. EIF/Firecracker). Incompatible with `uefi-secure-boot`. Defaults to `false`.
+
+```ignore
+[package.metadata.build-variant.image-features]
+no-private-partition = true
+```
+
 */
 
 mod error;
@@ -531,7 +553,39 @@ impl ManifestInfo {
                 println!("cargo:warning=Image feature {deprecated} is deprecated and will be removed in a future release!");
             }
         }
+        if features.contains(&ImageFeature::NoPrivatePartition) {
+            println!(
+                "cargo:warning=Image feature no-private-partition is enabled: the variant image \
+                will be built without Bottlerocket's settings and apiserver. You are responsible \
+                for owning the configuration of the services inside the image."
+            );
+        }
+        if features.contains(&ImageFeature::NoDataPartitions) {
+            println!(
+                "cargo:warning=Image feature no-data-partitions is enabled: the variant image \
+                will be built without pre-provisioned data partition(s). You are responsible \
+                for mounting a partition with PARTLABEL=BOTTLEROCKET-DATA at runtime."
+            );
+        }
         Some(features)
+    }
+
+    /// Validate that the configured image features are mutually compatible.
+    ///
+    /// Returns an error for known-bad combinations so that misconfigured
+    /// `Cargo.toml` / `Twoliter.toml` files fail fast — before any build
+    /// artifact is produced — rather than failing later inside `rpm2img`
+    /// or as opaque RPM dependency-resolution errors.
+    ///
+    /// Note: `uefi-secure-boot` × `no-data-partitions` is intentionally
+    /// allowed. Secure Boot's PCR predictions reference the BOOT, ROOT,
+    /// HASH, and PRIVATE partitions but not BOTTLEROCKET-DATA, so omitting
+    /// the data partition does not break the secure-boot flow.
+    pub fn validate_image_features(&self) -> Result<()> {
+        let Some(features) = self.image_features() else {
+            return Ok(());
+        };
+        validate_image_feature_set(&features)
     }
 
     /// Returns the type of build the manifest is requesting.
@@ -849,14 +903,62 @@ pub enum ImageFeature {
     HostContainers,
     ExternalKmodDevelopment,
     EncryptedStorage,
+    NoDataPartitions,
+    NoPrivatePartition,
 }
 
-const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[&ImageFeature::EncryptedStorage];
+const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[
+    &ImageFeature::EncryptedStorage,
+    &ImageFeature::NoDataPartitions,
+    &ImageFeature::NoPrivatePartition,
+];
 
 const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
     &ImageFeature::GrubSetPrivateVar,
     &ImageFeature::SystemdNetworkd,
 ];
+
+/// Validate that a set of image features is mutually compatible.
+///
+/// Pure helper extracted from [`ManifestInfo::validate_image_features`] so
+/// that the rules can be unit-tested independently of a `Cargo.toml`
+/// fixture.
+fn validate_image_feature_set(features: &HashSet<ImageFeature>) -> Result<()> {
+    // `uefi-secure-boot` relies on the in-tree grub flow (and PCR
+    // predictions reference the PRIVATE partition), so it cannot be
+    // combined with `no-private-partition`.
+    if features.contains(&ImageFeature::UefiSecureBoot)
+        && features.contains(&ImageFeature::NoPrivatePartition)
+    {
+        return error::IncompatibleImageFeaturesSnafu {
+            first: "uefi-secure-boot",
+            second: "no-private-partition",
+        }
+        .fail()?;
+    }
+    // `encrypted-storage` relies on both BOTTLEROCKET-DATA (LUKS device)
+    // and BOTTLEROCKET-PRIVATE (datastore directory + keystore), so it
+    // cannot be combined with the partition-omitting features.
+    if features.contains(&ImageFeature::EncryptedStorage)
+        && features.contains(&ImageFeature::NoDataPartitions)
+    {
+        return error::IncompatibleImageFeaturesSnafu {
+            first: "encrypted-storage",
+            second: "no-data-partitions",
+        }
+        .fail()?;
+    }
+    if features.contains(&ImageFeature::EncryptedStorage)
+        && features.contains(&ImageFeature::NoPrivatePartition)
+    {
+        return error::IncompatibleImageFeaturesSnafu {
+            first: "encrypted-storage",
+            second: "no-private-partition",
+        }
+        .fail()?;
+    }
+    Ok(())
+}
 
 impl TryFrom<String> for ImageFeature {
     type Error = Error;
@@ -872,6 +974,8 @@ impl TryFrom<String> for ImageFeature {
             "host-containers" => Ok(ImageFeature::HostContainers),
             "external-kmod-development" => Ok(ImageFeature::ExternalKmodDevelopment),
             "encrypted-storage" => Ok(ImageFeature::EncryptedStorage),
+            "no-data-partitions" => Ok(ImageFeature::NoDataPartitions),
+            "no-private-partition" => Ok(ImageFeature::NoPrivatePartition),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -890,6 +994,8 @@ impl fmt::Display for ImageFeature {
             ImageFeature::HostContainers => write!(f, "HOST_CONTAINERS"),
             ImageFeature::ExternalKmodDevelopment => write!(f, "EXTERNAL_KMOD_DEVELOPMENT"),
             ImageFeature::EncryptedStorage => write!(f, "ENCRYPTED_STORAGE"),
+            ImageFeature::NoDataPartitions => write!(f, "NO_DATA_PARTITIONS"),
+            ImageFeature::NoPrivatePartition => write!(f, "NO_PRIVATE_PARTITION"),
         }
     }
 }
@@ -1032,5 +1138,98 @@ mod test {
             "extra-3-kit".to_string(),
         ];
         assert_eq!(kit_list, expected);
+    }
+
+    fn feature_set<I: IntoIterator<Item = ImageFeature>>(features: I) -> HashSet<ImageFeature> {
+        features.into_iter().collect()
+    }
+
+    #[test]
+    fn validate_image_features_accepts_empty_set() {
+        validate_image_feature_set(&HashSet::new()).expect("empty feature set must be valid");
+    }
+
+    #[test]
+    fn validate_image_features_accepts_default_runtime_features() {
+        // The implicit defaults injected by `ManifestInfo::image_features()`
+        // must always validate cleanly.
+        let features = feature_set([
+            ImageFeature::InPlaceUpdates,
+            ImageFeature::HostContainers,
+            ImageFeature::ExternalKmodDevelopment,
+        ]);
+        validate_image_feature_set(&features).expect("default features must be valid");
+    }
+
+    #[test]
+    fn validate_image_features_accepts_uefi_with_no_data_partitions() {
+        // `uefi-secure-boot` × `no-data-partitions` is intentionally allowed:
+        // PCR predictions don't reference BOTTLEROCKET-DATA.
+        let features = feature_set([ImageFeature::UefiSecureBoot, ImageFeature::NoDataPartitions]);
+        validate_image_feature_set(&features)
+            .expect("uefi-secure-boot is compatible with no-data-partitions");
+    }
+
+    #[test]
+    fn validate_image_features_rejects_uefi_with_no_private_partition() {
+        let features = feature_set([
+            ImageFeature::UefiSecureBoot,
+            ImageFeature::NoPrivatePartition,
+        ]);
+        let err = validate_image_feature_set(&features)
+            .expect_err("uefi-secure-boot × no-private-partition must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("uefi-secure-boot"), "error message: {msg}");
+        assert!(msg.contains("no-private-partition"), "error message: {msg}");
+    }
+
+    #[test]
+    fn validate_image_features_rejects_encrypted_storage_with_no_data_partitions() {
+        let features = feature_set([
+            ImageFeature::EncryptedStorage,
+            ImageFeature::NoDataPartitions,
+        ]);
+        let err = validate_image_feature_set(&features)
+            .expect_err("encrypted-storage × no-data-partitions must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("encrypted-storage"), "error message: {msg}");
+        assert!(msg.contains("no-data-partitions"), "error message: {msg}");
+    }
+
+    #[test]
+    fn validate_image_features_rejects_encrypted_storage_with_no_private_partition() {
+        let features = feature_set([
+            ImageFeature::EncryptedStorage,
+            ImageFeature::NoPrivatePartition,
+        ]);
+        let err = validate_image_feature_set(&features)
+            .expect_err("encrypted-storage × no-private-partition must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("encrypted-storage"), "error message: {msg}");
+        assert!(msg.contains("no-private-partition"), "error message: {msg}");
+    }
+
+    #[test]
+    fn validate_image_features_rejects_all_three_partition_omitting_combo() {
+        // The "user accidentally enables every dangerous flag at once" case.
+        // The validator should reject it eagerly with a single clear message
+        // (rather than letting RPM dependency-resolution noise leak through).
+        let features = feature_set([
+            ImageFeature::EncryptedStorage,
+            ImageFeature::NoDataPartitions,
+            ImageFeature::NoPrivatePartition,
+        ]);
+        validate_image_feature_set(&features)
+            .expect_err("encrypted-storage with both partition-omitting features must fail");
+    }
+
+    #[test]
+    fn validate_image_features_accepts_no_data_and_no_private_without_encrypted_storage() {
+        let features = feature_set([
+            ImageFeature::NoDataPartitions,
+            ImageFeature::NoPrivatePartition,
+        ]);
+        validate_image_feature_set(&features)
+            .expect("partition-omitting features alone must be valid");
     }
 }

--- a/tools/buildsys/src/manifest/error.rs
+++ b/tools/buildsys/src/manifest/error.rs
@@ -43,6 +43,13 @@ pub(super) enum Error {
     ParseImageFeature { what: String },
 
     #[snafu(display(
+        "Image feature '{}' is incompatible with image feature '{}'",
+        first,
+        second
+    ))]
+    IncompatibleImageFeatures { first: String, second: String },
+
+    #[snafu(display(
         "The cargo package we are building, '{name}', could not be found in the graph"
     ))]
     RootDependencyMissing { name: String },

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -229,6 +229,8 @@ ARG HOST_CONTAINERS
 ARG FIPS
 ARG EXTERNAL_KMOD_DEVELOPMENT
 ARG ENCRYPTED_STORAGE
+ARG NO_DATA_PARTITIONS
+ARG NO_PRIVATE_PARTITION
 
 USER builder
 WORKDIR /home/builder
@@ -252,7 +254,9 @@ RUN \
    && echo -e -n "${IN_PLACE_UPDATES:+%bcond_without in_place_updates\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${HOST_CONTAINERS:+%bcond_without host_containers\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${EXTERNAL_KMOD_DEVELOPMENT:+%bcond_without external_kmod_development\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${ENCRYPTED_STORAGE:+%bcond_without encrypted_storage\n}" >> "${RPM_BCONDS}"
+   && echo -e -n "${ENCRYPTED_STORAGE:+%bcond_without encrypted_storage\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${NO_DATA_PARTITIONS:+%bcond_without no_data_partitions\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${NO_PRIVATE_PARTITION:+%bcond_without no_private_partition\n}" >> "${RPM_BCONDS}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an RPM repository from packages created in Section 1 and kits from Section 2.
@@ -364,6 +368,8 @@ ARG EROFS_ROOT_PARTITION
 ARG UEFI_SECURE_BOOT
 ARG IN_PLACE_UPDATES
 ARG ENCRYPTED_STORAGE
+ARG NO_DATA_PARTITIONS
+ARG NO_PRIVATE_PARTITION
 ARG PROJECT_VENDOR
 ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
@@ -407,7 +413,9 @@ RUN --mount=target=/host \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
       ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
-      ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} && \
+      ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} \
+      ${NO_DATA_PARTITIONS:+--with-no-data-partitions=yes} \
+      ${NO_PRIVATE_PARTITION:+--with-no-private-partition=yes} && \
     rm -rf /local/rpms && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
@@ -527,6 +535,8 @@ ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG UEFI_SECURE_BOOT
 ARG EROFS_ROOT_PARTITION
 ARG IN_PLACE_UPDATES
+ARG NO_DATA_PARTITIONS
+ARG NO_PRIVATE_PARTITION
 ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 WORKDIR /root
@@ -564,7 +574,9 @@ RUN --mount=target=/host \
       --ovf-template="/bypass/variants/${VARIANT_NAME}/template.ovf" \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
-      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} && \
+      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
+      ${NO_DATA_PARTITIONS:+--with-no-data-partitions=yes} \
+      ${NO_PRIVATE_PARTITION:+--with-no-private-partition=yes} && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
     rm /bypass && \

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -9,6 +9,8 @@ OVF_TEMPLATE=""
 EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
+NO_DATA_PARTITIONS="no"
+NO_PRIVATE_PARTITION="no"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -25,6 +27,8 @@ for opt in "$@"; do
   --with-erofs-root-partition=*) EROFS_ROOT_PARTITION="${optarg}" ;;
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
+  --with-no-data-partitions=*) NO_DATA_PARTITIONS="${optarg}" ;;
+  --with-no-private-partition=*) NO_PRIVATE_PARTITION="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -66,6 +70,16 @@ check_debugfs_errors() {
 sanity_checks \
   "${OUTPUT_FMT}" "${PARTITION_PLAN}" "${OVF_TEMPLATE}" "${UEFI_SECURE_BOOT}"
 
+# Fail fast on unsupported flag combinations. UEFI Secure Boot relies on the
+# in-tree grub flow (and PCR predictions reference the PRIVATE partition), so
+# it cannot be combined with `no-private-partition`. The same combinations
+# are rejected up-front by `buildsys`'s manifest validator and by `rpm2img`,
+# but img2img can be invoked independently so we re-check here.
+if [[ "${NO_PRIVATE_PARTITION}" == "yes" && "${UEFI_SECURE_BOOT}" == "yes" ]]; then
+  echo "no-private-partition is incompatible with uefi-secure-boot" >&2
+  exit 1
+fi
+
 ###############################################################################
 # Section 1: prepare working environment
 
@@ -91,7 +105,8 @@ declare -A partsize partoff
 set_partition_sizes \
   "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
   "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
-  partsize partoff
+  partsize partoff \
+  "${NO_PRIVATE_PARTITION}" "${NO_DATA_PARTITIONS}"
 
 # Process and stage the input images to the working directory.
 declare OS_IMAGE DATA_IMAGE

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -66,6 +66,18 @@ Provides: %{_cross_os}image-feature(encrypted-storage)
 Provides: %{_cross_os}image-feature(no-encrypted-storage)
 %endif
 
+%if %{with no_data_partitions}
+Provides: %{_cross_os}image-feature(no-data-partitions)
+%else
+Provides: %{_cross_os}image-feature(data-partitions)
+%endif
+
+%if %{with no_private_partition}
+Provides: %{_cross_os}image-feature(no-private-partition)
+%else
+Provides: %{_cross_os}image-feature(private-partition)
+%endif
+
 %description
 %{summary}.
 

--- a/twoliter/embedded/partyplanner
+++ b/twoliter/embedded/partyplanner
@@ -192,6 +192,7 @@ get_partition_sizes() {
 # Populate the caller's tables with sizes and offsets for known partitions.
 set_partition_sizes() {
   local os_image_gib data_image_gib partition_plan in_place_updates
+  local no_private_partition no_data_partitions
   local -n pp_size pp_offset
   os_image_gib="${1:?}"
   data_image_gib="${2:?}"
@@ -211,8 +212,18 @@ set_partition_sizes() {
   # Table for partition offsets from start of disk, in MiB.
   pp_offset="${6:?}"
 
+  # Optional: skip allocating the BOTTLEROCKET-PRIVATE partition. Reclaimed
+  # space is folded into the trailing RESERVED partition so existing OS
+  # partition offsets are preserved.
+  no_private_partition="${7:-no}"
+
+  # Optional: skip allocating BOTTLEROCKET-DATA-A (and DATA-B for split). On
+  # unified, the data region at the end of the disk is dropped entirely. On
+  # split, the data image is not partitioned at all.
+  no_data_partitions="${8:-no}"
+
   # Most of the partitions on the main image scale with the overall size.
-  local boot_mib root_mib hash_mib reserved_mib private_mib
+  local boot_mib root_mib hash_mib reserved_mib private_mib data_a_mib
   boot_mib="$((os_image_gib * BOOT_SCALE_FACTOR))"
   root_mib="$((os_image_gib * ROOT_SCALE_FACTOR))"
   hash_mib="$((os_image_gib * HASH_SCALE_FACTOR))"
@@ -224,7 +235,36 @@ set_partition_sizes() {
   # Private space scales per GiB, minus the BIOS and GPT partition overhead.
   private_mib=$((os_image_gib * PRIVATE_SCALE_FACTOR - OVERHEAD_MIB))
   # We need 1 MiB of space for data partition A.
-  private_mib=$((private_mib - DATA_A_MIB))
+  data_a_mib="${DATA_A_MIB}"
+  private_mib=$((private_mib - data_a_mib))
+
+  # If the data partitions are disabled, the 1 MiB nominally reserved for
+  # DATA-A on the OS image is reclaimed by the trailing partition. For unified
+  # plans we skip it entirely (the disk shrinks); for split plans the DATA-A
+  # slot is folded into PRIVATE (or, below, into RESERVED if PRIVATE is also
+  # disabled) so the GPT footer stays correctly placed.
+  if [[ "${no_data_partitions}" == "yes" ]]; then
+    if [[ "${no_private_partition}" != "yes" ]]; then
+      private_mib=$((private_mib + data_a_mib))
+      data_a_mib=0
+    fi
+    # If both flags are set, data_a_mib is folded into RESERVED below.
+  fi
+
+  # If the private partition is disabled, fold its space into the trailing
+  # reserved partition of the last bank so that the OS partitions keep their
+  # offsets and the disk size stays the same. When DATA-A is also disabled
+  # (split plan), fold its MiB into RESERVED as well so no gap remains before
+  # the GPT footer.
+  local extra_reserved_mib=0
+  if [[ "${no_private_partition}" == "yes" ]]; then
+    extra_reserved_mib="${private_mib}"
+    private_mib=0
+    if [[ "${no_data_partitions}" == "yes" ]]; then
+      extra_reserved_mib=$((extra_reserved_mib + data_a_mib))
+      data_a_mib=0
+    fi
+  fi
 
   # Skip the GPT label at start of disk.
   local offset
@@ -254,8 +294,15 @@ set_partition_sizes() {
       ((offset += hash_mib))
 
       pp_offset["RESERVED-${bank}"]="${offset}"
-      pp_size["RESERVED-${bank}"]="${reserved_mib}"
-      ((offset += reserved_mib))
+      # The last bank's RESERVED partition absorbs any space reclaimed from a
+      # disabled PRIVATE partition so that the OS image size is unchanged.
+      if [[ "${bank}" == "B" ]]; then
+        pp_size["RESERVED-${bank}"]="$((reserved_mib + extra_reserved_mib))"
+        ((offset += reserved_mib + extra_reserved_mib))
+      else
+        pp_size["RESERVED-${bank}"]="${reserved_mib}"
+        ((offset += reserved_mib))
+      fi
     done
   else
     # Allocate a single partition bank, where each partition is twice as large.
@@ -276,32 +323,41 @@ set_partition_sizes() {
     ((offset += hash_mib * 2))
 
     pp_offset["RESERVED-A"]="${offset}"
-    pp_size["RESERVED-A"]="$(( reserved_mib * 2 ))"
-    ((offset += reserved_mib * 2))
+    # The single-bank RESERVED partition absorbs any space reclaimed from a
+    # disabled PRIVATE partition so that the OS image size is unchanged.
+    pp_size["RESERVED-A"]="$(( reserved_mib * 2 + extra_reserved_mib ))"
+    ((offset += reserved_mib * 2 + extra_reserved_mib))
   fi
 
-  pp_offset["PRIVATE"]="${offset}"
-  pp_size["PRIVATE"]="${private_mib}"
-  ((offset += private_mib))
+  # Allocate PRIVATE only when it is enabled.
+  if [[ "${no_private_partition}" != "yes" ]]; then
+    pp_offset["PRIVATE"]="${offset}"
+    pp_size["PRIVATE"]="${private_mib}"
+    ((offset += private_mib))
+  fi
 
   case "${partition_plan}" in
   split)
-    # For data partition A that lives on the OS image
-    pp_offset["DATA-A"]="${offset}"
-    pp_size["DATA-A"]="${DATA_A_MIB}"
-    ((offset += DATA_A_MIB))
+    if [[ "${no_data_partitions}" != "yes" ]]; then
+      # For data partition A that lives on the OS image
+      pp_offset["DATA-A"]="${offset}"
+      pp_size["DATA-A"]="${data_a_mib}"
+      ((offset += data_a_mib))
 
-    # For a split data image, the first and last MiB are reserved for the GPT
-    # labels, and the rest is for data partition B.
-    pp_size["DATA-B"]="$((data_image_gib * 1024 - GPT_MIB * 2))"
-    pp_offset["DATA-B"]="1"
+      # For a split data image, the first and last MiB are reserved for the GPT
+      # labels, and the rest is for data partition B.
+      pp_size["DATA-B"]="$((data_image_gib * 1024 - GPT_MIB * 2))"
+      pp_offset["DATA-B"]="1"
+    fi
     ;;
   unified)
-    # For a unified image, we've already accounted for the GPT label space in
-    # the earlier calculations, so all the space is for the data partition.
-    pp_size["DATA-A"]="$((data_image_gib * 1024))"
-    pp_offset["DATA-A"]="${offset}"
-    ((offset += data_image_gib * 1024))
+    if [[ "${no_data_partitions}" != "yes" ]]; then
+      # For a unified image, we've already accounted for the GPT label space in
+      # the earlier calculations, so all the space is for the data partition.
+      pp_size["DATA-A"]="$((data_image_gib * 1024))"
+      pp_offset["DATA-A"]="${offset}"
+      ((offset += data_image_gib * 1024))
+    fi
     ;;
   *)
     echo "unknown partition plan '${partition_plan}'" >&2

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -11,6 +11,8 @@ EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
 ENCRYPTED_STORAGE="no"
+NO_DATA_PARTITIONS="no"
+NO_PRIVATE_PARTITION="no"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -30,6 +32,8 @@ for opt in "$@"; do
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   --with-encrypted-storage=*) ENCRYPTED_STORAGE="${optarg}" ;;
+  --with-no-data-partitions=*) NO_DATA_PARTITIONS="${optarg}" ;;
+  --with-no-private-partition=*) NO_PRIVATE_PARTITION="${optarg}" ;;
   --sbom-package-dir=*) SBOM_PACKAGE_DIR="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
@@ -48,6 +52,26 @@ done
 
 sanity_checks \
   "${OUTPUT_FMT}" "${PARTITION_PLAN}" "${OVF_TEMPLATE}" "${UEFI_SECURE_BOOT}" "${SBOM_PACKAGE_DIR}"
+
+# Fail fast on unsupported flag combinations. UEFI Secure Boot relies on the
+# in-tree grub flow (and PCR predictions reference the PRIVATE partition), so
+# it cannot be combined with `no-private-partition`.
+if [[ "${NO_PRIVATE_PARTITION}" == "yes" && "${UEFI_SECURE_BOOT}" == "yes" ]]; then
+  echo "no-private-partition is incompatible with uefi-secure-boot" >&2
+  exit 1
+fi
+
+# `encrypted-storage` requires both BOTTLEROCKET-DATA (LUKS device) and
+# BOTTLEROCKET-PRIVATE (datastore directory + keystore), so it cannot be
+# combined with the partition-omitting features.
+if [[ "${ENCRYPTED_STORAGE}" == "yes" && "${NO_DATA_PARTITIONS}" == "yes" ]]; then
+  echo "encrypted-storage is incompatible with no-data-partitions" >&2
+  exit 1
+fi
+if [[ "${ENCRYPTED_STORAGE}" == "yes" && "${NO_PRIVATE_PARTITION}" == "yes" ]]; then
+  echo "encrypted-storage is incompatible with no-private-partition" >&2
+  exit 1
+fi
 
 # Store output artifacts in a versioned directory.
 OUTPUT_DIR="${OUTPUT_DIR}/${VERSION_ID}-${BUILD_ID}"
@@ -90,10 +114,17 @@ ROOT_STRIPE_WIDTH=1024
 case "${PARTITION_PLAN}" in
 split)
   truncate -s "${OS_IMAGE_SIZE_GIB}G" "${OS_IMAGE}"
-  truncate -s "${DATA_IMAGE_SIZE_GIB}G" "${DATA_IMAGE}"
+  if [[ "${NO_DATA_PARTITIONS}" != "yes" ]]; then
+    truncate -s "${DATA_IMAGE_SIZE_GIB}G" "${DATA_IMAGE}"
+  fi
   ;;
 unified)
-  truncate -s "$((OS_IMAGE_SIZE_GIB + DATA_IMAGE_SIZE_GIB))G" "${OS_IMAGE}"
+  if [[ "${NO_DATA_PARTITIONS}" == "yes" ]]; then
+    # No data partition means the unified disk only needs to hold the OS.
+    truncate -s "${OS_IMAGE_SIZE_GIB}G" "${OS_IMAGE}"
+  else
+    truncate -s "$((OS_IMAGE_SIZE_GIB + DATA_IMAGE_SIZE_GIB))G" "${OS_IMAGE}"
+  fi
   ;;
 *)
   echo "unexpected partition plan '${PARTITION_PLAN}'" >&2
@@ -105,7 +136,8 @@ declare -A partlabel parttype partguid partsize partoff
 set_partition_sizes \
   "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
   "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
-  partsize partoff
+  partsize partoff \
+  "${NO_PRIVATE_PARTITION}" "${NO_DATA_PARTITIONS}"
 set_partition_labels partlabel
 set_partition_types parttype
 set_partition_uuids partguid "${PARTITION_PLAN}"
@@ -116,7 +148,12 @@ partitions+=(EFI-A BOOT-A ROOT-A HASH-A RESERVED-A)
 if [[ "${IN_PLACE_UPDATES}" == "yes" ]]; then
   partitions+=(EFI-B BOOT-B ROOT-B HASH-B RESERVED-B)
 fi
-partitions+=(PRIVATE DATA-A DATA-B)
+if [[ "${NO_PRIVATE_PARTITION}" != "yes" ]]; then
+  partitions+=(PRIVATE)
+fi
+if [[ "${NO_DATA_PARTITIONS}" != "yes" ]]; then
+  partitions+=(DATA-A DATA-B)
+fi
 
 declare -a partargs
 for part in "${partitions[@]}"; do
@@ -151,7 +188,7 @@ done
 sgdisk --clear "${partargs[@]}" --sort --print "${OS_IMAGE}"
 
 # Partition the separate data disk, if we're using the split layout.
-if [[ "${PARTITION_PLAN}" == "split" ]]; then
+if [[ "${PARTITION_PLAN}" == "split" && "${NO_DATA_PARTITIONS}" != "yes" ]]; then
   data_start="${partoff["DATA-B"]}"
   data_end=$((data_start + partsize["DATA-A"]))
   data_end=$((data_end * 2048 - 1))
@@ -443,11 +480,16 @@ BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
 DOCUMENTATION_URL="https://bottlerocket.dev"
 EOF
 
-# Set the BOTTLEROCKET-DATA Filesystem for creating/mounting
-if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
-  printf "%s\n" "DATA_PARTITION_FILESYSTEM=xfs" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
-else
-  printf "%s\n" "DATA_PARTITION_FILESYSTEM=ext4" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+# Set the BOTTLEROCKET-DATA Filesystem for creating/mounting.
+# When `no-data-partitions` is set, there is no BOTTLEROCKET-DATA partition,
+# so the filesystem choice is meaningless and the variable is omitted to
+# avoid implying support that doesn't exist.
+if [[ "${NO_DATA_PARTITIONS}" != "yes" ]]; then
+  if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
+    printf "%s\n" "DATA_PARTITION_FILESYSTEM=xfs" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+  else
+    printf "%s\n" "DATA_PARTITION_FILESYSTEM=ext4" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+  fi
 fi
 
 # Set in-place updates flag
@@ -462,6 +504,20 @@ if [[ "${ENCRYPTED_STORAGE}" == "yes" ]]; then
   printf "%s\n" "ENCRYPTED_STORAGE=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 else
   printf "%s\n" "ENCRYPTED_STORAGE=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+fi
+
+# Set no-data-partitions flag
+if [[ "${NO_DATA_PARTITIONS}" == "yes" ]]; then
+  printf "%s\n" "NO_DATA_PARTITIONS=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+else
+  printf "%s\n" "NO_DATA_PARTITIONS=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+fi
+
+# Set no-private-partition flag
+if [[ "${NO_PRIVATE_PARTITION}" == "yes" ]]; then
+  printf "%s\n" "NO_PRIVATE_PARTITION=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+else
+  printf "%s\n" "NO_PRIVATE_PARTITION=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 fi
 
 # BOTTLEROCKET-ROOT-A
@@ -583,17 +639,19 @@ echo "${root_usage}" "${boot_usage}" | jq -s 'add | {disk_usage: .}' > "${OUTPUT
 
 # BOTTLEROCKET-PRIVATE
 
-# Generate bootconfig file for the image.
-touch "${PRIVATE_MOUNT}/bootconfig.data"
-bootconfig -a "${BOOTCONFIG_INPUT}" "${PRIVATE_MOUNT}/bootconfig.data"
+if [[ "${NO_PRIVATE_PARTITION}" != "yes" ]]; then
+  # Generate bootconfig file for the image.
+  touch "${PRIVATE_MOUNT}/bootconfig.data"
+  bootconfig -a "${BOOTCONFIG_INPUT}" "${PRIVATE_MOUNT}/bootconfig.data"
 
-# Targeted toward the current API server implementation.
-# Relative to the ext4 defaults, we:
-# - adjust the inode ratio since we expect lots of small files
-# - retain the inode size to allow most settings to be stored inline
-# - retain the block size to handle worse-case alignment for hardware
-mkfs.ext4 -b 4096 -i 4096 -I 256 -d "${PRIVATE_MOUNT}" "${PRIVATE_IMAGE}" "${partsize[PRIVATE]}M"
-dd if="${PRIVATE_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRIVATE]}"
+  # Targeted toward the current API server implementation.
+  # Relative to the ext4 defaults, we:
+  # - adjust the inode ratio since we expect lots of small files
+  # - retain the inode size to allow most settings to be stored inline
+  # - retain the block size to handle worse-case alignment for hardware
+  mkfs.ext4 -b 4096 -i 4096 -I 256 -d "${PRIVATE_MOUNT}" "${PRIVATE_IMAGE}" "${partsize[PRIVATE]}M"
+  dd if="${PRIVATE_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRIVATE]}"
+fi
 
 # Predict PCR values after all partitions are written.
 if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
@@ -624,26 +682,28 @@ UNLABELED=$(find "${DATA_MOUNT}" |
 #
 # If the other partition is available at runtime, the filesystem will be created
 # during first boot instead, providing flexibility at the cost of a minor delay.
-if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
-  mkfs_data_fn="mkfs_data_xfs"
-else
-  mkfs_data_fn="mkfs_data_ext4"
-fi
+if [[ "${NO_DATA_PARTITIONS}" != "yes" ]]; then
+  if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
+    mkfs_data_fn="mkfs_data_xfs"
+  else
+    mkfs_data_fn="mkfs_data_ext4"
+  fi
 
-case "${PARTITION_PLAN}" in
-unified)
-  "${mkfs_data_fn}" "${OS_IMAGE}" "${partsize["DATA-A"]}M" "${partoff["DATA-A"]}" \
-    "${BOTTLEROCKET_DATA}" "${DATA_MOUNT}" "${UNLABELED}"
-  ;;
-split)
-  "${mkfs_data_fn}" "${DATA_IMAGE}" "${partsize["DATA-B"]}M" "${partoff["DATA-B"]}" \
-    "${BOTTLEROCKET_DATA}" "${DATA_MOUNT}" "${UNLABELED}"
-  ;;
-*)
-  echo "unexpected partition plan '${PARTITION_PLAN}'" >&2
-  exit 1
-  ;;
-esac
+  case "${PARTITION_PLAN}" in
+  unified)
+    "${mkfs_data_fn}" "${OS_IMAGE}" "${partsize["DATA-A"]}M" "${partoff["DATA-A"]}" \
+      "${BOTTLEROCKET_DATA}" "${DATA_MOUNT}" "${UNLABELED}"
+    ;;
+  split)
+    "${mkfs_data_fn}" "${DATA_IMAGE}" "${partsize["DATA-B"]}M" "${partoff["DATA-B"]}" \
+      "${BOTTLEROCKET_DATA}" "${DATA_MOUNT}" "${UNLABELED}"
+    ;;
+  *)
+    echo "unexpected partition plan '${PARTITION_PLAN}'" >&2
+    exit 1
+    ;;
+  esac
+fi
 
 sgdisk -v "${OS_IMAGE}"
 [[ -s "${DATA_IMAGE}" ]] && sgdisk -v "${DATA_IMAGE}"


### PR DESCRIPTION
Introduce two opt-in image features for advanced callers (e.g. EIF/Firecracker) that supply data persistence and/or an external bootloader:

- no-data-partitions: skips mkfs/dd for BOTTLEROCKET-DATA-{A,B} and suppresses the separate data-image artifact for the split partition plan. Partition layout is unchanged.
- no-private-partition: skips bootconfig generation and mkfs/dd for BOTTLEROCKET-PRIVATE. Incompatible with uefi-secure-boot (enforced with a fast-fail in rpm2img).

Both default to false, preserving existing behavior. Plumb the flags through manifest.rs (enum + TryFrom + Display), build.Dockerfile (ARG + forwarded --with-* flags), and rpm2img (option parsing + gated blocks).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
