### PR TITLE
feat(buildsys): add first-party-stack image feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* New `first-party-stack` image feature (default `true`): controls whether the
+  Bottlerocket-provided software stack (orchestrator integration, settings
+  system, in-place updates, BOTTLEROCKET-PRIVATE / BOTTLEROCKET-DATA partitions)
+  is built into the image. Setting `first-party-stack = false` produces a
+  stripped-down OS image with a single bank of partitions (BIOS-BOOT,
+  EFI-SYSTEM, BOOT-A, ROOT-A, HASH-A), no RESERVED, PRIVATE, or DATA
+  partitions, defaulting to a 1 GiB total disk size. Requires
+  `partition-plan = "unified"`, and is incompatible with `uefi-secure-boot`,
+  `encrypted-storage`, `in-place-updates`, `host-containers`, and
+  `partition-plan = "split"`; the build fails fast with a clear message in
+  those cases. The metadata RPM provides
+  `image-feature(first-party-stack)` or `image-feature(no-first-party-stack)`
+  accordingly.
+
 [unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.20.0...HEAD
 
 ## [0.20.0] - 2026-05-27

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -9,8 +9,8 @@ pub(crate) mod error;
 use crate::args::{BuildKitArgs, BuildPackageArgs, BuildVariantArgs, RepackVariantArgs};
 use bottlerocket_variant::Variant;
 use buildsys::manifest::{
-    ExternalKitMetadataView, ImageFeature, ImageFormat, ImageLayout, Manifest, PartitionPlan,
-    SupportedArch,
+    resolved_image_layout, validate_image_features, ExternalKitMetadataView, ImageFeature,
+    ImageFormat, Manifest, PartitionPlan, SupportedArch,
 };
 use buildsys::BuildType;
 use buildsys_config::EXTERNAL_KIT_METADATA;
@@ -266,7 +266,16 @@ impl VariantBuildArgs {
         args.build_arg("VERSION_ID", &self.version_image);
 
         for image_feature in self.image_features.iter() {
-            args.build_arg(format!("{image_feature}"), "1");
+            // `first-party-stack` is the inverted, default-true feature: pass
+            // `yes` to bash so the Dockerfile can pipe the value through to
+            // `--with-first-party-stack=`. All other features stay on the
+            // simple `1`-presence convention.
+            let value = if matches!(image_feature, ImageFeature::FirstPartyStack) {
+                "yes"
+            } else {
+                "1"
+            };
+            args.build_arg(format!("{image_feature}"), value);
         }
 
         args
@@ -311,7 +320,12 @@ impl RepackVariantBuildArgs {
         args.build_arg("VERSION_ID", &self.version_image);
 
         for image_feature in self.image_features.iter() {
-            args.build_arg(format!("{image_feature}"), "1");
+            let value = if matches!(image_feature, ImageFeature::FirstPartyStack) {
+                "yes"
+            } else {
+                "1"
+            };
+            args.build_arg(format!("{image_feature}"), value);
         }
 
         args
@@ -435,13 +449,16 @@ impl DockerBuild {
 
     /// Create a new `DockerBuild` that can build a variant image.
     pub(crate) fn new_variant(args: BuildVariantArgs, manifest: &Manifest) -> Result<Self> {
-        let image_layout = manifest.info().image_layout().cloned().unwrap_or_default();
-        let ImageLayout {
-            os_image_size_gib,
-            data_image_size_gib,
-            partition_plan,
-            ..
-        } = image_layout;
+        let raw_layout = manifest.info().image_layout().cloned().unwrap_or_default();
+        let features = manifest.info().image_features().unwrap_or_default();
+        let image_layout = resolved_image_layout(&raw_layout, &features);
+        // Defense in depth: re-run the image feature validator here so that
+        // any future code path that constructs a `DockerBuild` cannot bypass
+        // the gate that `main.rs::validate_first_party_stack_or_warn` provides.
+        validate_image_features(&features, &image_layout).context(error::GraphSnafu)?;
+        let os_image_size_gib = image_layout.os_image_size_gib();
+        let data_image_size_gib = image_layout.data_image_size_gib;
+        let partition_plan = image_layout.partition_plan;
 
         let (os_image_publish_size_gib, data_image_publish_size_gib) =
             image_layout.publish_image_sizes_gib();
@@ -533,13 +550,16 @@ impl DockerBuild {
 
     /// Create a new `DockerBuild` that can repackage a variant image.
     pub(crate) fn repack_variant(args: RepackVariantArgs, manifest: &Manifest) -> Result<Self> {
-        let image_layout = manifest.info().image_layout().cloned().unwrap_or_default();
-        let ImageLayout {
-            os_image_size_gib,
-            data_image_size_gib,
-            partition_plan,
-            ..
-        } = image_layout;
+        let raw_layout = manifest.info().image_layout().cloned().unwrap_or_default();
+        let features = manifest.info().image_features().unwrap_or_default();
+        let image_layout = resolved_image_layout(&raw_layout, &features);
+        // Defense in depth: re-run the image feature validator here so that
+        // any future code path that constructs a `DockerBuild` cannot bypass
+        // the gate that `main.rs::validate_first_party_stack_or_warn` provides.
+        validate_image_features(&features, &image_layout).context(error::GraphSnafu)?;
+        let os_image_size_gib = image_layout.os_image_size_gib();
+        let data_image_size_gib = image_layout.data_image_size_gib;
+        let partition_plan = image_layout.partition_plan;
 
         let (os_image_publish_size_gib, data_image_publish_size_gib) =
             image_layout.publish_image_sizes_gib();

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -19,7 +19,10 @@ use crate::args::{
     BuildKitArgs, BuildPackageArgs, BuildVariantArgs, Buildsys, Command, RepackVariantArgs,
 };
 use crate::builder::DockerBuild;
-use buildsys::manifest::{BundleModule, Manifest, ManifestInfo, SupportedArch};
+use buildsys::manifest::{
+    resolved_image_layout, validate_image_features, BundleModule, ImageFeature, Manifest,
+    ManifestInfo, SupportedArch,
+};
 use buildsys_config::EXTERNAL_KIT_METADATA;
 use cache::LookasideCache;
 use clap::Parser;
@@ -40,6 +43,9 @@ mod error {
     pub(super) enum Error {
         #[snafu(display("{source}"))]
         ManifestParse { source: buildsys::manifest::Error },
+
+        #[snafu(display("invalid image-feature combination: {source}"))]
+        ImageFeatures { source: buildsys::manifest::Error },
 
         #[snafu(display("{source}"))]
         SpecParse { source: super::spec::error::Error },
@@ -246,6 +252,7 @@ fn build_variant(args: BuildVariantArgs) -> Result<()> {
     .context(error::ManifestParseSnafu)?;
 
     check_arch_support(manifest.info(), args.common.arch);
+    validate_first_party_stack_or_warn(manifest.info())?;
 
     if args.common.cicd_hack {
         return Ok(());
@@ -267,6 +274,7 @@ fn repack_variant(args: RepackVariantArgs) -> Result<()> {
     .context(error::ManifestParseSnafu)?;
 
     check_arch_support(manifest.info(), args.common.arch);
+    validate_first_party_stack_or_warn(manifest.info())?;
 
     if args.common.cicd_hack {
         return Ok(());
@@ -290,6 +298,34 @@ fn check_arch_support(manifest: &ManifestInfo, arch: SupportedArch) {
             std::process::exit(0);
         }
     }
+}
+
+/// Re-validate image features against the resolved image layout, and emit a
+/// multi-line warning when `first-party-stack = false` so that build logs
+/// make the implications obvious.
+fn validate_first_party_stack_or_warn(manifest: &ManifestInfo) -> Result<()> {
+    let features = manifest.image_features().unwrap_or_default();
+    let raw_layout = manifest.image_layout().cloned().unwrap_or_default();
+    let layout = resolved_image_layout(&raw_layout, &features);
+    validate_image_features(&features, &layout).context(error::ImageFeaturesSnafu)?;
+
+    if !features.contains(&ImageFeature::FirstPartyStack) {
+        // `cargo:warning` is line-oriented, so emit one line per call.
+        for line in [
+            "WARNING: image feature `first-party-stack` is disabled.",
+            "With `first-party-stack = false`, the resulting image will NOT contain the",
+            "Bottlerocket datastore, settings subsystem, host-containers, or any",
+            "first-party Bottlerocket management software. You are responsible for",
+            "owning all system configuration yourself. The image will not have a",
+            "BOTTLEROCKET-PRIVATE partition or a BOTTLEROCKET-DATA partition. If your",
+            "variant ships components that expect persistent storage at",
+            "partlabel=BOTTLEROCKET-DATA, you may optionally attach such a volume",
+            "at runtime; otherwise no extra volume is required.",
+        ] {
+            println!("cargo:warning={line}");
+        }
+    }
+    Ok(())
 }
 
 /// Prior to the release of Kits as a build feature, packages could, and did, declare themselves

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -254,6 +254,34 @@ only be enabled for variants that can guarantee that a TPM 2.0 device will be pr
 encrypted-storage = true
 ```
 
+`first-party-stack` controls whether the Bottlerocket-provided software stack — the
+orchestrator integration (kubelet, containerd, host-containers, admin-containers), the
+settings system (apiserver, datastore, settings rendering, migrations), in-place updates, and
+the BOTTLEROCKET-PRIVATE / BOTTLEROCKET-DATA partitions — is built into the image. The
+default is `true`.
+
+When `first-party-stack = false`, the image is reduced to the kernel, base userspace,
+dm-verity-protected rootfs, and the update mechanism. The OS image has a single bank of OS
+partitions (BIOS-BOOT, EFI-SYSTEM, BOOT-A, ROOT-A, HASH-A) with no `RESERVED-A` partition;
+ROOT-A absorbs the slack. The default OS image size becomes 1 GiB unless `os-image-size-gib`
+is explicitly set. The variant author owns all system configuration; if Bottlerocket
+components that expect persistent storage at `partlabel=BOTTLEROCKET-DATA` are shipped, such
+a volume may optionally be attached at runtime.
+
+`first-party-stack = false` requires `partition-plan = "unified"`, and is incompatible with
+`uefi-secure-boot`, `encrypted-storage`, `in-place-updates`, and `host-containers`; the build
+will fail fast in those cases. Setting `first-party-stack = false` also turns off the silent
+defaults for `in-place-updates` and `host-containers` so that, once `partition-plan = "unified"`
+is set, toggling `first-party-stack = false` is sufficient to produce a stripped-down image.
+
+```ignore
+[package.metadata.build-variant.image-features]
+first-party-stack = false
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+```
+
 */
 
 mod error;
@@ -507,11 +535,27 @@ impl ManifestInfo {
     /// Convenience method to return the enabled image features for this variant.
     pub fn image_features(&self) -> Option<HashSet<ImageFeature>> {
         let variant = self.build_variant()?;
-        let mut features = HashSet::from([
-            ImageFeature::InPlaceUpdates,
-            ImageFeature::HostContainers,
-            ImageFeature::ExternalKmodDevelopment,
-        ]);
+        // If the user explicitly disabled `first-party-stack`, drop the silent
+        // defaults for `in-place-updates` and `host-containers` (and
+        // `first-party-stack` itself). An explicit `in-place-updates = true`
+        // is still rejected later by the validator.
+        let first_party_stack_explicitly_disabled = variant
+            .image_features
+            .as_ref()
+            .and_then(|m| m.get(&ImageFeature::FirstPartyStack))
+            .copied()
+            .map(|enabled| !enabled)
+            .unwrap_or(false);
+        let mut features = if first_party_stack_explicitly_disabled {
+            HashSet::from([ImageFeature::ExternalKmodDevelopment])
+        } else {
+            HashSet::from([
+                ImageFeature::FirstPartyStack,
+                ImageFeature::InPlaceUpdates,
+                ImageFeature::HostContainers,
+                ImageFeature::ExternalKmodDevelopment,
+            ])
+        };
         if let Some(image_features) = &variant.image_features {
             for (feature, enabled) in image_features.iter() {
                 if *enabled {
@@ -738,9 +782,18 @@ impl Display for ImageSize {
 
 #[derive(Deserialize, Debug, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
+/// Image layout settings as deserialized from a variant manifest.
+///
+/// Note: callers should always run the layout through
+/// [`resolved_image_layout`] before using it to drive a build. Other fields
+/// (`data_image_size_gib`, `partition_plan`) remain `pub` for direct access
+/// since they have no feature-dependent default.
 pub struct ImageLayout {
-    #[serde(default = "ImageLayout::default_os_image_size_gib")]
-    pub os_image_size_gib: ImageSize,
+    /// Raw value as it appeared (or did not appear) in the manifest. Use
+    /// [`ImageLayout::os_image_size_gib`] to read the resolved value, which
+    /// substitutes the appropriate default when this is `None`.
+    #[serde(default, rename = "os-image-size-gib")]
+    os_image_size_gib: Option<ImageSize>,
     #[serde(default = "ImageLayout::default_data_image_size_gib")]
     pub data_image_size_gib: ImageSize,
     #[serde(default = "ImageLayout::default_publish_image_size_hint_gib")]
@@ -752,15 +805,14 @@ pub struct ImageLayout {
 /// These are the historical defaults for all variants, before we added support
 /// for customizing these properties.
 static DEFAULT_OS_IMAGE_SIZE_GIB: ImageSize = ImageSize(2);
+/// Default OS image size when `first-party-stack = false` and the manifest
+/// does not specify `os-image-size-gib`.
+static DEFAULT_NO_FIRST_PARTY_OS_IMAGE_SIZE_GIB: ImageSize = ImageSize(1);
 static DEFAULT_DATA_IMAGE_SIZE_GIB: ImageSize = ImageSize(1);
 static DEFAULT_PUBLISH_IMAGE_SIZE_HINT_GIB: ImageSize = ImageSize(22);
 static DEFAULT_PARTITION_PLAN: PartitionPlan = PartitionPlan::Split;
 
 impl ImageLayout {
-    fn default_os_image_size_gib() -> ImageSize {
-        DEFAULT_OS_IMAGE_SIZE_GIB
-    }
-
     fn default_data_image_size_gib() -> ImageSize {
         DEFAULT_DATA_IMAGE_SIZE_GIB
     }
@@ -773,11 +825,22 @@ impl ImageLayout {
         DEFAULT_PARTITION_PLAN
     }
 
+    /// Returns the resolved OS image size. If the manifest did not specify
+    /// `os-image-size-gib`, the historical 2 GiB default is used.
+    pub fn os_image_size_gib(&self) -> ImageSize {
+        self.os_image_size_gib.unwrap_or(DEFAULT_OS_IMAGE_SIZE_GIB)
+    }
+
+    /// Returns whether `os-image-size-gib` was explicitly set in the manifest.
+    pub fn os_image_size_gib_was_set(&self) -> bool {
+        self.os_image_size_gib.is_some()
+    }
+
     // At publish time we will need specific sizes for the OS image and the (optional) data image.
     // The sizes returned by this function depend on the image layout, and whether the publish
     // image hint is larger than the required minimum size.
     pub fn publish_image_sizes_gib(&self) -> (i32, i32) {
-        let os_image_base_size_gib = self.os_image_size_gib.0;
+        let os_image_base_size_gib = self.os_image_size_gib().0;
         let data_image_base_size_gib = self.data_image_size_gib.0;
         let publish_image_size_hint_gib = self.publish_image_size_hint_gib.0;
 
@@ -801,7 +864,7 @@ impl ImageLayout {
 impl Default for ImageLayout {
     fn default() -> Self {
         Self {
-            os_image_size_gib: Self::default_os_image_size_gib(),
+            os_image_size_gib: None,
             data_image_size_gib: Self::default_data_image_size_gib(),
             publish_image_size_hint_gib: Self::default_publish_image_size_hint_gib(),
             partition_plan: Self::default_partition_plan(),
@@ -849,6 +912,7 @@ pub enum ImageFeature {
     HostContainers,
     ExternalKmodDevelopment,
     EncryptedStorage,
+    FirstPartyStack,
 }
 
 const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[&ImageFeature::EncryptedStorage];
@@ -857,6 +921,98 @@ const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
     &ImageFeature::GrubSetPrivateVar,
     &ImageFeature::SystemdNetworkd,
 ];
+
+/// Returns an [`ImageLayout`] with the OS image size adjusted for the given
+/// feature set. If `first-party-stack` is disabled and the manifest did not
+/// explicitly set `os-image-size-gib`, the default OS image size is reduced
+/// from 2 GiB to 1 GiB. All other fields are passed through unchanged.
+pub fn resolved_image_layout(
+    layout: &ImageLayout,
+    features: &HashSet<ImageFeature>,
+) -> ImageLayout {
+    let mut resolved = *layout;
+    if !features.contains(&ImageFeature::FirstPartyStack) && !layout.os_image_size_gib_was_set() {
+        resolved.os_image_size_gib = Some(DEFAULT_NO_FIRST_PARTY_OS_IMAGE_SIZE_GIB);
+    }
+    resolved
+}
+
+/// Validate that the requested image features and layout are compatible.
+///
+/// Currently this enforces that disabling `first-party-stack` is not combined
+/// with any of `uefi-secure-boot`, `encrypted-storage`, `in-place-updates`,
+/// `host-containers`, or with a `split` partition plan.
+///
+/// All discovered conflicts are reported in a single error so that users see
+/// the complete list in one build cycle. The conflict list is iterated in a
+/// fixed order, so the resulting error message is deterministic.
+///
+/// # Internal contract
+///
+/// Callers that pass `features` from [`ManifestInfo::image_features`] and
+/// `layout` from [`resolved_image_layout`] should invoke this function before
+/// constructing any `DockerBuild` or otherwise using those values to drive a
+/// build. Both `DockerBuild::new_variant` and `DockerBuild::repack_variant`
+/// call this internally as defense-in-depth so that adding a new entry point
+/// cannot silently bypass validation.
+pub fn validate_image_features(
+    features: &HashSet<ImageFeature>,
+    layout: &ImageLayout,
+) -> Result<()> {
+    if features.contains(&ImageFeature::FirstPartyStack) {
+        return Ok(());
+    }
+    let conflicts: &[(ImageFeature, &str, &str)] = &[
+        (
+            ImageFeature::UefiSecureBoot,
+            "uefi-secure-boot",
+            "secure boot relies on signed first-party artifacts that are not present when `first-party-stack = false`",
+        ),
+        (
+            ImageFeature::EncryptedStorage,
+            "encrypted-storage",
+            "encrypted storage requires the BOTTLEROCKET-PRIVATE/DATA partitions, which are not built when `first-party-stack = false`",
+        ),
+        (
+            ImageFeature::InPlaceUpdates,
+            "in-place-updates",
+            "in-place updates require two banks of OS partitions, which are not built when `first-party-stack = false`",
+        ),
+        (
+            ImageFeature::HostContainers,
+            "host-containers",
+            "host-containers require the BOTTLEROCKET-DATA partition, which is not built when `first-party-stack = false`",
+        ),
+    ];
+
+    // Collect all conflicts in a deterministic order so the user sees the
+    // complete list in a single build cycle, rather than playing whack-a-mole.
+    // Use the kebab-case manifest key in messages to match the TOML the user
+    // wrote and the error messages produced by the shell-side validators.
+    let mut conflict_messages: Vec<String> = conflicts
+        .iter()
+        .filter(|(feature, _, _)| features.contains(feature))
+        .map(|(_, name, reason)| format!("`{name}`: {reason}"))
+        .collect();
+
+    if matches!(layout.partition_plan, PartitionPlan::Split) {
+        conflict_messages.push(
+            "`partition-plan=split`: when `first-party-stack = false`, the image uses a \
+             single unified disk with no separate data image"
+                .to_string(),
+        );
+    }
+
+    if !conflict_messages.is_empty() {
+        // Render one conflict per line, indented, so the resulting error
+        // message remains readable when several conflicts are reported at
+        // once.
+        let reason = format!("\n  - {}", conflict_messages.join("\n  - "));
+        return error::IncompatibleImageFeaturesSnafu { reason }.fail()?;
+    }
+
+    Ok(())
+}
 
 impl TryFrom<String> for ImageFeature {
     type Error = Error;
@@ -872,11 +1028,35 @@ impl TryFrom<String> for ImageFeature {
             "host-containers" => Ok(ImageFeature::HostContainers),
             "external-kmod-development" => Ok(ImageFeature::ExternalKmodDevelopment),
             "encrypted-storage" => Ok(ImageFeature::EncryptedStorage),
+            "first-party-stack" => Ok(ImageFeature::FirstPartyStack),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
 }
 
+/// String representations of image-feature flags across the toolchain.
+///
+/// A single feature has multiple string representations as it flows through
+/// the build pipeline. Keep these in mind when adding or modifying features:
+///
+/// | Layer                              | Representation       | Example          |
+/// |------------------------------------|----------------------|------------------|
+/// | Rust enum variant                  | UpperCamelCase       | `FirstPartyStack` |
+/// | Manifest TOML key (TryFrom impl)   | kebab-case           | `first-party-stack` |
+/// | Display impl (env var name)        | UPPER_SNAKE_CASE     | `FIRST_PARTY_STACK` |
+/// | Dockerfile `--build-arg` value     | `1` (truthy) or `yes` | `FIRST_PARTY_STACK=yes` |
+/// | Shell script `--with-X=` value     | `yes` / `no`         | `--with-first-party-stack=no` |
+/// | Runtime `image-features.env` value | `true` / `false`     | `FIRST_PARTY_STACK=true` |
+///
+/// Each layer's representation is intentional: the Dockerfile uses `1` so
+/// that bash's `${VAR:+...}` expansion can convert presence to a flag, the
+/// shell scripts use `yes`/`no` to be readable in build logs, and the
+/// runtime env file uses `true`/`false` to be parseable by configuration
+/// loaders. `FirstPartyStack` is the exception: since it is default-true
+/// and inverted, its build-arg is `yes` so the Dockerfile can pipe the
+/// value directly to `--with-first-party-stack=`. See
+/// `tools/buildsys/src/builder.rs`, `twoliter/embedded/build.Dockerfile`,
+/// and `twoliter/embedded/rpm2img` for the conversions between layers.
 impl fmt::Display for ImageFeature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -890,6 +1070,7 @@ impl fmt::Display for ImageFeature {
             ImageFeature::HostContainers => write!(f, "HOST_CONTAINERS"),
             ImageFeature::ExternalKmodDevelopment => write!(f, "EXTERNAL_KMOD_DEVELOPMENT"),
             ImageFeature::EncryptedStorage => write!(f, "ENCRYPTED_STORAGE"),
+            ImageFeature::FirstPartyStack => write!(f, "FIRST_PARTY_STACK"),
         }
     }
 }
@@ -1032,5 +1213,244 @@ mod test {
             "extra-3-kit".to_string(),
         ];
         assert_eq!(kit_list, expected);
+    }
+
+    fn first_party_stack_disabled_layout(os_size: Option<u16>, plan: PartitionPlan) -> ImageLayout {
+        ImageLayout {
+            os_image_size_gib: os_size.map(ImageSize),
+            data_image_size_gib: DEFAULT_DATA_IMAGE_SIZE_GIB,
+            publish_image_size_hint_gib: DEFAULT_PUBLISH_IMAGE_SIZE_HINT_GIB,
+            partition_plan: plan,
+        }
+    }
+
+    #[test]
+    fn first_party_stack_disabled_default_os_size_is_one_gib() {
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        // No FirstPartyStack in the set → stripped image, default 1 GiB.
+        let features: HashSet<ImageFeature> = HashSet::new();
+        let resolved = resolved_image_layout(&layout, &features);
+        assert_eq!(resolved.os_image_size_gib().0, 1);
+    }
+
+    #[test]
+    fn first_party_stack_disabled_respects_explicit_os_size() {
+        let layout = first_party_stack_disabled_layout(Some(4), PartitionPlan::Unified);
+        let features: HashSet<ImageFeature> = HashSet::new();
+        let resolved = resolved_image_layout(&layout, &features);
+        assert_eq!(resolved.os_image_size_gib().0, 4);
+    }
+
+    #[test]
+    fn first_party_stack_default_os_size_is_two_gib() {
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::FirstPartyStack]);
+        let resolved = resolved_image_layout(&layout, &features);
+        assert_eq!(resolved.os_image_size_gib().0, 2);
+    }
+
+    #[test]
+    fn first_party_stack_disabled_alone_passes_validation() {
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        let features: HashSet<ImageFeature> = HashSet::new();
+        validate_image_features(&features, &layout)
+            .expect("first-party-stack=false + unified should validate");
+    }
+
+    #[test]
+    fn first_party_stack_disabled_rejects_secure_boot() {
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::UefiSecureBoot]);
+        assert!(validate_image_features(&features, &layout).is_err());
+    }
+
+    #[test]
+    fn first_party_stack_disabled_rejects_encrypted_storage() {
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::EncryptedStorage]);
+        assert!(validate_image_features(&features, &layout).is_err());
+    }
+
+    #[test]
+    fn first_party_stack_disabled_rejects_in_place_updates() {
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::InPlaceUpdates]);
+        assert!(validate_image_features(&features, &layout).is_err());
+    }
+
+    #[test]
+    fn first_party_stack_disabled_rejects_split_partition_plan() {
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Split);
+        let features: HashSet<ImageFeature> = HashSet::new();
+        assert!(validate_image_features(&features, &layout).is_err());
+    }
+
+    #[test]
+    fn validation_is_noop_when_first_party_stack_enabled() {
+        // With `first-party-stack` enabled, the validator should accept any
+        // combination.
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Split);
+        let features = HashSet::from([
+            ImageFeature::FirstPartyStack,
+            ImageFeature::UefiSecureBoot,
+            ImageFeature::EncryptedStorage,
+            ImageFeature::InPlaceUpdates,
+        ]);
+        validate_image_features(&features, &layout)
+            .expect("validation should be no-op with first-party-stack enabled");
+    }
+
+    #[test]
+    fn first_party_stack_disabled_rejects_host_containers() {
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::HostContainers]);
+        assert!(validate_image_features(&features, &layout).is_err());
+    }
+
+    #[test]
+    fn first_party_stack_disabled_reports_all_conflicts_at_once() {
+        // The validator should report every conflict in a single error so the
+        // user does not have to fix them one at a time across multiple builds.
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Split);
+        let features = HashSet::from([
+            ImageFeature::UefiSecureBoot,
+            ImageFeature::EncryptedStorage,
+            ImageFeature::InPlaceUpdates,
+            ImageFeature::HostContainers,
+        ]);
+        let err = validate_image_features(&features, &layout)
+            .expect_err("multi-conflict combination should fail validation");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("uefi-secure-boot"),
+            "missing uefi-secure-boot in: {msg}"
+        );
+        assert!(
+            msg.contains("encrypted-storage"),
+            "missing encrypted-storage in: {msg}"
+        );
+        assert!(
+            msg.contains("in-place-updates"),
+            "missing in-place-updates in: {msg}"
+        );
+        assert!(
+            msg.contains("host-containers"),
+            "missing host-containers in: {msg}"
+        );
+        assert!(
+            msg.contains("partition-plan=split"),
+            "missing partition-plan in: {msg}"
+        );
+    }
+
+    /// Build a `ManifestInfo` from a TOML manifest fragment string.
+    fn manifest_info_from_toml(toml_str: &str) -> ManifestInfo {
+        toml::from_str(toml_str).expect("failed to parse test manifest")
+    }
+
+    /// Build a `[package.metadata.build-variant]` manifest with the given
+    /// inline `image-features` map.
+    fn variant_manifest_with_image_features(image_features_block: &str) -> String {
+        format!(
+            r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+{image_features_block}
+"#
+        )
+    }
+
+    #[test]
+    fn image_features_first_party_stack_disabled_drops_silent_defaults() {
+        // `first-party-stack = false` alone should drop the silent
+        // `in-place-updates` and `host-containers` defaults (and remove
+        // `first-party-stack` itself from the seed).
+        let toml = variant_manifest_with_image_features(
+            "[package.metadata.build-variant.image-features]\nfirst-party-stack = false",
+        );
+        let info = manifest_info_from_toml(&toml);
+        let features = info.image_features().expect("variant has image-features");
+        assert!(!features.contains(&ImageFeature::FirstPartyStack));
+        assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));
+        assert!(!features.contains(&ImageFeature::InPlaceUpdates));
+        assert!(!features.contains(&ImageFeature::HostContainers));
+    }
+
+    #[test]
+    fn image_features_first_party_stack_disabled_with_host_containers_keeps_both() {
+        // The seed-set logic adds host-containers back if it's explicitly set
+        // to `true`, so that the validator can later reject the combination
+        // with a clear error rather than silently producing a confused image.
+        let toml = variant_manifest_with_image_features(
+            "[package.metadata.build-variant.image-features]\n\
+             first-party-stack = false\n\
+             host-containers = true",
+        );
+        let info = manifest_info_from_toml(&toml);
+        let features = info.image_features().expect("variant has image-features");
+        assert!(!features.contains(&ImageFeature::FirstPartyStack));
+        assert!(features.contains(&ImageFeature::HostContainers));
+        // Validator should reject this combination.
+        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        assert!(validate_image_features(&features, &layout).is_err());
+    }
+
+    #[test]
+    fn image_features_default_seed_includes_first_party_stack() {
+        // No `image-features` at all → the default seed includes
+        // `first-party-stack` along with the historical silent defaults.
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+"#;
+        let info = manifest_info_from_toml(toml);
+        let features = info
+            .image_features()
+            .expect("variant has build-variant section");
+        assert!(features.contains(&ImageFeature::FirstPartyStack));
+        assert!(features.contains(&ImageFeature::InPlaceUpdates));
+        assert!(features.contains(&ImageFeature::HostContainers));
+        assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));
+    }
+
+    #[test]
+    fn image_features_explicit_first_party_stack_true_preserves_defaults() {
+        // Explicit `first-party-stack = true` is a no-op vs. the default; the
+        // historical silent defaults remain.
+        let toml = variant_manifest_with_image_features(
+            "[package.metadata.build-variant.image-features]\nfirst-party-stack = true",
+        );
+        let info = manifest_info_from_toml(&toml);
+        let features = info.image_features().expect("variant has image-features");
+        assert!(features.contains(&ImageFeature::FirstPartyStack));
+        assert!(features.contains(&ImageFeature::InPlaceUpdates));
+        assert!(features.contains(&ImageFeature::HostContainers));
+        assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));
+    }
+
+    #[test]
+    fn image_features_omitted_uses_default_image() {
+        // A variant that omits the `[image-features]` section entirely
+        // produces the standard Bottlerocket image: `first-party-stack` is in
+        // the silent default seed, and the resolved layout uses the historical
+        // 2 GiB OS size.
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+"#;
+        let info = manifest_info_from_toml(toml);
+        let features = info
+            .image_features()
+            .expect("variant has build-variant section");
+        let raw_layout = ImageLayout::default();
+        let layout = resolved_image_layout(&raw_layout, &features);
+        assert_eq!(layout.os_image_size_gib().0, 2);
+        validate_image_features(&features, &layout).expect("default image should pass validation");
     }
 }

--- a/tools/buildsys/src/manifest/error.rs
+++ b/tools/buildsys/src/manifest/error.rs
@@ -46,4 +46,7 @@ pub(super) enum Error {
         "The cargo package we are building, '{name}', could not be found in the graph"
     ))]
     RootDependencyMissing { name: String },
+
+    #[snafu(display("`first-party-stack = false` is incompatible with: {reason}"))]
+    IncompatibleImageFeatures { reason: String },
 }

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -229,6 +229,7 @@ ARG HOST_CONTAINERS
 ARG FIPS
 ARG EXTERNAL_KMOD_DEVELOPMENT
 ARG ENCRYPTED_STORAGE
+ARG FIRST_PARTY_STACK
 
 USER builder
 WORKDIR /home/builder
@@ -252,7 +253,8 @@ RUN \
    && echo -e -n "${IN_PLACE_UPDATES:+%bcond_without in_place_updates\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${HOST_CONTAINERS:+%bcond_without host_containers\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${EXTERNAL_KMOD_DEVELOPMENT:+%bcond_without external_kmod_development\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${ENCRYPTED_STORAGE:+%bcond_without encrypted_storage\n}" >> "${RPM_BCONDS}"
+   && echo -e -n "${ENCRYPTED_STORAGE:+%bcond_without encrypted_storage\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${FIRST_PARTY_STACK:+%bcond_without first_party_stack\n}" >> "${RPM_BCONDS}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an RPM repository from packages created in Section 1 and kits from Section 2.
@@ -364,6 +366,7 @@ ARG EROFS_ROOT_PARTITION
 ARG UEFI_SECURE_BOOT
 ARG IN_PLACE_UPDATES
 ARG ENCRYPTED_STORAGE
+ARG FIRST_PARTY_STACK
 ARG PROJECT_VENDOR
 ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
@@ -407,7 +410,8 @@ RUN --mount=target=/host \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
       ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
-      ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} && \
+      ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} \
+      --with-first-party-stack="${FIRST_PARTY_STACK:-no}" && \
     rm -rf /local/rpms && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
@@ -527,6 +531,7 @@ ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG UEFI_SECURE_BOOT
 ARG EROFS_ROOT_PARTITION
 ARG IN_PLACE_UPDATES
+ARG FIRST_PARTY_STACK
 ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 WORKDIR /root
@@ -564,7 +569,8 @@ RUN --mount=target=/host \
       --ovf-template="/bypass/variants/${VARIANT_NAME}/template.ovf" \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
-      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} && \
+      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
+      --with-first-party-stack="${FIRST_PARTY_STACK:-no}" && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
     rm /bypass && \

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -9,6 +9,12 @@ OVF_TEMPLATE=""
 EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
+# img2img does not currently parse `--with-encrypted-storage`, but we initialize
+# the variable so the first-party-stack validation below treats it consistently
+# with rpm2img. If a future change adds a flag for it, the validation below will
+# already enforce mutual exclusion when `first-party-stack = false`.
+ENCRYPTED_STORAGE="no"
+FIRST_PARTY_STACK="yes"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -25,6 +31,7 @@ for opt in "$@"; do
   --with-erofs-root-partition=*) EROFS_ROOT_PARTITION="${optarg}" ;;
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
+  --with-first-party-stack=*) FIRST_PARTY_STACK="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -66,6 +73,28 @@ check_debugfs_errors() {
 sanity_checks \
   "${OUTPUT_FMT}" "${PARTITION_PLAN}" "${OVF_TEMPLATE}" "${UEFI_SECURE_BOOT}"
 
+# Re-validate flag combinations: img2img can be invoked directly via
+# repack-variant, so we cannot rely on buildsys to have already enforced these.
+# Keep this list in sync with `rpm2img` and with `validate_image_features` in
+# `tools/buildsys/src/manifest.rs`.
+if [[ "${FIRST_PARTY_STACK}" == "no" ]]; then
+  declare -A first_party_stack_conflicts=(
+    [UEFI_SECURE_BOOT]="uefi-secure-boot"
+    [IN_PLACE_UPDATES]="in-place-updates"
+    [ENCRYPTED_STORAGE]="encrypted-storage"
+  )
+  for f in "${!first_party_stack_conflicts[@]}"; do
+    if [[ "${!f}" == "yes" ]]; then
+      echo "\`first-party-stack = false\` is incompatible with '${first_party_stack_conflicts[${f}]}'" >&2
+      exit 1
+    fi
+  done
+  if [[ "${PARTITION_PLAN}" == "split" ]]; then
+    echo "\`first-party-stack = false\` is incompatible with 'partition-plan=split'" >&2
+    exit 1
+  fi
+fi
+
 ###############################################################################
 # Section 1: prepare working environment
 
@@ -87,11 +116,15 @@ SELINUX_POLICY="fortified"
 SELINUX_FILE_CONTEXTS="${ROOT_MOUNT}/${SELINUX_ROOT}/${SELINUX_POLICY}/contexts/files/file_contexts"
 
 # Collect partition sizes and offsets from the partition plan.
+# The caller is responsible for resolving any feature-dependent default
+# for OS_IMAGE_SIZE_GIB (e.g., 1 GiB when `first-party-stack = false`) before invoking
+# this script; we use the value as-is. See `resolved_image_layout` in
+# `tools/buildsys/src/manifest.rs` for the canonical resolver.
 declare -A partsize partoff
 set_partition_sizes \
   "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
   "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
-  partsize partoff
+  partsize partoff "${FIRST_PARTY_STACK}"
 
 # Process and stage the input images to the working directory.
 declare OS_IMAGE DATA_IMAGE

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -66,6 +66,12 @@ Provides: %{_cross_os}image-feature(encrypted-storage)
 Provides: %{_cross_os}image-feature(no-encrypted-storage)
 %endif
 
+%if %{with first_party_stack}
+Provides: %{_cross_os}image-feature(first-party-stack)
+%else
+Provides: %{_cross_os}image-feature(no-first-party-stack)
+%endif
+
 %description
 %{summary}.
 

--- a/twoliter/embedded/partyplanner
+++ b/twoliter/embedded/partyplanner
@@ -135,6 +135,25 @@ PRIVATE_SCALE_FACTOR="24"
 # Postlude | GPT footer               1 MiB  | GPT is fixed, private partition grows.
 #          +---------------------------------+
 
+# Layout for an OS image with `first-party-stack = false` (default 1 GiB):
+# single bank, no RESERVED, no PRIVATE, no DATA. ROOT-A absorbs all the slack
+# that would otherwise go to those partitions. The variant has no
+# Bottlerocket-managed datastore or settings subsystem, so there is nothing
+# to persist.
+# Sizes marked with (*) scale with overall image size, but ROOT-A is the
+# residual: ROOT-A = (image size MiB) - GPT*2 - BIOS - EFI-A - BOOT-A - HASH-A.
+
+#          +---------------------------------+
+#  Prelude | GPT header               1 MiB  | 5 MiB
+#          | BIOS boot partition      4 MiB  | Fixed size.
+#          +---------------------------------+
+#          | EFI system partition    10 MiB  |
+#          | Boot partition          40 MiB* |
+#   Bank A | Root partition       residual*  | absorbs RESERVED + PRIVATE + DATA-A slack
+#          | Hash partition          10 MiB* |
+# Postlude | GPT footer               1 MiB  |
+#          +---------------------------------+
+
 ##############################################################################
 # Section 5: library functions
 
@@ -190,8 +209,28 @@ get_partition_sizes() {
 }
 
 # Populate the caller's tables with sizes and offsets for known partitions.
+#
+# Positional arguments (kept in fixed order for backward compatibility with
+# existing callers in `rpm2img` and `img2img`):
+#   $1  os_image_gib       OS image size in GiB. Required, must be a positive
+#                          integer. The caller is responsible for resolving
+#                          any feature-dependent default (e.g. 1 GiB when
+#                          `first-party-stack = false`) before invoking this
+#                          function; we use the value as-is.
+#   $2  data_image_gib     Data image size in GiB. Required even when
+#                          `first_party_stack=no` (where it is unused) so
+#                          that the parameter list remains stable.
+#   $3  partition_plan     "split" or "unified".
+#   $4  in_place_updates   "yes" or "no". Ignored when `first_party_stack=no`;
+#                          the two are validated as mutually exclusive below.
+#   $5  pp_size            (nameref) bash assoc-array to populate with sizes.
+#   $6  pp_offset          (nameref) bash assoc-array to populate with offsets.
+#   $7  first_party_stack  (optional, default "yes") "yes" or "no". When
+#                          "no", a single-bank stripped-down layout is
+#                          produced with no RESERVED, PRIVATE, or DATA
+#                          partitions.
 set_partition_sizes() {
-  local os_image_gib data_image_gib partition_plan in_place_updates
+  local os_image_gib data_image_gib partition_plan in_place_updates first_party_stack
   local -n pp_size pp_offset
   os_image_gib="${1:?}"
   data_image_gib="${2:?}"
@@ -211,11 +250,75 @@ set_partition_sizes() {
   # Table for partition offsets from start of disk, in MiB.
   pp_offset="${6:?}"
 
+  # Whether we're building the standard Bottlerocket image (the first-party
+  # software stack and its supporting partitions) or the stripped-down image
+  # without those. Defaults to "yes" if not provided so existing direct
+  # callers continue to get the standard layout unchanged.
+  first_party_stack="${7:-yes}"
+
   # Most of the partitions on the main image scale with the overall size.
   local boot_mib root_mib hash_mib reserved_mib private_mib
   boot_mib="$((os_image_gib * BOOT_SCALE_FACTOR))"
   root_mib="$((os_image_gib * ROOT_SCALE_FACTOR))"
   hash_mib="$((os_image_gib * HASH_SCALE_FACTOR))"
+
+  # Fast-path the stripped-down layout (`first-party-stack = false`). Single
+  # bank, no RESERVED-A, no PRIVATE, no DATA-A/B; ROOT-A is sized so that
+  # the partitions exactly fill the nominal image size and the GPT footer
+  # is preserved.
+  if [[ "${first_party_stack}" == "no" ]]; then
+    # Defense-in-depth: the buildsys validator and the rpm2img/img2img
+    # entry-point checks already reject these combinations, but a stale or
+    # buggy direct caller of this function should also fail loudly rather
+    # than silently producing an unexpected layout.
+    if [[ "${in_place_updates}" == "yes" ]]; then
+      echo "set_partition_sizes: first_party_stack=no is incompatible with in_place_updates=yes" >&2
+      exit 1
+    fi
+    if [[ "${partition_plan}" == "split" ]]; then
+      echo "set_partition_sizes: first_party_stack=no is incompatible with partition_plan=split" >&2
+      exit 1
+    fi
+
+    local total_mib offset
+    total_mib="$((os_image_gib * 1024))"
+    ((offset = 1)) # GPT header
+
+    pp_offset["BIOS"]="${offset}"
+    pp_size["BIOS"]="${BIOS_MIB}"
+    ((offset += BIOS_MIB))
+
+    pp_offset["EFI-A"]="${offset}"
+    pp_size["EFI-A"]="$(( EFI_MIB * 2 ))"
+    ((offset += EFI_MIB * 2))
+
+    pp_offset["BOOT-A"]="${offset}"
+    pp_size["BOOT-A"]="$(( boot_mib * 2 ))"
+    ((offset += boot_mib * 2))
+
+    # ROOT-A absorbs all the leftover space between BOOT-A and HASH-A, so:
+    # ROOT-A = total - GPT(header) - BIOS - EFI-A*2 - BOOT-A*2 - HASH-A*2 - GPT(footer)
+    local root_a_mib
+    root_a_mib="$(( total_mib - 1 - BIOS_MIB - (EFI_MIB * 2) - (boot_mib * 2) - (hash_mib * 2) - 1 ))"
+    if (( root_a_mib <= 0 )); then
+      echo "image size ${os_image_gib} GiB is too small for first_party_stack=no partition layout" >&2
+      exit 1
+    fi
+    pp_offset["ROOT-A"]="${offset}"
+    pp_size["ROOT-A"]="${root_a_mib}"
+    ((offset += root_a_mib))
+
+    pp_offset["HASH-A"]="${offset}"
+    pp_size["HASH-A"]="$(( hash_mib * 2 ))"
+    ((offset += hash_mib * 2))
+
+    # Sanity check: offsets + GPT footer must equal total_mib.
+    if (( offset + 1 != total_mib )); then
+      echo "first_party_stack=no partition layout offset mismatch: offset=${offset}, total=${total_mib}" >&2
+      exit 1
+    fi
+    return 0
+  fi
 
   # Reserved space is everything left in the bank after the other partitions
   # are scaled, minus the fixed 5 MiB EFI partition in that bank.

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -11,6 +11,7 @@ EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
 ENCRYPTED_STORAGE="no"
+FIRST_PARTY_STACK="yes"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -30,6 +31,7 @@ for opt in "$@"; do
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   --with-encrypted-storage=*) ENCRYPTED_STORAGE="${optarg}" ;;
+  --with-first-party-stack=*) FIRST_PARTY_STACK="${optarg}" ;;
   --sbom-package-dir=*) SBOM_PACKAGE_DIR="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
@@ -48,6 +50,28 @@ done
 
 sanity_checks \
   "${OUTPUT_FMT}" "${PARTITION_PLAN}" "${OVF_TEMPLATE}" "${UEFI_SECURE_BOOT}" "${SBOM_PACKAGE_DIR}"
+
+# Re-validate flag combinations: img2img/rpm2img can be invoked directly via
+# repack-variant, so we cannot rely on buildsys to have already enforced these.
+# Keep this list in sync with `img2img` and with `validate_image_features` in
+# `tools/buildsys/src/manifest.rs`.
+if [[ "${FIRST_PARTY_STACK}" == "no" ]]; then
+  declare -A first_party_stack_conflicts=(
+    [UEFI_SECURE_BOOT]="uefi-secure-boot"
+    [IN_PLACE_UPDATES]="in-place-updates"
+    [ENCRYPTED_STORAGE]="encrypted-storage"
+  )
+  for f in "${!first_party_stack_conflicts[@]}"; do
+    if [[ "${!f}" == "yes" ]]; then
+      echo "\`first-party-stack = false\` is incompatible with '${first_party_stack_conflicts[${f}]}'" >&2
+      exit 1
+    fi
+  done
+  if [[ "${PARTITION_PLAN}" == "split" ]]; then
+    echo "\`first-party-stack = false\` is incompatible with 'partition-plan=split'" >&2
+    exit 1
+  fi
+fi
 
 # Store output artifacts in a versioned directory.
 OUTPUT_DIR="${OUTPUT_DIR}/${VERSION_ID}-${BUILD_ID}"
@@ -93,7 +117,18 @@ split)
   truncate -s "${DATA_IMAGE_SIZE_GIB}G" "${DATA_IMAGE}"
   ;;
 unified)
-  truncate -s "$((OS_IMAGE_SIZE_GIB + DATA_IMAGE_SIZE_GIB))G" "${OS_IMAGE}"
+  # The caller is responsible for resolving any feature-dependent default
+  # for OS_IMAGE_SIZE_GIB (e.g., 1 GiB when `first-party-stack = false`)
+  # before invoking
+  # this script; we use the value as-is. See `resolved_image_layout` in
+  # `tools/buildsys/src/manifest.rs` for the canonical resolver.
+  if [[ "${FIRST_PARTY_STACK}" == "no" ]]; then
+    # Stripped-down images do not have a DATA partition, so do not pad the
+    # OS image with the would-be data image space.
+    truncate -s "${OS_IMAGE_SIZE_GIB}G" "${OS_IMAGE}"
+  else
+    truncate -s "$((OS_IMAGE_SIZE_GIB + DATA_IMAGE_SIZE_GIB))G" "${OS_IMAGE}"
+  fi
   ;;
 *)
   echo "unexpected partition plan '${PARTITION_PLAN}'" >&2
@@ -105,18 +140,21 @@ declare -A partlabel parttype partguid partsize partoff
 set_partition_sizes \
   "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
   "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
-  partsize partoff
+  partsize partoff "${FIRST_PARTY_STACK}"
 set_partition_labels partlabel
 set_partition_types parttype
 set_partition_uuids partguid "${PARTITION_PLAN}"
 
 declare -a partitions
 partitions=(BIOS)
-partitions+=(EFI-A BOOT-A ROOT-A HASH-A RESERVED-A)
-if [[ "${IN_PLACE_UPDATES}" == "yes" ]]; then
-  partitions+=(EFI-B BOOT-B ROOT-B HASH-B RESERVED-B)
+partitions+=(EFI-A BOOT-A ROOT-A HASH-A)
+if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+  partitions+=(RESERVED-A)
+  if [[ "${IN_PLACE_UPDATES}" == "yes" ]]; then
+    partitions+=(EFI-B BOOT-B ROOT-B HASH-B RESERVED-B)
+  fi
+  partitions+=(PRIVATE DATA-A DATA-B)
 fi
-partitions+=(PRIVATE DATA-A DATA-B)
 
 declare -a partargs
 for part in "${partitions[@]}"; do
@@ -151,7 +189,7 @@ done
 sgdisk --clear "${partargs[@]}" --sort --print "${OS_IMAGE}"
 
 # Partition the separate data disk, if we're using the split layout.
-if [[ "${PARTITION_PLAN}" == "split" ]]; then
+if [[ "${FIRST_PARTY_STACK}" == "yes" && "${PARTITION_PLAN}" == "split" ]]; then
   data_start="${partoff["DATA-B"]}"
   data_end=$((data_start + partsize["DATA-A"]))
   data_end=$((data_end * 2048 - 1))
@@ -443,7 +481,10 @@ BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
 DOCUMENTATION_URL="https://bottlerocket.dev"
 EOF
 
-# Set the BOTTLEROCKET-DATA Filesystem for creating/mounting
+# Set the BOTTLEROCKET-DATA Filesystem for creating/mounting. This is
+# written unconditionally so that `prepare-local-fs.service` can format an
+# attached data volume with `systemd-makefs` even for stripped-down images
+# (`first-party-stack = false`) that don't bake in a DATA partition.
 if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
   printf "%s\n" "DATA_PARTITION_FILESYSTEM=xfs" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 else
@@ -462,6 +503,13 @@ if [[ "${ENCRYPTED_STORAGE}" == "yes" ]]; then
   printf "%s\n" "ENCRYPTED_STORAGE=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 else
   printf "%s\n" "ENCRYPTED_STORAGE=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+fi
+
+# Set first-party-stack flag
+if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+  printf "%s\n" "FIRST_PARTY_STACK=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+else
+  printf "%s\n" "FIRST_PARTY_STACK=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 fi
 
 # BOTTLEROCKET-ROOT-A
@@ -494,9 +542,16 @@ generate_verity_root "${ROOT_IMAGE}" "${VERITY_IMAGE}" "${partsize["HASH-A"]}" \
 dd if="${VERITY_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff["HASH-A"]}"
 
 # write GRUB config
-# Include the parameters that support Boot Config
-BOOTCONFIG='bootconfig'
-INITRD="initrd (\$private)/bootconfig.data"
+# Include the parameters that support Boot Config. Stripped-down images
+# (`first-party-stack = false`) have no PRIVATE partition to hold
+# bootconfig.data, so omit these entries entirely.
+if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+  BOOTCONFIG='bootconfig'
+  INITRD="initrd (\$private)/bootconfig.data"
+else
+  BOOTCONFIG=''
+  INITRD=''
+fi
 
 # If UEFI_SECURE_BOOT is set, disable interactive edits. Otherwise the intended
 # kernel command line parameters could be changed if the boot fails. Disable
@@ -582,18 +637,19 @@ boot_usage=$(get_ext4_usage "${BOOT_IMAGE}" "BOOT-A")
 echo "${root_usage}" "${boot_usage}" | jq -s 'add | {disk_usage: .}' > "${OUTPUT_DIR}/artifact-metadata.json"
 
 # BOTTLEROCKET-PRIVATE
+if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+  # Generate bootconfig file for the image.
+  touch "${PRIVATE_MOUNT}/bootconfig.data"
+  bootconfig -a "${BOOTCONFIG_INPUT}" "${PRIVATE_MOUNT}/bootconfig.data"
 
-# Generate bootconfig file for the image.
-touch "${PRIVATE_MOUNT}/bootconfig.data"
-bootconfig -a "${BOOTCONFIG_INPUT}" "${PRIVATE_MOUNT}/bootconfig.data"
-
-# Targeted toward the current API server implementation.
-# Relative to the ext4 defaults, we:
-# - adjust the inode ratio since we expect lots of small files
-# - retain the inode size to allow most settings to be stored inline
-# - retain the block size to handle worse-case alignment for hardware
-mkfs.ext4 -b 4096 -i 4096 -I 256 -d "${PRIVATE_MOUNT}" "${PRIVATE_IMAGE}" "${partsize[PRIVATE]}M"
-dd if="${PRIVATE_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRIVATE]}"
+  # Targeted toward the current API server implementation.
+  # Relative to the ext4 defaults, we:
+  # - adjust the inode ratio since we expect lots of small files
+  # - retain the inode size to allow most settings to be stored inline
+  # - retain the block size to handle worse-case alignment for hardware
+  mkfs.ext4 -b 4096 -i 4096 -I 256 -d "${PRIVATE_MOUNT}" "${PRIVATE_IMAGE}" "${partsize[PRIVATE]}M"
+  dd if="${PRIVATE_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff[PRIVATE]}"
+fi
 
 # Predict PCR values after all partitions are written.
 if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
@@ -605,45 +661,46 @@ if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
 fi
 
 # BOTTLEROCKET-DATA-A and BOTTLEROCKET-DATA-B
+if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+  # If we build on a host with SELinux enabled, we could end up with labels that
+  # do not match our policy. Since we allow replacing the data volume at runtime,
+  # we can't count on these labels being correct in any case, and it's better to
+  # remove them all.
+  UNLABELED=$(find "${DATA_MOUNT}" |
+    awk -v root="${DATA_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_rm", $1, "security.selinux"}')
 
-# If we build on a host with SELinux enabled, we could end up with labels that
-# do not match our policy. Since we allow replacing the data volume at runtime,
-# we can't count on these labels being correct in any case, and it's better to
-# remove them all.
-UNLABELED=$(find "${DATA_MOUNT}" |
-  awk -v root="${DATA_MOUNT}" '{gsub(root"/","/"); gsub(root,"/"); print "ea_rm", $1, "security.selinux"}')
+  # Decide which data filesystem to create at build time based on layout.
+  #
+  # The DATA-A partition will always exist, but for the "split" layout, it will be
+  # too small to provide the desired filesystem parameters (inode count, etc) when
+  # it is grown later on. Hence this filesystem is only created for "unified".
+  #
+  # The DATA-B partition does not exist on the "unified" layout, which anticipates
+  # a single storage device. Hence this filesystem is only created for "split".
+  #
+  # If the other partition is available at runtime, the filesystem will be created
+  # during first boot instead, providing flexibility at the cost of a minor delay.
+  if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
+    mkfs_data_fn="mkfs_data_xfs"
+  else
+    mkfs_data_fn="mkfs_data_ext4"
+  fi
 
-# Decide which data filesystem to create at build time based on layout.
-#
-# The DATA-A partition will always exist, but for the "split" layout, it will be
-# too small to provide the desired filesystem parameters (inode count, etc) when
-# it is grown later on. Hence this filesystem is only created for "unified".
-#
-# The DATA-B partition does not exist on the "unified" layout, which anticipates
-# a single storage device. Hence this filesystem is only created for "split".
-#
-# If the other partition is available at runtime, the filesystem will be created
-# during first boot instead, providing flexibility at the cost of a minor delay.
-if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
-  mkfs_data_fn="mkfs_data_xfs"
-else
-  mkfs_data_fn="mkfs_data_ext4"
+  case "${PARTITION_PLAN}" in
+  unified)
+    "${mkfs_data_fn}" "${OS_IMAGE}" "${partsize["DATA-A"]}M" "${partoff["DATA-A"]}" \
+      "${BOTTLEROCKET_DATA}" "${DATA_MOUNT}" "${UNLABELED}"
+    ;;
+  split)
+    "${mkfs_data_fn}" "${DATA_IMAGE}" "${partsize["DATA-B"]}M" "${partoff["DATA-B"]}" \
+      "${BOTTLEROCKET_DATA}" "${DATA_MOUNT}" "${UNLABELED}"
+    ;;
+  *)
+    echo "unexpected partition plan '${PARTITION_PLAN}'" >&2
+    exit 1
+    ;;
+  esac
 fi
-
-case "${PARTITION_PLAN}" in
-unified)
-  "${mkfs_data_fn}" "${OS_IMAGE}" "${partsize["DATA-A"]}M" "${partoff["DATA-A"]}" \
-    "${BOTTLEROCKET_DATA}" "${DATA_MOUNT}" "${UNLABELED}"
-  ;;
-split)
-  "${mkfs_data_fn}" "${DATA_IMAGE}" "${partsize["DATA-B"]}M" "${partoff["DATA-B"]}" \
-    "${BOTTLEROCKET_DATA}" "${DATA_MOUNT}" "${UNLABELED}"
-  ;;
-*)
-  echo "unexpected partition plan '${PARTITION_PLAN}'" >&2
-  exit 1
-  ;;
-esac
 
 sgdisk -v "${OS_IMAGE}"
 [[ -s "${DATA_IMAGE}" ]] && sgdisk -v "${DATA_IMAGE}"

--- a/twoliter/embedded/tests/test_partyplanner.sh
+++ b/twoliter/embedded/tests/test_partyplanner.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# Test the `first-party-stack` partition-layout math in `partyplanner` by
+# sourcing the script into a sub-shell and asserting on the populated
+# `pp_size`/`pp_offset` tables. This complements the Rust-side validator
+# tests in `tools/buildsys/src/manifest.rs`, which cover the high-level
+# feature validation but not the actual disk geometry that lives in bash.
+#
+# Run from the repo root via `bash twoliter/embedded/tests/test_partyplanner.sh`.
+
+set -eu -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARTYPLANNER="${SCRIPT_DIR}/../partyplanner"
+
+if [[ ! -f "${PARTYPLANNER}" ]]; then
+  echo "test_partyplanner: partyplanner not found at ${PARTYPLANNER}" >&2
+  exit 1
+fi
+
+# We source the helper as a library to make `set_partition_sizes` callable.
+# shellcheck source=../partyplanner
+. "${PARTYPLANNER}"
+
+pass_count=0
+fail_count=0
+
+# Mark a test as passed; print a short progress line.
+pass() {
+  pass_count=$((pass_count + 1))
+  echo "  ok: $1"
+}
+
+# Mark a test as failed; print details and continue (so we get a full report).
+fail() {
+  fail_count=$((fail_count + 1))
+  echo "  FAIL: $1" >&2
+}
+
+# Assert two strings are equal.
+assert_eq() {
+  local actual expected name
+  actual="$1"
+  expected="$2"
+  name="$3"
+  if [[ "${actual}" == "${expected}" ]]; then
+    pass "${name} (got '${actual}')"
+  else
+    fail "${name}: expected '${expected}' got '${actual}'"
+  fi
+}
+
+# Assert that an associative-array key is *not* set.
+assert_unset() {
+  local -n arr="$1"
+  local key name
+  key="$2"
+  name="$3"
+  if [[ -v "arr[${key}]" ]]; then
+    fail "${name}: key '${key}' should not be set, but is '${arr[${key}]}'"
+  else
+    pass "${name}"
+  fi
+}
+
+# Assert that a sub-shell command exits non-zero.
+assert_fails() {
+  local name="$1"
+  shift
+  if ( "$@" ) >/dev/null 2>&1; then
+    fail "${name}: expected non-zero exit but command succeeded"
+  else
+    pass "${name}"
+  fi
+}
+
+###############################################################################
+# Test 1: 1 GiB stripped-down image (first_party_stack=no) produces the
+# expected partition table.
+#
+# With BIOS_MIB=4, EFI_MIB=5, BOOT_SCALE_FACTOR=20, HASH_SCALE_FACTOR=5:
+#   total      = 1024 MiB
+#   GPT header = 1
+#   BIOS       = 4
+#   EFI-A      = 10  (5 * 2)
+#   BOOT-A     = 40  (20 * 2)
+#   ROOT-A     = total - 1 - 4 - 10 - 40 - 10 - 1 = 958
+#   HASH-A     = 10  (5 * 2)
+#   GPT footer = 1
+###############################################################################
+echo "Test 1: first_party_stack=no 1 GiB layout"
+declare -A partsize partoff
+set_partition_sizes 1 1 unified no partsize partoff no
+
+assert_eq "${partoff[BIOS]}"   "1"   "BIOS offset"
+assert_eq "${partsize[BIOS]}"  "4"   "BIOS size"
+assert_eq "${partoff[EFI-A]}"  "5"   "EFI-A offset"
+assert_eq "${partsize[EFI-A]}" "10"  "EFI-A size"
+assert_eq "${partoff[BOOT-A]}" "15"  "BOOT-A offset"
+assert_eq "${partsize[BOOT-A]}" "40" "BOOT-A size"
+assert_eq "${partoff[ROOT-A]}" "55"  "ROOT-A offset"
+assert_eq "${partsize[ROOT-A]}" "958" "ROOT-A size (residual)"
+assert_eq "${partoff[HASH-A]}" "1013" "HASH-A offset"
+assert_eq "${partsize[HASH-A]}" "10" "HASH-A size"
+
+# The stripped-down layout omits these partitions entirely.
+for omitted in RESERVED-A PRIVATE DATA-A DATA-B EFI-B BOOT-B ROOT-B HASH-B RESERVED-B; do
+  assert_unset partsize "${omitted}" "partsize[${omitted}] is unset"
+  assert_unset partoff  "${omitted}" "partoff[${omitted}] is unset"
+done
+
+# Sanity check: offsets sum to total - 1 (GPT footer).
+total_used=$((partoff[HASH-A] + partsize[HASH-A]))
+assert_eq "${total_used}" "1023" "partitions fill image up to GPT footer"
+
+###############################################################################
+# Test 2: 2 GiB stripped-down image scales correctly.
+#
+# total      = 2048
+# BIOS       = 4
+# EFI-A      = 10  (fixed across image sizes)
+# BOOT-A     = 80  (20 * 2 * 2 GiB)
+# HASH-A     = 20  (5 * 2 * 2 GiB)
+# ROOT-A     = 2048 - 1 - 4 - 10 - 80 - 20 - 1 = 1932
+###############################################################################
+echo "Test 2: first_party_stack=no 2 GiB layout"
+declare -A partsize2 partoff2
+set_partition_sizes 2 1 unified no partsize2 partoff2 no
+
+assert_eq "${partsize2[BIOS]}"   "4"    "2GiB BIOS size"
+assert_eq "${partsize2[EFI-A]}"  "10"   "2GiB EFI-A size"
+assert_eq "${partsize2[BOOT-A]}" "80"   "2GiB BOOT-A size"
+assert_eq "${partsize2[HASH-A]}" "20"   "2GiB HASH-A size"
+assert_eq "${partsize2[ROOT-A]}" "1932" "2GiB ROOT-A size (residual)"
+
+###############################################################################
+# Test 3: defense-in-depth — first_party_stack=no + in_place_updates=yes is
+# rejected.
+#
+# Run in a sub-shell so the `exit 1` inside `set_partition_sizes` does not
+# kill the test runner.
+###############################################################################
+echo "Test 3: first_party_stack=no rejects in_place_updates=yes"
+assert_fails "set_partition_sizes 1 1 unified yes <size> <off> no" \
+  bash -c '
+    set -eu -o pipefail
+    . "'"${PARTYPLANNER}"'"
+    declare -A s o
+    set_partition_sizes 1 1 unified yes s o no
+  '
+
+###############################################################################
+# Test 4: defense-in-depth — first_party_stack=no + partition_plan=split is
+# rejected.
+###############################################################################
+echo "Test 4: first_party_stack=no rejects partition_plan=split"
+assert_fails "set_partition_sizes 1 1 split no <size> <off> no" \
+  bash -c '
+    set -eu -o pipefail
+    . "'"${PARTYPLANNER}"'"
+    declare -A s o
+    set_partition_sizes 1 1 split no s o no
+  '
+
+###############################################################################
+# Test 5: too-small image is rejected with a clear error.
+#
+# We force a too-small image by overriding BOOT_SCALE_FACTOR so that ROOT-A
+# would be non-positive.
+###############################################################################
+echo "Test 5: too-small first_party_stack=no image is rejected"
+assert_fails "first_party_stack=no 1 GiB with absurd boot scale factor" \
+  bash -c '
+    set -eu -o pipefail
+    . "'"${PARTYPLANNER}"'"
+    BOOT_SCALE_FACTOR=10000
+    declare -A s o
+    set_partition_sizes 1 1 unified no s o no
+  '
+
+###############################################################################
+# Test 6: backward-compat / default — omitting the 7th arg defaults to
+# first_party_stack=yes and produces the standard layout (with PRIVATE/DATA
+# partitions). This is the polarity-flipped default: direct callers that do
+# not pass the flag get the full Bottlerocket layout, matching the new Rust
+# default of `first-party-stack = true`.
+###############################################################################
+echo "Test 6: first_party_stack defaults to 'yes' for the standard layout"
+declare -A partsize3 partoff3
+set_partition_sizes 2 1 unified no partsize3 partoff3
+# We expect PRIVATE to exist in the standard layout.
+if [[ -v "partsize3[PRIVATE]" ]]; then
+  pass "PRIVATE partition present when first_party_stack is omitted"
+else
+  fail "PRIVATE partition should exist when first_party_stack is omitted"
+fi
+if [[ -v "partsize3[DATA-A]" ]]; then
+  pass "DATA-A partition present when first_party_stack is omitted"
+else
+  fail "DATA-A partition should exist when first_party_stack is omitted"
+fi
+
+###############################################################################
+echo
+echo "Results: ${pass_count} passed, ${fail_count} failed"
+if [[ "${fail_count}" -gt 0 ]]; then
+  exit 1
+fi

--- a/twoliter/src/tool-crates/embedded-bundle/tests/partyplanner.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/tests/partyplanner.rs
@@ -1,0 +1,45 @@
+//! Integration test that runs the bash-side `partyplanner` test suite.
+//!
+//! The actual assertions live in `embedded/tests/test_partyplanner.sh`,
+//! which sources `partyplanner` as a library and exercises the
+//! `set_partition_sizes` helper across standard and stripped-down (first-party-stack
+//! disabled) layouts. This
+//! Rust wrapper exists so the bash tests run under `cargo test` alongside
+//! the validator tests in the `buildsys` crate.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn partyplanner_bash_tests() {
+    // The `embedded` directory is a symlink to `twoliter/embedded` at the
+    // crate root, so `CARGO_MANIFEST_DIR` reaches the script either way.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = manifest_dir.join("embedded/tests/test_partyplanner.sh");
+
+    assert!(
+        script.is_file(),
+        "test_partyplanner.sh not found at {}",
+        script.display(),
+    );
+
+    let output = Command::new("bash")
+        .arg(&script)
+        .output()
+        .expect("failed to invoke bash");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Always print so failures show what the bash runner saw.
+    println!("--- test_partyplanner.sh stdout ---\n{stdout}");
+    if !stderr.is_empty() {
+        println!("--- test_partyplanner.sh stderr ---\n{stderr}");
+    }
+
+    assert!(
+        output.status.success(),
+        "test_partyplanner.sh failed with status {:?}",
+        output.status,
+    );
+}


### PR DESCRIPTION
Introduce an `first-party-stack` image feature that produces a stripped-down OS image with a single bank of partitions (BIOS-BOOT, EFI-SYSTEM, BOOT-A, ROOT-A, HASH-A) and no RESERVED, PRIVATE, or DATA partitions when set to false. The default OS image size is 1 GiB when `first-party-stack` is disabled.

The feature being turned off is incompatible with `uefi-secure-boot`, `encrypted-storage`, `in-place-updates`, and `partition-plan = split`; the build fails fast with a clear message in those cases. Validation is enforced both in buildsys and re-checked in rpm2img/img2img since those can be invoked directly via repack-variant.

The metadata RPM provides `image-feature(first-party-stack)` or `image-feature(no-first-party-stack)` accordingly, and a build-time warning makes the implications obvious in build logs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
