### PR TITLE
buildsys: add Rust third-party dependency vendoring

### DIFF
--- a/tools/buildsys/src/gomod.rs
+++ b/tools/buildsys/src/gomod.rs
@@ -15,61 +15,17 @@ when the docker-go script is invoked.
 
  */
 
-pub(crate) mod error;
+pub(crate) mod error {
+    pub(crate) use crate::vendormod::error::*;
+}
 
+use crate::vendormod::{VendorMod, GO_CONFIG};
 use buildsys::manifest;
-use duct::cmd;
 use error::Result;
-use filetime::{set_file_mtime, FileTime};
-use snafu::{ensure, OptionExt, ResultExt};
-use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::{env, fs};
+use filetime::FileTime;
+use std::path::Path;
 
 pub(crate) struct GoMod;
-
-const GO_MOD_DOCKER_SCRIPT_NAME: &str = "docker-go-script.sh";
-
-// The following bash template script is intended to be run within a container
-// using the docker-go tool found in this codebase under `tools/docker-go`.
-//
-// This script inspects the top level directory found in the package upstream
-// archive and uses that as the default Go module path if no explicit module
-// path was provided. It will then untar the archive, vendor the Go
-// dependencies, create a new archive using the {module-path}/vendor directory
-// and name it the output path provided. If no output path was given, it
-// defaults to "bundled-{package-file-name}". Finally, it cleans up by removing
-// the untar'd source code. The upstream archive remains intact and both tar
-// files can then be used during packaging.
-//
-// This script exists as an in memory template string literal and is populated
-// into a temporary file in the package directory itself to enable buildsys to
-// be as portable as possible and have no dependency on runtime paths. Since
-// buildsys is executed from the context of many different package directories,
-// managing a temporary file via this Rust module prevents having to acquire the
-// path of some static script file on the host system.
-const GO_MOD_SCRIPT_TMPL: &str = r#"#!/bin/bash
-
-set -e
-
-toplevel=$(tar tf __LOCAL_FILE_NAME__ | head -1)
-if [ -z __MOD_DIR__ ] ; then
-    targetdir="${toplevel}"
-else
-    targetdir="__MOD_DIR__"
-fi
-
-tar xf __LOCAL_FILE_NAME__
-
-pushd "${targetdir}"
-    go list -mod=readonly ./... >/dev/null && go mod vendor
-popd
-
-tar czf __OUTPUT__ "${targetdir}"/vendor
-rm -rf "${targetdir}"
-touch -r __LOCAL_FILE_NAME__ __OUTPUT__
-"#;
 
 impl GoMod {
     pub(crate) fn vendor(
@@ -79,137 +35,6 @@ impl GoMod {
         sdk: &str,
         mtime: FileTime,
     ) -> Result<()> {
-        let url_file_name = extract_file_name(&external_file.url)?;
-        let local_file_name = &external_file.path.as_ref().unwrap_or(&url_file_name);
-        ensure!(
-            local_file_name.components().count() == 1,
-            error::InputFileSnafu
-        );
-
-        let full_path = package_dir.join(local_file_name);
-        ensure!(
-            full_path.is_file(),
-            error::InputFileBadSnafu { path: full_path }
-        );
-
-        // If a module directory was not provided, set as an empty path.
-        // By default, without a provided module directory, tar will be passed
-        // the first directory found in the archives as the top level Go module
-        let default_empty_path = PathBuf::from("");
-        let mod_dir = external_file
-            .bundle_root_path
-            .as_ref()
-            .unwrap_or(&default_empty_path);
-
-        // Use a default "bundle-{name-of-file}" if no output path was provided
-        let default_output_path =
-            PathBuf::from(format!("bundled-{}", local_file_name.to_string_lossy()));
-        let output_path_arg = external_file
-            .bundle_output_path
-            .as_ref()
-            .unwrap_or(&default_output_path);
-        println!(
-            "cargo:rerun-if-changed={}",
-            output_path_arg.to_string_lossy()
-        );
-
-        let args = DockerGoArgs {
-            module_path: package_dir,
-            sdk_image: sdk.to_string(),
-            go_mod_cache: &root_dir.join(".gomodcache"),
-            command: format!("./{GO_MOD_DOCKER_SCRIPT_NAME}"),
-        };
-
-        // Create and/or write the temporary script file to the package directory
-        // using the script template string and placeholder variables
-        let script_contents = GO_MOD_SCRIPT_TMPL
-            .replace("__LOCAL_FILE_NAME__", &local_file_name.to_string_lossy())
-            .replace("__MOD_DIR__", &mod_dir.to_string_lossy())
-            .replace("__OUTPUT__", &output_path_arg.to_string_lossy());
-        let script_path = format!(
-            "{}/{}",
-            package_dir.to_string_lossy(),
-            GO_MOD_DOCKER_SCRIPT_NAME
-        );
-
-        // Drop the reference after writing the file to avoid a "text busy" error
-        // when attempting to execute it.
-        {
-            let mut script_file = fs::File::create(&script_path)
-                .context(error::CreateFileSnafu { path: &script_path })?;
-            fs::set_permissions(&script_path, fs::Permissions::from_mode(0o777))
-                .context(error::SetFilePermissionsSnafu { path: &script_path })?;
-            script_file
-                .write_all(script_contents.as_bytes())
-                .context(error::WriteFileSnafu { path: &script_path })?;
-        }
-
-        let res = docker_go(&args);
-        fs::remove_file(&script_path).context(error::RemoveFileSnafu { path: &script_path })?;
-
-        if res.is_ok() {
-            set_file_mtime(output_path_arg, mtime).context(error::SetMtimeSnafu {
-                path: output_path_arg,
-            })?;
-        }
-
-        res
+        VendorMod::vendor(&GO_CONFIG, root_dir, package_dir, external_file, sdk, mtime)
     }
-}
-
-fn extract_file_name(url: &str) -> Result<PathBuf> {
-    let parsed = reqwest::Url::parse(url).context(error::InputUrlSnafu { url })?;
-    let name = parsed
-        .path_segments()
-        .context(error::InputFileBadSnafu { path: url })?
-        .next_back()
-        .context(error::InputFileBadSnafu { path: url })?;
-    Ok(name.into())
-}
-
-struct DockerGoArgs<'a> {
-    module_path: &'a Path,
-    sdk_image: String,
-    go_mod_cache: &'a Path,
-    command: String,
-}
-
-/// Run `docker-go` with the specified arguments.
-fn docker_go(dg_args: &DockerGoArgs) -> Result<()> {
-    let args = vec![
-        "--module-path",
-        dg_args
-            .module_path
-            .to_str()
-            .context(error::InputFileSnafu)?,
-        "--sdk-image",
-        &dg_args.sdk_image,
-        "--go-mod-cache",
-        dg_args
-            .go_mod_cache
-            .to_str()
-            .context(error::InputFileSnafu)?,
-        "--command",
-        &dg_args.command,
-    ];
-    let arg_string = args.join(" ");
-    let twoliter_tools_dir = env::var("TWOLITER_TOOLS_DIR").context(error::EnvironmentSnafu {
-        var: "TWOLITER_TOOLS_DIR",
-    })?;
-    let program = PathBuf::from(twoliter_tools_dir).join("docker-go");
-    println!("program: {}", program.to_string_lossy());
-    let output = cmd(program, args)
-        .stderr_to_stdout()
-        .stdout_capture()
-        .unchecked()
-        .run()
-        .context(error::CommandStartSnafu)?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    println!("{}", &stdout);
-    ensure!(
-        output.status.success(),
-        error::DockerExecutionSnafu { args: arg_string }
-    );
-    Ok(())
 }

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -13,7 +13,9 @@ mod builder;
 mod cache;
 mod gomod;
 mod project;
+mod rustmod;
 mod spec;
+mod vendormod;
 
 use crate::args::{
     BuildKitArgs, BuildPackageArgs, BuildVariantArgs, Buildsys, Command, RepackVariantArgs,
@@ -26,6 +28,7 @@ use clap::Parser;
 use filetime::FileTime;
 use gomod::GoMod;
 use project::ProjectInfo;
+use rustmod::RustMod;
 use snafu::{ensure, ResultExt};
 use spec::SpecInfo;
 use std::path::{Path, PathBuf};
@@ -55,6 +58,11 @@ mod error {
 
         #[snafu(display("{source}"))]
         GoMod { source: super::gomod::error::Error },
+
+        #[snafu(display("{source}"))]
+        RustMod {
+            source: super::rustmod::error::Error,
+        },
 
         #[snafu(display("{source}"))]
         ProjectCrawl {
@@ -165,6 +173,14 @@ fn build_package(args: BuildPackageArgs) -> Result<()> {
                         mtime,
                     )
                     .context(error::GoModSnafu)?,
+                    BundleModule::Rust => RustMod::vendor(
+                        &args.common.root_dir,
+                        &args.common.cargo_manifest_dir,
+                        f,
+                        &args.common.sdk_image,
+                        mtime,
+                    )
+                    .context(error::RustModSnafu)?,
                 }
             }
         }

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -898,6 +898,7 @@ impl fmt::Display for ImageFeature {
 #[serde(rename_all = "lowercase")]
 pub enum BundleModule {
     Go,
+    Rust,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/tools/buildsys/src/rustmod.rs
+++ b/tools/buildsys/src/rustmod.rs
@@ -1,0 +1,45 @@
+/*!
+Packages using the Rust programming language may have upstream tar archives that
+include only the source code of the project, but not the source code of any
+dependencies. Rust projects use Cargo for dependency management, with dependencies
+declared in `Cargo.toml` and locked versions in `Cargo.lock`.
+
+This module extends the functionality of `packages.metadata.build-package.external-files`
+and provides the ability to retrieve and vendor dependencies using `cargo vendor`
+given a tar archive containing a `Cargo.toml` and `Cargo.lock`.
+
+The vendored output includes both the `vendor/` directory and `.cargo/config.toml`
+which configures Cargo to use the vendored dependencies.
+
+ */
+
+pub(crate) mod error {
+    pub(crate) use crate::vendormod::error::*;
+}
+
+use crate::vendormod::{VendorMod, RUST_CONFIG};
+use buildsys::manifest;
+use error::Result;
+use filetime::FileTime;
+use std::path::Path;
+
+pub(crate) struct RustMod;
+
+impl RustMod {
+    pub(crate) fn vendor(
+        root_dir: &Path,
+        package_dir: &Path,
+        external_file: &manifest::ExternalFile,
+        sdk: &str,
+        mtime: FileTime,
+    ) -> Result<()> {
+        VendorMod::vendor(
+            &RUST_CONFIG,
+            root_dir,
+            package_dir,
+            external_file,
+            sdk,
+            mtime,
+        )
+    }
+}

--- a/tools/buildsys/src/vendormod.rs
+++ b/tools/buildsys/src/vendormod.rs
@@ -1,0 +1,324 @@
+/*!
+Shared vendoring abstraction for Go and Rust modules.
+
+This module provides a unified implementation for vendoring dependencies
+from upstream tar archives. Language-specific behavior is controlled via
+`VendorConfig` structs.
+*/
+
+pub(crate) mod error;
+
+use buildsys::manifest;
+use duct::cmd;
+use error::Result;
+use filetime::{set_file_mtime, FileTime};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+/// Configuration for language-specific vendoring behavior.
+pub(crate) struct VendorConfig {
+    pub script_name: &'static str,
+    pub script_template: &'static str,
+    pub docker_tool: &'static str,
+    pub cache_dir: &'static str,
+    pub cache_arg_name: &'static str,
+}
+
+// The following bash template scripts are intended to be run within a container
+// using the docker-go or docker-cargo tools found in this codebase.
+//
+// Each script inspects the top level directory found in the package upstream
+// archive and uses that as the default module path if no explicit path was
+// provided. It then untars the archive, vendors dependencies, creates a new
+// archive of the vendor directory, and names it the output path provided. If no
+// output path was given, it defaults to "bundled-{package-file-name}". Finally,
+// it cleans up by removing the untar'd source code. The upstream archive
+// remains intact and both tar files can then be used during packaging.
+//
+// These scripts exist as in-memory template string literals and are written to
+// temporary files in the package directory itself to enable buildsys to be as
+// portable as possible with no dependency on runtime paths. Since buildsys is
+// executed from the context of many different package directories, managing a
+// temporary file via this module prevents having to acquire the path of some
+// static script file on the host system.
+
+// Go vendoring configuration
+const GO_SCRIPT_TMPL: &str = r#"#!/bin/bash
+
+set -e
+
+toplevel=$(tar tf "__LOCAL_FILE_NAME__" | head -1)
+if [ -z "__MOD_DIR__" ] ; then
+    targetdir="${toplevel}"
+else
+    targetdir="__MOD_DIR__"
+fi
+
+tar xf "__LOCAL_FILE_NAME__"
+
+pushd "${targetdir}"
+    go list -mod=readonly ./... >/dev/null && go mod vendor
+popd
+
+tar czf "__OUTPUT__" "${targetdir}"/vendor
+rm -rf "${targetdir}"
+touch -r "__LOCAL_FILE_NAME__" "__OUTPUT__"
+"#;
+
+pub(crate) const GO_CONFIG: VendorConfig = VendorConfig {
+    script_name: "docker-go-script.sh",
+    script_template: GO_SCRIPT_TMPL,
+    docker_tool: "docker-go",
+    cache_dir: ".gomodcache",
+    cache_arg_name: "--go-mod-cache",
+};
+
+// Rust vendoring configuration
+const RUST_SCRIPT_TMPL: &str = r#"#!/bin/bash
+
+set -e
+
+toplevel=$(tar tf "__LOCAL_FILE_NAME__" | head -1)
+if [ -z "__MOD_DIR__" ] ; then
+    targetdir="${toplevel}"
+else
+    targetdir="__MOD_DIR__"
+fi
+
+tar xf "__LOCAL_FILE_NAME__"
+
+pushd "${targetdir}"
+    mkdir -p .cargo
+    cargo metadata --locked --format-version 1 >/dev/null && cargo vendor --locked > .cargo/config.toml
+popd
+
+tar czf "__OUTPUT__" -C "${targetdir}" vendor .cargo/config.toml
+rm -rf "${targetdir}"
+touch -r "__LOCAL_FILE_NAME__" "__OUTPUT__"
+"#;
+
+pub(crate) const RUST_CONFIG: VendorConfig = VendorConfig {
+    script_name: "docker-cargo-script.sh",
+    script_template: RUST_SCRIPT_TMPL,
+    docker_tool: "docker-cargo",
+    cache_dir: ".cargo",
+    cache_arg_name: "--cargo-home",
+};
+
+pub(crate) struct VendorMod;
+
+impl VendorMod {
+    pub(crate) fn vendor(
+        config: &VendorConfig,
+        root_dir: &Path,
+        package_dir: &Path,
+        external_file: &manifest::ExternalFile,
+        sdk: &str,
+        mtime: FileTime,
+    ) -> Result<()> {
+        let url_file_name = extract_file_name(&external_file.url)?;
+        let local_file_name = external_file.path.as_ref().unwrap_or(&url_file_name);
+        ensure!(
+            local_file_name.components().count() == 1,
+            error::InputFileSnafu
+        );
+
+        let full_path = package_dir.join(local_file_name);
+        ensure!(
+            full_path.is_file(),
+            error::InputFileBadSnafu { path: full_path }
+        );
+
+        // If a module directory was not provided, set as an empty path.
+        // By default, without a provided module directory, tar will be passed
+        // the first directory found in the archive as the top level module.
+        let default_empty_path = PathBuf::from("");
+        let mod_dir = external_file
+            .bundle_root_path
+            .as_ref()
+            .unwrap_or(&default_empty_path);
+
+        // Use a default "bundled-{name-of-file}" if no output path was provided.
+        let default_output_path =
+            PathBuf::from(format!("bundled-{}", local_file_name.to_string_lossy()));
+        let output_path_arg = external_file
+            .bundle_output_path
+            .as_ref()
+            .unwrap_or(&default_output_path);
+        println!(
+            "cargo:rerun-if-changed={}",
+            output_path_arg.to_string_lossy()
+        );
+
+        // Create and/or write the temporary script file to the package directory
+        // using the script template string and placeholder variables.
+        let script_contents = config
+            .script_template
+            .replace("__LOCAL_FILE_NAME__", &local_file_name.to_string_lossy())
+            .replace("__MOD_DIR__", &mod_dir.to_string_lossy())
+            .replace("__OUTPUT__", &output_path_arg.to_string_lossy());
+        let script_path = package_dir.join(config.script_name);
+
+        // Drop the reference after writing the file to avoid a "text busy" error
+        // when attempting to execute it.
+        {
+            let mut script_file = fs::File::create(&script_path)
+                .context(error::CreateFileSnafu { path: &script_path })?;
+            fs::set_permissions(&script_path, fs::Permissions::from_mode(0o777))
+                .context(error::SetFilePermissionsSnafu { path: &script_path })?;
+            script_file
+                .write_all(script_contents.as_bytes())
+                .context(error::WriteFileSnafu { path: &script_path })?;
+        }
+
+        let res = run_docker_tool(
+            config,
+            package_dir,
+            sdk,
+            &root_dir.join(config.cache_dir),
+            &format!("./{}", config.script_name),
+        );
+        fs::remove_file(&script_path).context(error::RemoveFileSnafu { path: &script_path })?;
+
+        if res.is_ok() {
+            set_file_mtime(output_path_arg, mtime).context(error::SetMtimeSnafu {
+                path: output_path_arg,
+            })?;
+        }
+
+        res
+    }
+}
+
+fn extract_file_name(url: &str) -> Result<PathBuf> {
+    let parsed = reqwest::Url::parse(url).context(error::InputUrlSnafu { url })?;
+    let name = parsed
+        .path_segments()
+        .context(error::InputFileBadSnafu { path: url })?
+        .next_back()
+        .context(error::InputFileBadSnafu { path: url })?;
+    Ok(name.into())
+}
+
+fn run_docker_tool(
+    config: &VendorConfig,
+    module_path: &Path,
+    sdk_image: &str,
+    cache_dir: &Path,
+    command: &str,
+) -> Result<()> {
+    let mut args = vec![
+        "--module-path",
+        module_path.to_str().context(error::InputFileSnafu)?,
+        "--sdk-image",
+        sdk_image,
+        config.cache_arg_name,
+        cache_dir.to_str().context(error::InputFileSnafu)?,
+    ];
+
+    args.push("--command");
+    args.push(command);
+
+    let arg_string = args.join(" ");
+    let twoliter_tools_dir = env::var("TWOLITER_TOOLS_DIR").context(error::EnvironmentSnafu {
+        var: "TWOLITER_TOOLS_DIR",
+    })?;
+    let program = PathBuf::from(twoliter_tools_dir).join(config.docker_tool);
+    println!("program: {}", program.to_string_lossy());
+    let output = cmd(program, args)
+        .stderr_to_stdout()
+        .stdout_capture()
+        .unchecked()
+        .run()
+        .context(error::CommandStartSnafu)?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", &stdout);
+    ensure!(
+        output.status.success(),
+        error::DockerExecutionSnafu {
+            tool: config.docker_tool,
+            args: arg_string
+        }
+    );
+    Ok(())
+}
+
+// =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_extract_file_name_simple_url() {
+        let result = extract_file_name("https://example.com/archive.tar.gz").unwrap();
+        assert_eq!(result, PathBuf::from("archive.tar.gz"));
+    }
+
+    #[test]
+    fn test_extract_file_name_nested_path() {
+        let result =
+            extract_file_name("https://github.com/org/repo/releases/download/v1.0/file.tar.xz")
+                .unwrap();
+        assert_eq!(result, PathBuf::from("file.tar.xz"));
+    }
+
+    #[test]
+    fn test_extract_file_name_invalid_url() {
+        assert!(extract_file_name("not-a-url").is_err());
+    }
+
+    #[test]
+    fn test_go_script_template_substitution() {
+        let script = GO_SCRIPT_TMPL
+            .replace("__LOCAL_FILE_NAME__", "source-1.0.tar.gz")
+            .replace("__MOD_DIR__", "")
+            .replace("__OUTPUT__", "bundled-source-1.0.tar.gz");
+        assert!(script.contains("tar tf \"source-1.0.tar.gz\""));
+        assert!(script.contains("tar xf \"source-1.0.tar.gz\""));
+        assert!(script.contains("tar czf \"bundled-source-1.0.tar.gz\""));
+        assert!(script.contains("go mod vendor"));
+    }
+
+    #[test]
+    fn test_rust_script_template_substitution() {
+        let script = RUST_SCRIPT_TMPL
+            .replace("__LOCAL_FILE_NAME__", "crate-2.0.tar.gz")
+            .replace("__MOD_DIR__", "")
+            .replace("__OUTPUT__", "bundled-crate-2.0.tar.gz");
+        assert!(script.contains("tar tf \"crate-2.0.tar.gz\""));
+        assert!(script.contains("tar xf \"crate-2.0.tar.gz\""));
+        assert!(script.contains("tar czf \"bundled-crate-2.0.tar.gz\""));
+        assert!(script.contains("cargo vendor --locked"));
+        assert!(script.contains(".cargo/config.toml"));
+    }
+
+    #[test]
+    fn test_script_template_with_mod_dir() {
+        let script = GO_SCRIPT_TMPL
+            .replace("__LOCAL_FILE_NAME__", "source.tar.gz")
+            .replace("__MOD_DIR__", "subdir/module")
+            .replace("__OUTPUT__", "bundled-source.tar.gz");
+        assert!(script.contains("if [ -z \"subdir/module\" ]"));
+    }
+
+    #[test]
+    fn test_go_config_values() {
+        assert_eq!(GO_CONFIG.docker_tool, "docker-go");
+        assert_eq!(GO_CONFIG.cache_dir, ".gomodcache");
+        assert_eq!(GO_CONFIG.cache_arg_name, "--go-mod-cache");
+        assert_eq!(GO_CONFIG.script_name, "docker-go-script.sh");
+    }
+
+    #[test]
+    fn test_rust_config_values() {
+        assert_eq!(RUST_CONFIG.docker_tool, "docker-cargo");
+        assert_eq!(RUST_CONFIG.cache_dir, ".cargo");
+        assert_eq!(RUST_CONFIG.cache_arg_name, "--cargo-home");
+        assert_eq!(RUST_CONFIG.script_name, "docker-cargo-script.sh");
+    }
+}

--- a/tools/buildsys/src/vendormod/error.rs
+++ b/tools/buildsys/src/vendormod/error.rs
@@ -3,13 +3,13 @@ use std::path::PathBuf;
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
-#[snafu(visibility(pub(super)))]
+#[snafu(visibility(pub(crate)))]
 pub(crate) enum Error {
     #[snafu(display("Failed to start command: {}", source))]
     CommandStart { source: std::io::Error },
 
-    #[snafu(display("Failed to execute docker-go script. 'args: {}'", args))]
-    DockerExecution { args: String },
+    #[snafu(display("Failed to execute {} script. 'args: {}'", tool, args))]
+    DockerExecution { tool: String, args: String },
 
     #[snafu(display("Input url is required"))]
     InputFile,
@@ -60,4 +60,4 @@ pub(crate) enum Error {
     },
 }
 
-pub(super) type Result<T> = std::result::Result<T, Error>;
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/twoliter/embedded/docker-cargo
+++ b/twoliter/embedded/docker-cargo
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Helper script for running commands in a Rust build/runtime environment for testing/vendoring/building a Rust crate
+
+set -e -o pipefail
+
+usage() {
+   cat >&2 <<EOF
+$(basename "${0}")
+                --module-path <path to Rust project>
+                --sdk-image <SDK image>
+                --cargo-home <path to CARGO_HOME>
+                --command "<command to run>"
+
+Required:
+    --module-path               The path of the Rust project to mount into the container
+    --sdk-image                 Name of the SDK image to use
+    --cargo-home                The Cargo home path to mount into the container
+    --command                   The command to run in the SDK container
+EOF
+}
+
+required_arg() {
+   local arg="${1:?}"
+   local value="${2}"
+   if [ -z "${value}" ]; then
+      echo "ERROR: ${arg} is required" >&2
+      exit 2
+   fi
+}
+
+parse_args() {
+  while [ ${#} -gt 0 ] ; do
+    case "${1}" in
+        --help ) usage; exit 0 ;;
+        --module-path ) shift; MODULE_PATH="${1}" ;;
+        --sdk-image ) shift; SDK_IMAGE="${1}" ;;
+        --cargo-home ) shift; CARGO_HOME="${1}" ;;
+        --command ) shift; COMMAND="${@:1}" ;;
+        *) ;;
+    esac
+    shift
+  done
+
+  required_arg "--module-path" "${MODULE_PATH}"
+  required_arg "--sdk-image" "${SDK_IMAGE}"
+  required_arg "--cargo-home" "${CARGO_HOME}"
+  required_arg "--command" "${COMMAND}"
+}
+
+DOCKER_RUN_ARGS="--network=host"
+
+parse_args "${@}"
+
+proxy_env=( )
+for i in http_proxy https_proxy no_proxy HTTP_PROXY HTTPS_PROXY NO_PROXY ; do
+  if [ -n "${!i}" ]; then
+    proxy_env[${#proxy_env[@]}]="--env=$i=${!i}"
+  fi
+done
+
+docker run --rm \
+  -e CARGO_HOME="${CARGO_HOME}" \
+  -e CARGO_TARGET_DIR='/tmp/.cache' \
+  "${proxy_env[@]}" \
+  --user "$(id -u):$(id -g)" \
+  --security-opt="label=disable" \
+  ${DOCKER_RUN_ARGS} \
+  -v "${CARGO_HOME}":"${CARGO_HOME}" \
+  -v "${MODULE_PATH}":"${MODULE_PATH}" \
+  -w "${MODULE_PATH}" \
+  "${SDK_IMAGE}" \
+    bash -c "${COMMAND}"

--- a/twoliter/src/tool-crates/embedded-bundle/build.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/build.rs
@@ -27,6 +27,7 @@ fn main() {
     paths.copy_file("Makefile.toml");
     paths.copy_file("build.Dockerfile");
     paths.copy_file("build.Dockerfile.dockerignore");
+    paths.copy_file("docker-cargo");
     paths.copy_file("docker-go");
     paths.copy_file("img2img");
     paths.copy_file("imghelper");


### PR DESCRIPTION
Refactor gomod.rs into a shared VendorMod abstraction and add a Rust vendoring path using `cargo vendor --locked`. Add docker-cargo embedded tool for running cargo in the SDK container.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
Refactor gomod.rs into a shared VendorMod abstraction and add a Rust vendoring path using `cargo vendor --locked`. Add docker-cargo embedded tool for running cargo in the SDK container.

This follows the same model as Go third-party vendoring


**Testing done:**
- Built a Rust package in bottlerocket-core-kit with `bundle-modules = ["rust"]` set, confirming end-to-end vendoring works 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
