### PR TITLE
pubsys: support publishing one AMI into multiple accounts per region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* pubsys: support publishing a single AMI into multiple accounts within the same region via a new `roles` list on `[aws.region.*]`. `role` and `roles` are mutually exclusive per region. ([#4858])
+
+### Changed
+* pubsys: the `--ami-input` JSON produced by `pubsys ami` and consumed by `pubsys ssm` / `pubsys publish-ami` is now a versioned envelope, `{"schema_version": 2, "amis": {region: {account_id: {…ami…}}}}`, replacing the previous bare `{region: {…ami…}}` map (now "v1"). A missing `schema_version` is treated as implied v1; any versioned file must carry the field, and an unrecognized version is rejected. Legacy v1 files are read transparently — each region's AMI is lifted into the per-account model by resolving the account from the region's role ARN (or via STS for a region with no configured role) — so existing inputs keep working. `pubsys ami` always writes v2 output. ([#4858])
+
+[#4858]: https://github.com/bottlerocket-os/bottlerocket/issues/4858
+
 [unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.20.0...HEAD
 
 ## [0.21.0] - 2026-06-19

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -138,11 +138,61 @@ pub struct AwsConfig {
     pub s3: Option<HashMap<String, S3Config>>,
 }
 
-/// AWS region-specific configuration
+/// A region's role configuration: either a single role or a list of roles, but not both. These
+/// are mutually exclusive by construction (a flattened, untagged enum), so an `Infra.toml` that
+/// specifies both `role` and `roles` for the same region fails to parse.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum RoleConfig {
+    /// A single role to assume for this region. Assumed after the "global" `aws.role`, if that is
+    /// also specified. Serializes to/from the `role` key in Infra.toml.
+    Role(String),
+
+    /// Multiple roles to assume for this region, one per target account. Each role is assumed
+    /// independently (after the "global" `aws.role`), producing a separate set of AMIs / SSM
+    /// parameters per account. Serializes to/from the `roles` key in Infra.toml.
+    Roles(Vec<String>),
+}
+
+/// AWS region-specific configuration
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct AwsRegionConfig {
-    pub role: Option<String>,
+    #[serde(flatten)]
+    pub role_config: Option<RoleConfig>,
+}
+
+impl AwsRegionConfig {
+    /// Returns the roles configured for this region as an ordered, de-duplicated list, or `None`
+    /// if no roles are configured (meaning "use the base/global credentials without assuming a
+    /// region-specific role").
+    pub fn all_roles(&self) -> Option<Vec<String>> {
+        let roles: Vec<&String> = match &self.role_config {
+            None => return None,
+            Some(RoleConfig::Role(role)) => vec![role],
+            Some(RoleConfig::Roles(roles)) => roles.iter().collect(),
+        };
+
+        let mut seen = std::collections::HashSet::new();
+        Some(
+            roles
+                .into_iter()
+                .filter(|role| seen.insert((*role).clone()))
+                .cloned()
+                .collect(),
+        )
+    }
+
+    /// Returns the configured role whose ARN targets the given account, by matching the account ID
+    /// embedded in a role ARN (`arn:aws:iam::<account>:role/...`). Returns `None` if no configured
+    /// role matches; for example when the AMI was published using the base/global credentials.
+    pub fn role_for_account(&self, account_id: &str) -> Option<String> {
+        let needle = format!(":{account_id}:");
+        self.all_roles()
+            .into_iter()
+            .flatten()
+            .find(|role| role.contains(&needle))
+    }
 }
 
 /// Location of signing keys
@@ -302,4 +352,130 @@ fn repo_expiration_deserialization_test() {
         .join("repo-expiration")
         .join("2w-2w-1w.toml");
     let _ = RepoExpirationPolicy::from_path(path).unwrap();
+}
+
+#[cfg(test)]
+mod aws_region_config_test {
+    use super::{AwsRegionConfig, RoleConfig};
+
+    fn arn(account: &str) -> String {
+        format!("arn:aws:iam::{account}:role/BottlerocketSourceRole")
+    }
+
+    #[test]
+    fn all_roles_empty_returns_none() {
+        let config = AwsRegionConfig { role_config: None };
+        assert_eq!(config.all_roles(), None);
+    }
+
+    #[test]
+    fn all_roles_single_role() {
+        let config = AwsRegionConfig {
+            role_config: Some(RoleConfig::Role(arn("111111111111"))),
+        };
+        assert_eq!(config.all_roles(), Some(vec![arn("111111111111")]));
+    }
+
+    #[test]
+    fn all_roles_lists_roles_in_order() {
+        let config = AwsRegionConfig {
+            role_config: Some(RoleConfig::Roles(vec![
+                arn("111111111111"),
+                arn("222222222222"),
+                arn("333333333333"),
+            ])),
+        };
+        assert_eq!(
+            config.all_roles(),
+            Some(vec![
+                arn("111111111111"),
+                arn("222222222222"),
+                arn("333333333333"),
+            ])
+        );
+    }
+
+    #[test]
+    fn all_roles_dedups_preserving_order() {
+        let config = AwsRegionConfig {
+            role_config: Some(RoleConfig::Roles(vec![
+                arn("111111111111"),
+                arn("111111111111"),
+                arn("222222222222"),
+            ])),
+        };
+        assert_eq!(
+            config.all_roles(),
+            Some(vec![arn("111111111111"), arn("222222222222")])
+        );
+    }
+
+    #[test]
+    fn role_for_account_matches_embedded_account_id() {
+        let config = AwsRegionConfig {
+            role_config: Some(RoleConfig::Roles(vec![
+                arn("111111111111"),
+                arn("222222222222"),
+            ])),
+        };
+        assert_eq!(
+            config.role_for_account("222222222222"),
+            Some(arn("222222222222"))
+        );
+        assert_eq!(
+            config.role_for_account("111111111111"),
+            Some(arn("111111111111"))
+        );
+        assert_eq!(config.role_for_account("999999999999"), None);
+    }
+
+    #[test]
+    fn region_config_deserializes_single_role() {
+        let toml_str = r#"role = "arn:aws:iam::111111111111:role/BottlerocketSourceRole""#;
+        let config: AwsRegionConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.role_config,
+            Some(RoleConfig::Role(arn("111111111111")))
+        );
+        assert_eq!(config.all_roles(), Some(vec![arn("111111111111")]));
+    }
+
+    #[test]
+    fn region_config_deserializes_roles_list() {
+        let toml_str = r#"
+            roles = [
+                "arn:aws:iam::222222222222:role/BottlerocketSourceRole",
+                "arn:aws:iam::333333333333:role/BottlerocketSourceRole",
+            ]
+        "#;
+        let config: AwsRegionConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.role_config,
+            Some(RoleConfig::Roles(vec![
+                arn("222222222222"),
+                arn("333333333333")
+            ]))
+        );
+        assert_eq!(
+            config.all_roles(),
+            Some(vec![arn("222222222222"), arn("333333333333")])
+        );
+    }
+
+    #[test]
+    fn region_config_empty_is_none() {
+        let config: AwsRegionConfig = toml::from_str("").unwrap();
+        assert_eq!(config.role_config, None);
+        assert_eq!(config.all_roles(), None);
+    }
+
+    #[test]
+    fn region_config_role_and_roles_are_mutually_exclusive() {
+        // Specifying both `role` and `roles` for the same region must fail to parse.
+        let toml_str = r#"
+            role = "arn:aws:iam::111111111111:role/BottlerocketSourceRole"
+            roles = ["arn:aws:iam::222222222222:role/BottlerocketSourceRole"]
+        "#;
+        assert!(toml::from_str::<AwsRegionConfig>(toml_str).is_err());
+    }
 }

--- a/tools/pubsys/Infra.toml.example
+++ b/tools/pubsys/Infra.toml.example
@@ -49,7 +49,20 @@ ssm_prefix = "/your/prefix/here"
 [aws.region.us-west-2]
 # If specified, we assume this role before making any API calls in this region.
 # (This is assumed after the "global" aws.role, if that is also specified.)
+# A region may specify *either* a single `role` (as here) or a `roles` list (see below), but not
+# both.
 role = "arn:aws:iam::012345678901:role/assume-regional"
+
+[aws.region.us-east-1]
+# To publish a single AMI into multiple accounts within the same region, list one role per target
+# account in `roles` instead of a single `role`.  We register the AMI once in the first account,
+# then copy it into each additional account, and publish a separate set of SSM parameters per
+# account.  Each role's ARN identifies the account it targets.  (Each role is assumed after the
+# "global" aws.role, if that is also specified.)
+roles = [
+    "arn:aws:iam::111111111111:role/assume-regional", # pre-prod
+    "arn:aws:iam::098765432109:role/assume-regional", # prod
+]
 
 [vmware]
 # A list of datacenter names to which you would like to upload an OVA.  These

--- a/tools/pubsys/src/aws/ami/mod.rs
+++ b/tools/pubsys/src/aws/ami/mod.rs
@@ -11,7 +11,7 @@ use self::register::mk_amispec;
 use crate::aws::ami::launch_permissions::get_launch_permissions;
 use crate::aws::ami::public::ami_is_public;
 use crate::aws::publish_ami::{get_snapshots, modify_image, modify_snapshots, ModifyOptions};
-use crate::aws::{client::build_client_config, region_from_string};
+use crate::aws::{client::build_client_config_for_role, region_from_string};
 use crate::frompath::FromPath;
 use crate::Args;
 use aws_sdk_ebs::Client as EbsClient;
@@ -105,8 +105,9 @@ pub(crate) async fn run(args: &Args, ami_args: &AmiArgs) -> Result<()> {
     }
 }
 
-async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>> {
-    let mut amis = HashMap::new();
+async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<RegionAccountImageMap> {
+    // Maps each region to a map of account ID -> the AMI registered/copied into that account.
+    let mut amis: RegionAccountImageMap = HashMap::new();
 
     // If a lock file exists, use that, otherwise use Infra.toml or default
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, true)
@@ -132,11 +133,20 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         }
     );
 
-    // We register in this base region first, then copy from there to any other regions.
+    // We register in this base region first, then copy from there to any other regions/accounts.
     let base_region = regions.remove(0);
 
+    // A region can target multiple accounts, one per configured role. We register the AMI once,
+    // using the first role of the base region (the "base account"), then copy it to every other
+    // (region, account) target.
+    let base_role = roles_for_region(&aws, &base_region)
+        .into_iter()
+        .next()
+        .flatten();
+
     // Build EBS client for snapshot management, and EC2 client for registration
-    let client_config = build_client_config(&base_region, &base_region, &aws).await;
+    let client_config =
+        build_client_config_for_role(&base_region, &base_region, &aws, base_role.as_deref()).await;
 
     let base_ebs_client = EbsClient::new(&client_config);
 
@@ -230,18 +240,49 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     #[expect(unused_variables)]
     let ami_args = ();
 
-    amis.insert(
-        base_region.as_ref().to_string(),
-        Image::new(
-            &ids_of_image.image_id,
-            &tentative_amispec.name,
-            Some(public),
-            Some(launch_permissions),
-        ),
-    );
+    // Resolve the account ID behind the base region's (base) role; this keys the source AMI in our
+    // output map. When a role is configured we parse the account ID out of its ARN; otherwise we
+    // fall back to STS to discover the account behind the base/global credentials.
+    let base_account_id = match &base_role {
+        Some(role) => account_id_from_role_arn(role)
+            .context(error::ParseRoleArnSnafu { role: role.clone() })?,
+        None => {
+            let base_sts_client = StsClient::new(&client_config);
+            get_account_id(&base_sts_client, &base_region).await?
+        }
+    };
 
-    // If we don't need to copy AMIs, we're done.
-    if regions.is_empty() {
+    amis.entry(base_region.as_ref().to_string())
+        .or_default()
+        .insert(
+            base_account_id.clone(),
+            Image::new(
+                &ids_of_image.image_id,
+                &tentative_amispec.name,
+                Some(public),
+                Some(launch_permissions),
+            ),
+        );
+
+    // Build the full list of (region, role) targets we need to copy into, which is the cartesian
+    // product of every region and every role configured for it, minus the source (base region,
+    // base role) pair which we just registered above.
+    let mut targets = Vec::new();
+    for region in std::iter::once(&base_region).chain(regions.iter()) {
+        for role in roles_for_region(&aws, region) {
+            // Skip the source pair; it's already registered.
+            if region.as_ref() == base_region.as_ref() && role == base_role {
+                continue;
+            }
+            targets.push(RegionRole {
+                region: region.clone(),
+                role,
+            });
+        }
+    }
+
+    // If we don't need to copy AMIs to any other target, we're done.
+    if targets.is_empty() {
         return Ok(amis);
     }
 
@@ -254,6 +295,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         "available",
         successes_required,
         &aws,
+        base_role.clone(),
     )
     .await
     .context(error::WaitAmiSnafu {
@@ -261,39 +303,40 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         region: base_region.as_ref(),
     })?;
 
-    // For every other region, initiate copy-image calls.
+    // For every other target, initiate copy-image calls.
 
-    // First we need to find the account IDs for any given roles, so we can grant access to those
-    // accounts to copy the AMI and snapshots.
-    info!("Getting account IDs for target regions so we can grant access to copy source AMI");
-    let mut account_ids = get_account_ids(&regions, &base_region, &aws).await?;
+    // First, make EC2 and STS clients per target so we can resolve account IDs, fetch, and copy
+    // AMIs.  We make a map storing our clients because they're used in a future and need to live
+    // until the future is resolved.
+    let mut ec2_clients = HashMap::with_capacity(targets.len());
+    for target in targets.iter() {
+        let client_config = build_client_config_for_role(
+            &target.region,
+            &base_region,
+            &aws,
+            target.role.as_deref(),
+        )
+        .await;
+        let ec2_client = Ec2Client::new(&client_config);
+        ec2_clients.insert(target.clone(), ec2_client);
+    }
 
-    // Get the account ID used in the base region; we don't need to grant to it so we can remove it
-    // from the list.
-    let client_config = build_client_config(&base_region, &base_region, &aws).await;
-    let base_sts_client = StsClient::new(&client_config);
+    // Resolve the account ID behind each target's role so we can key the output map and grant
+    // access to the source snapshots/AMI.
+    info!("Getting account IDs for targets so we can grant access to copy source AMI");
+    let account_ids = get_account_ids(&targets, &base_region, &aws).await?;
 
-    let response = base_sts_client
-        .get_caller_identity()
-        .send()
-        .await
-        .map_err(AwsSdkError::from)
-        .context(error::GetCallerIdentitySnafu {
-            region: base_region.as_ref(),
-        })?;
-    let base_account_id = response.account.context(error::MissingInResponseSnafu {
-        request_type: "GetCallerIdentity",
-        missing: "account",
-    })?;
-    account_ids.remove(&base_account_id);
-
-    // If we have any accounts other than the base account, grant them access.
-    if !account_ids.is_empty() {
+    // Grant access to every target account (other than the base account) so they can copy the AMI
+    // and its snapshots.
+    let grant_account_ids: HashSet<String> = account_ids
+        .values()
+        .filter(|account_id| **account_id != base_account_id)
+        .cloned()
+        .collect();
+    if !grant_account_ids.is_empty() {
         info!("Granting access to target accounts so we can copy the AMI");
-        let account_id_vec: Vec<_> = account_ids.into_iter().collect();
-
         let modify_options = ModifyOptions {
-            user_ids: account_id_vec,
+            user_ids: grant_account_ids.into_iter().collect(),
             group_names: Vec::new(),
             organization_arns: Vec::new(),
             organizational_unit_arns: Vec::new(),
@@ -325,31 +368,26 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         })?;
     }
 
-    // Next, make EC2 clients so we can fetch and copy AMIs.  We make a map storing our regional
-    // clients because they're used in a future and need to live until the future is resolved.
-    let mut ec2_clients = HashMap::with_capacity(regions.len());
-    for region in regions.iter() {
-        let client_config = build_client_config(region, &base_region, &aws).await;
-        let ec2_client = Ec2Client::new(&client_config);
-        ec2_clients.insert(region.clone(), ec2_client);
-    }
-
-    // First, we check if the AMI already exists in each region.
-    info!("Checking whether AMIs already exist in target regions");
-    let mut get_requests = Vec::with_capacity(regions.len());
-    for region in regions.iter() {
-        let ec2_client = &ec2_clients[region];
-        let get_request = get_ami_id(&tentative_amispec.name, &arch, region, ec2_client);
-        let info_future = ready(region.clone());
+    // First, we check if the AMI already exists in each target (region + account).
+    info!("Checking whether AMIs already exist in target regions/accounts");
+    let mut get_requests = Vec::with_capacity(targets.len());
+    for target in targets.iter() {
+        let ec2_client = &ec2_clients[target];
+        let get_request = get_ami_id(&tentative_amispec.name, &arch, &target.region, ec2_client);
+        let info_future = ready(target.clone());
         get_requests.push(join(info_future, get_request));
     }
     let request_stream = stream::iter(get_requests).buffer_unordered(4);
-    let get_responses: Vec<(Region, std::result::Result<Option<String>, register::Error>)> =
-        request_stream.collect().await;
+    let get_responses: Vec<(
+        RegionRole,
+        std::result::Result<Option<String>, register::Error>,
+    )> = request_stream.collect().await;
 
     // If an AMI already existed, just add it to our list, otherwise prepare a copy request.
-    let mut copy_requests = Vec::with_capacity(regions.len());
-    for (region, get_response) in get_responses {
+    let mut copy_requests = Vec::with_capacity(targets.len());
+    for (target, get_response) in get_responses {
+        let region = &target.region;
+        let account_id = &account_ids[&target];
         let get_response = get_response.context(error::GetAmiIdSnafu {
             name: &tentative_amispec.name,
             arch: &arch,
@@ -357,10 +395,10 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
         })?;
         if let Some(id) = get_response {
             info!(
-                "Found '{}' already registered in {}: {}",
-                tentative_amispec.name, region, id
+                "Found '{}' already registered in {} ({}): {}",
+                tentative_amispec.name, region, account_id, id
             );
-            let public = ami_is_public(&ec2_clients[&region], region.as_ref(), &id)
+            let public = ami_is_public(&ec2_clients[&target], region.as_ref(), &id)
                 .await
                 .context(error::IsAmiPublicSnafu {
                     image_id: id.clone(),
@@ -368,15 +406,15 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
                 })?;
 
             let launch_permissions =
-                get_launch_permissions(&ec2_clients[&region], region.as_ref(), &id)
+                get_launch_permissions(&ec2_clients[&target], region.as_ref(), &id)
                     .await
                     .context(error::DescribeImageAttributeSnafu {
                         region: region.as_ref(),
                         image_id: id.clone(),
                     })?;
 
-            amis.insert(
-                region.as_ref().to_string(),
+            amis.entry(region.as_ref().to_string()).or_default().insert(
+                account_id.clone(),
                 Image::new(
                     &id,
                     &tentative_amispec.name,
@@ -387,7 +425,7 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
             continue;
         }
 
-        let ec2_client = &ec2_clients[&region];
+        let ec2_client = &ec2_clients[&target];
         let base_region = base_region.to_owned();
         let copy_future = ec2_client
             .copy_image()
@@ -399,14 +437,18 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
             .send()
             .map_err(AwsSdkError::from);
 
-        // Store the region so we can output it to the user
-        let region_future = ready(region.clone());
+        // Store the target so we can output it to the user
+        let target_future = ready(target.clone());
         // Let the user know the copy is starting, when this future goes to run
-        let message_future = lazy(move |_| info!("Starting copy from {base_region} to {region}"));
-        copy_requests.push(message_future.then(|_| join(region_future, copy_future)));
+        let dest_region = region.clone();
+        let dest_account = account_id.clone();
+        let message_future = lazy(move |_| {
+            info!("Starting copy from {base_region} to {dest_region} ({dest_account})")
+        });
+        copy_requests.push(message_future.then(|_| join(target_future, copy_future)));
     }
 
-    // If all target regions already have the AMI, we're done.
+    // If all targets already have the AMI, we're done.
     if copy_requests.is_empty() {
         return Ok(amis);
     }
@@ -415,27 +457,29 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     // afterward.  You should wait for the AMI status to be "available" before launching it.
     // (We still use buffer_unordered, rather than something like join_all, to retain some control
     // over the number of requests going out in case we need it later, but this will effectively
-    // spin through all regions quickly because the requests return before any copying is done.)
+    // spin through all targets quickly because the requests return before any copying is done.)
     let request_stream = stream::iter(copy_requests).buffer_unordered(4);
     // Run through the stream and collect results into a list.
     let copy_responses: Vec<(
-        Region,
+        RegionRole,
         std::result::Result<CopyImageOutput, AwsSdkError<CopyImageError>>,
     )> = request_stream.collect().await;
 
     // Report on successes and errors; don't fail immediately if we see an error so we can report
     // all successful IDs.
     let mut saw_error = false;
-    for (region, copy_response) in copy_responses {
+    for (target, copy_response) in copy_responses {
+        let region = &target.region;
+        let account_id = &account_ids[&target];
         match copy_response {
             Ok(success) => {
                 if let Some(image_id) = success.image_id {
                     info!(
-                        "Registered AMI '{}' in {}: {}",
-                        tentative_amispec.name, region, image_id,
+                        "Registered AMI '{}' in {} ({}): {}",
+                        tentative_amispec.name, region, account_id, image_id,
                     );
-                    amis.insert(
-                        region.as_ref().to_string(),
+                    amis.entry(region.as_ref().to_string()).or_default().insert(
+                        account_id.clone(),
                         Image::new(
                             &image_id,
                             &tentative_amispec.name,
@@ -446,16 +490,17 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
                 } else {
                     saw_error = true;
                     error!(
-                        "Registered AMI '{}' in {} but didn't receive an AMI ID!",
-                        tentative_amispec.name, region,
+                        "Registered AMI '{}' in {} ({}) but didn't receive an AMI ID!",
+                        tentative_amispec.name, region, account_id,
                     );
                 }
             }
             Err(e) => {
                 saw_error = true;
                 error!(
-                    "Copy to {} failed: {}",
+                    "Copy to {} ({}) failed: {}",
                     region,
+                    account_id,
                     e.as_service_error()
                         .and_then(|err| err.code())
                         .unwrap_or("unknown")
@@ -467,6 +512,240 @@ async fn _run(args: &Args, ami_args: &AmiArgs) -> Result<HashMap<String, Image>>
     ensure!(!saw_error, error::AmiCopySnafu);
 
     Ok(amis)
+}
+
+/// An account ID, in its 12-digit string form.
+pub(crate) type AccountId = String;
+
+/// The output of an AMI publish run: for each region, a map of account ID to the AMI that was
+/// registered or copied into that account.  A single region can map to multiple accounts when
+/// multiple roles are configured for it.  The `ssm` and `publish-ami` subcommands consume this
+/// (serialized to JSON, inside an [`AmiInputFile`] envelope) to know which AMIs exist where.
+pub(crate) type RegionAccountImageMap = HashMap<String, HashMap<AccountId, Image>>;
+
+/// The current schema version of the `--ami-input` / `--ami-output` JSON file.
+///
+/// Version 1 is the legacy, pre-multi-account format: a bare `{region: Image}` map with no
+/// version field. It was never written with an explicit `schema_version`, so we don't define a
+/// constant for it; it's recognized structurally on read (see [`AmiInputFile`]).
+///
+/// Version 2 introduced the per-account nesting (`{region: {account: Image}}`) and the explicit
+/// `schema_version` envelope. New files are always written as v2.
+pub(crate) const AMI_INPUT_SCHEMA_VERSION: u32 = 2;
+
+/// The current (v2) envelope written to `--ami-output`. Wrapping the AMI map in a struct with an
+/// explicit `schema_version` lets consumers (including external tooling) detect the format and
+/// lets us evolve it without silently misparsing.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct AmiInputFile {
+    /// The schema version of this file; see [`AMI_INPUT_SCHEMA_VERSION`].
+    pub(crate) schema_version: u32,
+    /// The region -> account -> AMI mapping.
+    pub(crate) amis: RegionAccountImageMap,
+}
+
+/// The result of parsing an `--ami-input` file: either the current versioned, per-account map, or
+/// a legacy v1 map that still needs to be lifted into the per-account model (see
+/// [`lift_legacy_ami_input`]).
+#[derive(Debug)]
+pub(crate) enum AmiInput {
+    /// The current (v2+) format: a region -> account -> AMI map.
+    Versioned(RegionAccountImageMap),
+    /// The legacy v1 format: a bare region -> AMI map, with no account dimension.
+    Legacy(HashMap<String, Image>),
+}
+
+/// A tolerant reader for the `--ami-input` file that accepts either the current versioned format
+/// or the legacy unversioned one. This is `#[serde(untagged)]` so that v1 files - which predate
+/// the `schema_version` field - still parse without it, while v2+ files are recognized by their
+/// envelope. Serde tries the variants top-to-bottom, so `Versioned` must come first.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum MaybeVersionedAmiInput {
+    /// The current format: an explicit `schema_version` plus the nested AMI map.
+    Versioned(AmiInputFile),
+    /// The legacy v1 format: a bare `region -> Image` map, no version field.
+    Legacy(HashMap<String, Image>),
+}
+
+impl AmiInputFile {
+    /// Wraps an AMI map in an envelope stamped with the current schema version.
+    pub(crate) fn new(amis: RegionAccountImageMap) -> Self {
+        Self {
+            schema_version: AMI_INPUT_SCHEMA_VERSION,
+            amis,
+        }
+    }
+
+    /// Parses an `--ami-input` file from JSON bytes, classifying it as either the current
+    /// versioned format or a legacy v1 file. A versioned file with an unrecognized
+    /// `schema_version` is rejected. Legacy files are returned as-is for the caller to lift via
+    /// [`lift_legacy_ami_input`] (which needs config/credentials this sync parser doesn't have).
+    pub(crate) fn from_json(bytes: &[u8]) -> std::result::Result<AmiInput, AmiInputError> {
+        let parsed: MaybeVersionedAmiInput = serde_json::from_slice(bytes)
+            .map_err(|source| AmiInputError::Deserialize { source })?;
+        match parsed {
+            MaybeVersionedAmiInput::Versioned(file) => {
+                ensure!(
+                    file.schema_version == AMI_INPUT_SCHEMA_VERSION,
+                    UnsupportedVersionSnafu {
+                        found: file.schema_version,
+                        supported: AMI_INPUT_SCHEMA_VERSION,
+                    }
+                );
+                Ok(AmiInput::Versioned(file.amis))
+            }
+            MaybeVersionedAmiInput::Legacy(map) => Ok(AmiInput::Legacy(map)),
+        }
+    }
+}
+
+/// Reads an `--ami-input` file and returns it in the current per-account form, transparently
+/// lifting a legacy v1 file if necessary. This is the entry point the `ssm` and `publish-ami`
+/// subcommands should use.
+pub(crate) async fn read_ami_input(
+    bytes: &[u8],
+    pubsys_aws_config: &PubsysAwsConfig,
+    base_region: &Region,
+) -> std::result::Result<RegionAccountImageMap, AmiInputError> {
+    match AmiInputFile::from_json(bytes)? {
+        AmiInput::Versioned(amis) => Ok(amis),
+        AmiInput::Legacy(legacy) => {
+            info!("AMI input is in the legacy (v1) format; lifting it into the per-account model");
+            lift_legacy_ami_input(legacy, pubsys_aws_config, base_region).await
+        }
+    }
+}
+
+/// Lifts a legacy (v1) `region -> Image` map into the current per-account model. A v1 file has one
+/// AMI per region and no account dimension, so for each region we resolve the single account that
+/// AMI belongs to: from the region's configured role ARN when one is set, or - for a region using
+/// the base/global credentials with no role - via an STS `GetCallerIdentity` call.
+pub(crate) async fn lift_legacy_ami_input(
+    legacy: HashMap<String, Image>,
+    pubsys_aws_config: &PubsysAwsConfig,
+    base_region: &Region,
+) -> std::result::Result<RegionAccountImageMap, AmiInputError> {
+    let mut amis: RegionAccountImageMap = HashMap::new();
+    for (region_name, image) in legacy {
+        let region = region_from_string(&region_name);
+        let account_id = region_account_id(&region, pubsys_aws_config, base_region).await?;
+        amis.entry(region_name)
+            .or_default()
+            .insert(account_id, image);
+    }
+    Ok(amis)
+}
+
+/// Resolves the single account ID reachable in a region under the current config: the account
+/// embedded in the region's configured role ARN, or - for a region with no role - the account
+/// behind the base/global credentials (discovered via STS).
+///
+/// This is the right notion of "the account for a region" for the single-account-per-region flows
+/// (`promote-ssm`, `validate-ssm`, and legacy `--ami-input` lifting). For a region configured with
+/// multiple `roles`, it returns the first.
+pub(crate) async fn region_account_id(
+    region: &Region,
+    pubsys_aws_config: &PubsysAwsConfig,
+    base_region: &Region,
+) -> std::result::Result<AccountId, AmiInputError> {
+    let maybe_role = roles_for_region(pubsys_aws_config, region)
+        .into_iter()
+        .next()
+        .flatten();
+
+    match maybe_role {
+        // The account ID is embedded in the role ARN - no API call needed.
+        Some(role) => {
+            account_id_from_role_arn(&role).context(LiftParseRoleArnSnafu { role: role.clone() })
+        }
+        // No role: ask STS which account the base/global credentials land in.
+        None => {
+            let client_config =
+                build_client_config_for_role(region, base_region, pubsys_aws_config, None).await;
+            let sts_client = StsClient::new(&client_config);
+            let response = sts_client
+                .get_caller_identity()
+                .send()
+                .await
+                .map_err(AwsSdkError::from)
+                .map_err(|source| AmiInputError::LiftResolveAccount {
+                    region: region.as_ref().to_string(),
+                    source: Box::new(source),
+                })?;
+            response.account.context(LiftMissingAccountSnafu {
+                region: region.as_ref().to_string(),
+            })
+        }
+    }
+}
+
+/// Errors that can occur while parsing or lifting an `--ami-input` file.
+#[derive(Debug, snafu::Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum AmiInputError {
+    #[snafu(display(
+        "AMI input file has schema_version {} but this pubsys only supports version {}. \
+         Regenerate it with `pubsys ami` using a compatible version.",
+        found,
+        supported
+    ))]
+    UnsupportedVersion { found: u32, supported: u32 },
+
+    #[snafu(display("Failed to deserialize AMI input file: {}", source))]
+    Deserialize { source: serde_json::Error },
+
+    #[snafu(display(
+        "Failed to parse an account ID out of the role ARN '{}' while lifting a legacy AMI input \
+         file; expected the form 'arn:aws:iam::<account>:role/<name>'",
+        role
+    ))]
+    LiftParseRoleArn { role: String },
+
+    #[snafu(display(
+        "Failed to resolve the account for legacy region '{}' via STS: {}",
+        region,
+        source
+    ))]
+    LiftResolveAccount {
+        region: String,
+        source: Box<AwsSdkError<GetCallerIdentityError>>,
+    },
+
+    #[snafu(display("STS did not return an account ID for legacy region '{}'", region))]
+    LiftMissingAccount { region: String },
+}
+
+/// Identifies a single copy target: a region together with the role to assume to reach a
+/// particular account in that region.  A `None` role means "use the base/global credentials".
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct RegionRole {
+    pub(crate) region: Region,
+    pub(crate) role: Option<String>,
+}
+
+/// Identifies a single AMI: a region together with the account that owns the AMI.  A single region
+/// can contain multiple accounts when multiple roles are configured for it.  The `ssm` and
+/// `publish-ami` subcommands use this to key AMIs read from the input JSON.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct RegionAccount {
+    pub(crate) region: Region,
+    pub(crate) account_id: AccountId,
+}
+
+/// Returns the publish targets for the given region: one entry per account to publish to, where
+/// `Some(role)` means "assume this role" and `None` means "use the base/global credentials without
+/// assuming a region-specific role".  A region with no configured role (or no config entry at all)
+/// yields a single `None` target.
+fn roles_for_region(pubsys_aws_config: &PubsysAwsConfig, region: &Region) -> Vec<Option<String>> {
+    match pubsys_aws_config
+        .region
+        .get(region.as_ref())
+        .and_then(|region_config| region_config.all_roles())
+    {
+        Some(roles) => roles.into_iter().map(Some).collect(),
+        None => vec![None],
+    }
 }
 
 /// If JSON output was requested, we serialize out a mapping of region to AMI information; this
@@ -496,56 +775,113 @@ impl Image {
     }
 }
 
-/// Returns the set of account IDs associated with the roles configured for the given regions.
-async fn get_account_ids(
-    regions: &[Region],
-    base_region: &Region,
-    pubsys_aws_config: &PubsysAwsConfig,
-) -> Result<HashSet<String>> {
-    let mut grant_accounts = HashSet::new();
-
-    // We make a map storing our regional clients because they're used in a future and need to
-    // live until the future is resolved.
-    let mut sts_clients = HashMap::with_capacity(regions.len());
-    for region in regions.iter() {
-        let client_config = build_client_config(region, base_region, pubsys_aws_config).await;
-        let sts_client = StsClient::new(&client_config);
-        sts_clients.insert(region.clone(), sts_client);
-    }
-
-    let mut requests = Vec::with_capacity(regions.len());
-    for region in regions.iter() {
-        let sts_client = &sts_clients[region];
-        let response_future = sts_client
-            .get_caller_identity()
-            .send()
-            .map_err(AwsSdkError::from);
-
-        // Store the region so we can include it in any errors
-        let region_future = ready(region.clone());
-        requests.push(join(region_future, response_future));
-    }
-
-    let request_stream = stream::iter(requests).buffer_unordered(4);
-    // Run through the stream and collect results into a list.
-    let responses: Vec<(
-        Region,
-        std::result::Result<GetCallerIdentityOutput, AwsSdkError<GetCallerIdentityError>>,
-    )> = request_stream.collect().await;
-
-    for (region, response) in responses {
-        let response = response.context(error::GetCallerIdentitySnafu {
+/// Resolves the account ID reachable through the given STS client (in the given region, used only
+/// for error messages).
+async fn get_account_id(sts_client: &StsClient, region: &Region) -> Result<String> {
+    let response = sts_client
+        .get_caller_identity()
+        .send()
+        .await
+        .map_err(AwsSdkError::from)
+        .context(error::GetCallerIdentitySnafu {
             region: region.as_ref(),
         })?;
-        let account_id = response.account.context(error::MissingInResponseSnafu {
-            request_type: "GetCallerIdentity",
-            missing: "account",
-        })?;
-        grant_accounts.insert(account_id);
-    }
-    trace!("Found account IDs {grant_accounts:?}");
+    response.account.context(error::MissingInResponseSnafu {
+        request_type: "GetCallerIdentity",
+        missing: "account",
+    })
+}
 
-    Ok(grant_accounts)
+/// Parses the 12-digit account ID out of an IAM role ARN of the form
+/// `arn:aws:iam::<account>:role/<name>` (the partition may vary, e.g. `aws-us-gov`). Returns
+/// `None` if the string isn't an ARN with an account ID in the expected position.
+fn account_id_from_role_arn(role_arn: &str) -> Option<String> {
+    // ARN format: arn:<partition>:<service>:<region>:<account-id>:<resource>
+    // For IAM roles the region is empty and the account ID is the 5th colon-delimited field.
+    let fields: Vec<&str> = role_arn.split(':').collect();
+    let account_id = fields.get(4)?;
+    // Account IDs are exactly 12 digits; guard against malformed input.
+    if account_id.len() == 12 && account_id.bytes().all(|b| b.is_ascii_digit()) {
+        Some((*account_id).to_string())
+    } else {
+        None
+    }
+}
+
+/// Resolves the account ID for each given target. When the target has a role, the account ID is
+/// parsed out of the role ARN (no API call). For any target without a role - i.e. using the
+/// base/global credentials - we fall back to STS GetCallerIdentity to discover the account.
+async fn get_account_ids(
+    targets: &[RegionRole],
+    base_region: &Region,
+    pubsys_aws_config: &PubsysAwsConfig,
+) -> Result<HashMap<RegionRole, String>> {
+    let mut account_ids = HashMap::with_capacity(targets.len());
+
+    // Targets without a role need STS to discover their account; collect them for a parallel
+    // lookup. Targets with a role are resolved synchronously by parsing the ARN.
+    let mut sts_targets = Vec::new();
+    for target in targets.iter() {
+        match &target.role {
+            Some(role) => {
+                let account_id = account_id_from_role_arn(role)
+                    .context(error::ParseRoleArnSnafu { role: role.clone() })?;
+                account_ids.insert(target.clone(), account_id);
+            }
+            None => sts_targets.push(target.clone()),
+        }
+    }
+
+    if !sts_targets.is_empty() {
+        // We make a map storing our clients because they're used in a future and need to live
+        // until the future is resolved.
+        let mut sts_clients = HashMap::with_capacity(sts_targets.len());
+        for target in sts_targets.iter() {
+            let client_config = build_client_config_for_role(
+                &target.region,
+                base_region,
+                pubsys_aws_config,
+                target.role.as_deref(),
+            )
+            .await;
+            sts_clients.insert(target.clone(), StsClient::new(&client_config));
+        }
+
+        let mut requests = Vec::with_capacity(sts_targets.len());
+        for target in sts_targets.iter() {
+            let sts_client = &sts_clients[target];
+            let response_future = sts_client
+                .get_caller_identity()
+                .send()
+                .map_err(AwsSdkError::from);
+
+            // Store the target so we can include it in any errors and key the result
+            let target_future = ready(target.clone());
+            requests.push(join(target_future, response_future));
+        }
+
+        let request_stream = stream::iter(requests).buffer_unordered(4);
+        // Run through the stream and collect results into a list.
+        let responses: Vec<(
+            RegionRole,
+            std::result::Result<GetCallerIdentityOutput, AwsSdkError<GetCallerIdentityError>>,
+        )> = request_stream.collect().await;
+
+        for (target, response) in responses {
+            let response = response.context(error::GetCallerIdentitySnafu {
+                region: target.region.as_ref(),
+            })?;
+            let account_id = response.account.context(error::MissingInResponseSnafu {
+                request_type: "GetCallerIdentity",
+                missing: "account",
+            })?;
+            account_ids.insert(target, account_id);
+        }
+    }
+
+    trace!("Found account IDs {account_ids:?}");
+
+    Ok(account_ids)
 }
 
 /// Parses a toml file, returning a `FromPath<T>`.
@@ -690,6 +1026,13 @@ mod error {
             missing: String,
         },
 
+        #[snafu(display(
+            "Failed to parse an account ID out of the role ARN '{}'; expected the form \
+             'arn:aws:iam::<account>:role/<name>'",
+            role
+        ))]
+        ParseRoleArn { role: String },
+
         #[snafu(display("Failed to parse file {} as toml: {}", filepath.display(), source))]
         ParseToml {
             filepath: PathBuf,
@@ -733,3 +1076,184 @@ use self::launch_permissions::LaunchPermissionDef;
 
 use super::publish_ami::write_amis;
 type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod test {
+    use super::{
+        account_id_from_role_arn, lift_legacy_ami_input, AmiInput, AmiInputError, AmiInputFile,
+        Image, Region, RegionAccountImageMap, AMI_INPUT_SCHEMA_VERSION,
+    };
+    use std::collections::HashMap;
+
+    #[test]
+    fn account_id_parsed_from_role_arn() {
+        assert_eq!(
+            account_id_from_role_arn("arn:aws:iam::012345678901:role/assume-regional"),
+            Some("012345678901".to_string())
+        );
+        // Non-commercial partitions still have the account ID in the same position.
+        assert_eq!(
+            account_id_from_role_arn("arn:aws-us-gov:iam::098765432109:role/some/path"),
+            Some("098765432109".to_string())
+        );
+    }
+
+    #[test]
+    fn account_id_from_malformed_arn_is_none() {
+        // Not an ARN at all.
+        assert_eq!(account_id_from_role_arn("not-an-arn"), None);
+        // Account-ID field present but not 12 digits.
+        assert_eq!(
+            account_id_from_role_arn("arn:aws:iam::123:role/too-short"),
+            None
+        );
+        // Account-ID field present but non-numeric.
+        assert_eq!(
+            account_id_from_role_arn("arn:aws:iam::notanaccount:role/x"),
+            None
+        );
+    }
+
+    /// The `--ami-input` JSON contract is shared by the `ami`, `ssm`, and `publish-ami`
+    /// subcommands.  This locks its versioned envelope around the nested
+    /// `region -> account -> image` shape.
+    #[test]
+    fn ami_input_file_json_round_trip() {
+        let json = r#"{
+            "schema_version": 2,
+            "amis": {
+                "us-west-2": {
+                    "777777777777": {
+                        "id": "ami-aaa",
+                        "name": "my-ami",
+                        "public": false,
+                        "launch_permissions": []
+                    },
+                    "999999999999": {
+                        "id": "ami-bbb",
+                        "name": "my-ami",
+                        "public": false,
+                        "launch_permissions": []
+                    }
+                },
+                "us-east-1": {
+                    "777777777777": {
+                        "id": "ami-ccc",
+                        "name": "my-ami",
+                        "public": true,
+                        "launch_permissions": null
+                    }
+                }
+            }
+        }"#;
+
+        let parsed = expect_versioned(AmiInputFile::from_json(json.as_bytes()).unwrap());
+
+        // Two accounts in us-west-2, one in us-east-1.
+        assert_eq!(parsed["us-west-2"].len(), 2);
+        assert_eq!(parsed["us-west-2"]["777777777777"].id, "ami-aaa");
+        assert_eq!(parsed["us-west-2"]["999999999999"].id, "ami-bbb");
+        assert_eq!(parsed["us-east-1"].len(), 1);
+        assert_eq!(parsed["us-east-1"]["777777777777"].public, Some(true));
+
+        // Round-trips back through the envelope to an equivalent structure.
+        let reserialized = serde_json::to_string(&AmiInputFile::new(parsed.clone())).unwrap();
+        let reparsed = expect_versioned(AmiInputFile::from_json(reserialized.as_bytes()).unwrap());
+        assert_eq!(parsed, reparsed);
+    }
+
+    /// A single account per region (the common case) is just a one-entry inner map.
+    #[test]
+    fn ami_input_file_single_account() {
+        let mut map = RegionAccountImageMap::new();
+        map.entry("us-west-2".to_string()).or_default().insert(
+            "123456789012".to_string(),
+            Image::new("ami-123", "my-ami", Some(false), Some(vec![])),
+        );
+
+        let json = serde_json::to_string(&AmiInputFile::new(map)).unwrap();
+        let parsed = expect_versioned(AmiInputFile::from_json(json.as_bytes()).unwrap());
+        assert_eq!(parsed["us-west-2"]["123456789012"].id, "ami-123");
+    }
+
+    /// What `pubsys ami` writes must be readable by `from_json` (the format the other subcommands
+    /// consume).
+    #[test]
+    fn ami_input_file_written_format_is_versioned() {
+        let map = RegionAccountImageMap::new();
+        let written = serde_json::to_value(AmiInputFile::new(map)).unwrap();
+        assert_eq!(written["schema_version"], AMI_INPUT_SCHEMA_VERSION);
+        assert!(written.get("amis").is_some());
+    }
+
+    /// A file with a different schema version is rejected with a clear error rather than
+    /// misparsed.
+    #[test]
+    fn ami_input_file_rejects_unsupported_version() {
+        let json = r#"{"schema_version": 999, "amis": {}}"#;
+        let err = AmiInputFile::from_json(json.as_bytes()).unwrap_err();
+        assert!(matches!(
+            err,
+            AmiInputError::UnsupportedVersion { found: 999, .. }
+        ));
+    }
+
+    /// A legacy (v1, unversioned) file is recognized and returned as `Legacy` for the caller to
+    /// lift, rather than being misparsed as the versioned format.
+    #[test]
+    fn ami_input_file_recognizes_legacy() {
+        // This is the old pre-envelope shape: a bare region -> image map.
+        let json = r#"{"us-west-2": {"id": "ami-aaa", "name": "x", "public": false, "launch_permissions": []}}"#;
+        let parsed = AmiInputFile::from_json(json.as_bytes()).unwrap();
+        match parsed {
+            AmiInput::Legacy(map) => {
+                assert_eq!(map["us-west-2"].id, "ami-aaa");
+            }
+            AmiInput::Versioned(_) => panic!("legacy file should not parse as versioned"),
+        }
+    }
+
+    /// Lifting a legacy file resolves each region's account from its configured role ARN, with no
+    /// API calls needed in the common (role-configured) case.
+    #[tokio::test]
+    async fn lift_legacy_uses_role_arn() {
+        use pubsys_config::{AwsConfig, AwsRegionConfig, RoleConfig};
+
+        let mut region = std::collections::HashMap::new();
+        region.insert(
+            "us-west-2".to_string(),
+            AwsRegionConfig {
+                role_config: Some(RoleConfig::Role(
+                    "arn:aws:iam::012345678901:role/assume-regional".to_string(),
+                )),
+            },
+        );
+        let aws = AwsConfig {
+            region,
+            ..AwsConfig::default()
+        };
+
+        let mut legacy = HashMap::new();
+        legacy.insert(
+            "us-west-2".to_string(),
+            Image::new("ami-aaa", "my-ami", Some(false), Some(vec![])),
+        );
+
+        let base_region = Region::new("us-west-2");
+        let lifted = lift_legacy_ami_input(legacy, &aws, &base_region)
+            .await
+            .unwrap();
+
+        // The single region's AMI is now keyed under the account parsed from the role ARN.
+        assert_eq!(lifted["us-west-2"].len(), 1);
+        assert_eq!(lifted["us-west-2"]["012345678901"].id, "ami-aaa");
+    }
+
+    /// Unwraps the versioned variant for tests that only exercise the current format.
+    fn expect_versioned(input: AmiInput) -> RegionAccountImageMap {
+        match input {
+            AmiInput::Versioned(map) => map,
+            AmiInput::Legacy(_) => panic!("expected versioned AMI input"),
+        }
+    }
+}

--- a/tools/pubsys/src/aws/ami/wait.rs
+++ b/tools/pubsys/src/aws/ami/wait.rs
@@ -1,4 +1,4 @@
-use crate::aws::client::build_client_config;
+use crate::aws::client::build_client_config_for_role;
 use aws_sdk_ec2::{config::Region, types::ImageState, Client as Ec2Client};
 use log::info;
 use pubsys_config::AwsConfig as PubsysAwsConfig;
@@ -15,6 +15,7 @@ pub(crate) async fn wait_for_ami(
     state: &str,
     successes_required: u8,
     pubsys_aws_config: &PubsysAwsConfig,
+    maybe_role: Option<String>,
 ) -> Result<()> {
     let mut successes = 0;
     let max_attempts = 90;
@@ -35,7 +36,13 @@ pub(crate) async fn wait_for_ami(
 
         // Use a new client each time so we have more confidence that different endpoints can see
         // the new AMI.
-        let client_config = build_client_config(region, sts_region, pubsys_aws_config).await;
+        let client_config = build_client_config_for_role(
+            region,
+            sts_region,
+            pubsys_aws_config,
+            maybe_role.as_deref(),
+        )
+        .await;
         let ec2_client = Ec2Client::new(&client_config);
         let describe_response = ec2_client
             .describe_images()

--- a/tools/pubsys/src/aws/client.rs
+++ b/tools/pubsys/src/aws/client.rs
@@ -7,25 +7,55 @@ use aws_types::region::Region;
 use pubsys_config::AwsConfig as PubsysAwsConfig;
 
 /// Create an AWS client config using the given regions and pubsys config.
+///
+/// This uses the singular region-specific `role` from the config (if any). To assume a specific
+/// role - for example when publishing to multiple accounts in the same region - use
+/// [`build_client_config_for_role`] instead.
 pub(crate) async fn build_client_config(
     region: &Region,
     sts_region: &Region,
     pubsys_aws_config: &PubsysAwsConfig,
 ) -> SdkConfig {
-    let maybe_profile = pubsys_aws_config.profile.clone();
-    let maybe_role = pubsys_aws_config.role.clone();
+    // Use the first role configured for this region (the singular `role`, or the first entry of a
+    // `roles` list). `all_roles()` returns `None` when no role is configured, so this naturally
+    // falls back to the base/global credentials.
     let maybe_regional_role = pubsys_aws_config
         .region
         .get(region.as_ref())
-        .and_then(|r| r.role.clone());
+        .and_then(|r| r.all_roles())
+        .and_then(|roles| roles.into_iter().next());
+    build_client_config_for_role(
+        region,
+        sts_region,
+        pubsys_aws_config,
+        maybe_regional_role.as_deref(),
+    )
+    .await
+}
+
+/// Create an AWS client config that assumes the given region-specific role (if any), rather than
+/// pulling the single role from the region's config. The given role is assumed after the "global"
+/// `aws.role`, just like the singular region role would be. This lets callers build a separate
+/// client per target account within a single region.
+pub(crate) async fn build_client_config_for_role(
+    region: &Region,
+    sts_region: &Region,
+    pubsys_aws_config: &PubsysAwsConfig,
+    maybe_regional_role: Option<&str>,
+) -> SdkConfig {
+    let maybe_profile = pubsys_aws_config.profile.clone();
+    let maybe_role = pubsys_aws_config.role.clone();
     let base_provider = base_provider(&maybe_profile).await;
 
     let config = match (&maybe_role, &maybe_regional_role) {
         (None, None) => aws_config::from_env().credentials_provider(base_provider),
         _ => {
-            let assume_roles = maybe_role.iter().chain(maybe_regional_role.iter()).cloned();
-            let provider =
-                build_provider(sts_region, assume_roles.clone(), base_provider.clone()).await;
+            let assume_roles = maybe_role
+                .iter()
+                .map(String::as_str)
+                .chain(maybe_regional_role)
+                .map(ToString::to_string);
+            let provider = build_provider(sts_region, assume_roles, base_provider.clone()).await;
             aws_config::from_env().credentials_provider(provider)
         }
     };

--- a/tools/pubsys/src/aws/promote_ssm/mod.rs
+++ b/tools/pubsys/src/aws/promote_ssm/mod.rs
@@ -1,6 +1,7 @@
 //! The promote_ssm module owns the 'promote-ssm' subcommand and controls the process of copying
 //! SSM parameters from one version to another
 
+use crate::aws::ami::{region_account_id, RegionAccount};
 use crate::aws::client::build_client_config;
 use crate::aws::ssm::template::RenderedParametersMap;
 use crate::aws::ssm::{key_difference, ssm, template, BuildContext, SsmKey};
@@ -93,11 +94,29 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
     );
     let base_region = &regions[0];
 
+    // Resolve the single account each region targets (from its role ARN, or STS for a region with
+    // no role), so SSM keys and clients can be scoped per (region, account).
+    let mut region_accounts = HashMap::with_capacity(regions.len());
+    for region in &regions {
+        let account_id = region_account_id(region, &aws, base_region).await.context(
+            error::ResolveAccountSnafu {
+                region: region.as_ref().to_string(),
+            },
+        )?;
+        region_accounts.insert(region.clone(), account_id);
+    }
+
     let mut ssm_clients = HashMap::with_capacity(regions.len());
     for region in &regions {
         let client_config = build_client_config(region, base_region, &aws).await;
         let ssm_client = SsmClient::new(&client_config);
-        ssm_clients.insert(region.clone(), ssm_client);
+        ssm_clients.insert(
+            RegionAccount {
+                region: region.clone(),
+                account_id: region_accounts[region].clone(),
+            },
+            ssm_client,
+        );
     }
 
     // Template setup   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
@@ -149,17 +168,19 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
     let source_keys: Vec<SsmKey> = regions
         .iter()
         .flat_map(|region| {
+            let account_id = region_accounts[region].clone();
             source_parameter_map
                 .values()
-                .map(move |name| SsmKey::new(region.clone(), name.clone()))
+                .map(move |name| SsmKey::new(region.clone(), account_id.clone(), name.clone()))
         })
         .collect();
     let target_keys: Vec<SsmKey> = regions
         .iter()
         .flat_map(|region| {
+            let account_id = region_accounts[region].clone();
             target_parameter_map
                 .values()
-                .map(move |name| SsmKey::new(region.clone(), name.clone()))
+                .map(move |name| SsmKey::new(region.clone(), account_id.clone(), name.clone()))
         })
         .collect();
 
@@ -190,12 +211,16 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
         .map(|(k, v)| (v, &target_parameter_map[k]))
         .collect();
 
-    // Create full set of target parameters
+    // Create full set of target parameters, preserving each key's region and account.
     let full_target_parameters = current_source_parameters
         .into_iter()
         .map(|(key, value)| {
             (
-                SsmKey::new(key.region, source_target_map[&key.name].to_string()),
+                SsmKey::new(
+                    key.region,
+                    key.account_id,
+                    source_target_map[&key.name].to_string(),
+                ),
                 value.clone(),
             )
         })
@@ -214,7 +239,13 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
     // write the newly promoted parameters to `ssm_parameter_output` along with the original
     // parameters
     if let Some(ssm_parameter_output) = &promote_args.ssm_parameter_output {
-        append_rendered_parameters(ssm_parameter_output, &full_target_parameters).await?;
+        append_rendered_parameters(
+            ssm_parameter_output,
+            &full_target_parameters,
+            &aws,
+            base_region,
+        )
+        .await?;
     }
 
     // Exit early if `--dry-run` is enabled
@@ -244,9 +275,11 @@ pub(crate) async fn run(args: &Args, promote_args: &PromoteArgs) -> Result<()> {
 async fn append_rendered_parameters(
     ssm_parameters_output: &PathBuf,
     set_parameters: &HashMap<SsmKey, String>,
+    aws: &pubsys_config::AwsConfig,
+    base_region: &Region,
 ) -> Result<()> {
     // If the file doesn't exist, assume that there are no existing parameters
-    let parsed_parameters = parse_parameters(&ssm_parameters_output.to_owned())
+    let parsed_parameters = parse_parameters(&ssm_parameters_output.to_owned(), aws, base_region)
         .await
         .or_else({
             |e| match e {
@@ -333,6 +366,12 @@ mod error {
         #[snafu(display("Failed to render templates: {}", source))]
         RenderTemplates { source: template::Error },
 
+        #[snafu(display("Failed to resolve the account for region {}: {}", region, source))]
+        ResolveAccount {
+            region: String,
+            source: crate::aws::ami::AmiInputError,
+        },
+
         #[snafu(display("Failed to set SSM parameters: {}", source))]
         SetSsm { source: ssm::Error },
 
@@ -372,20 +411,33 @@ mod test {
     fn combined_parameters() {
         let existing_parameters = HashMap::from([
             (
-                SsmKey::new(Region::new("us-west-2"), "test1-parameter-name".to_string()),
+                SsmKey::new(
+                    Region::new("us-west-2"),
+                    "1234567890".to_string(),
+                    "test1-parameter-name".to_string(),
+                ),
                 "test1-parameter-value".to_string(),
             ),
             (
-                SsmKey::new(Region::new("us-west-2"), "test2-parameter-name".to_string()),
+                SsmKey::new(
+                    Region::new("us-west-2"),
+                    "1234567890".to_string(),
+                    "test2-parameter-name".to_string(),
+                ),
                 "test2-parameter-value".to_string(),
             ),
             (
-                SsmKey::new(Region::new("us-east-1"), "test3-parameter-name".to_string()),
+                SsmKey::new(
+                    Region::new("us-east-1"),
+                    "1234567890".to_string(),
+                    "test3-parameter-name".to_string(),
+                ),
                 "test3-parameter-value".to_string(),
             ),
             (
                 SsmKey::new(
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                     "test4-unpromoted-parameter-name".to_string(),
                 ),
                 "test4-unpromoted-parameter-value".to_string(),
@@ -395,6 +447,7 @@ mod test {
             (
                 SsmKey::new(
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                     "test1-parameter-name-promoted".to_string(),
                 ),
                 "test1-parameter-value".to_string(),
@@ -402,6 +455,7 @@ mod test {
             (
                 SsmKey::new(
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                     "test2-parameter-name-promoted".to_string(),
                 ),
                 "test2-parameter-value".to_string(),
@@ -409,6 +463,7 @@ mod test {
             (
                 SsmKey::new(
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                     "test3-parameter-name-promoted".to_string(),
                 ),
                 "test3-parameter-value".to_string(),
@@ -420,16 +475,25 @@ mod test {
                 Region::new("us-west-2"),
                 HashMap::from([
                     (
-                        SsmKey::new(Region::new("us-west-2"), "test1-parameter-name".to_string()),
+                        SsmKey::new(
+                            Region::new("us-west-2"),
+                            "1234567890".to_string(),
+                            "test1-parameter-name".to_string(),
+                        ),
                         "test1-parameter-value".to_string(),
                     ),
                     (
-                        SsmKey::new(Region::new("us-west-2"), "test2-parameter-name".to_string()),
+                        SsmKey::new(
+                            Region::new("us-west-2"),
+                            "1234567890".to_string(),
+                            "test2-parameter-name".to_string(),
+                        ),
                         "test2-parameter-value".to_string(),
                     ),
                     (
                         SsmKey::new(
                             Region::new("us-west-2"),
+                            "1234567890".to_string(),
                             "test1-parameter-name-promoted".to_string(),
                         ),
                         "test1-parameter-value".to_string(),
@@ -437,6 +501,7 @@ mod test {
                     (
                         SsmKey::new(
                             Region::new("us-west-2"),
+                            "1234567890".to_string(),
                             "test2-parameter-name-promoted".to_string(),
                         ),
                         "test2-parameter-value".to_string(),
@@ -447,12 +512,17 @@ mod test {
                 Region::new("us-east-1"),
                 HashMap::from([
                     (
-                        SsmKey::new(Region::new("us-east-1"), "test3-parameter-name".to_string()),
+                        SsmKey::new(
+                            Region::new("us-east-1"),
+                            "1234567890".to_string(),
+                            "test3-parameter-name".to_string(),
+                        ),
                         "test3-parameter-value".to_string(),
                     ),
                     (
                         SsmKey::new(
                             Region::new("us-east-1"),
+                            "1234567890".to_string(),
                             "test3-parameter-name-promoted".to_string(),
                         ),
                         "test3-parameter-value".to_string(),
@@ -460,6 +530,7 @@ mod test {
                     (
                         SsmKey::new(
                             Region::new("us-east-1"),
+                            "1234567890".to_string(),
                             "test4-unpromoted-parameter-name".to_string(),
                         ),
                         "test4-unpromoted-parameter-value".to_string(),
@@ -474,30 +545,51 @@ mod test {
     fn combined_parameters_overwrite() {
         let existing_parameters = HashMap::from([
             (
-                SsmKey::new(Region::new("us-west-2"), "test1-parameter-name".to_string()),
+                SsmKey::new(
+                    Region::new("us-west-2"),
+                    "1234567890".to_string(),
+                    "test1-parameter-name".to_string(),
+                ),
                 "test1-parameter-value".to_string(),
             ),
             (
-                SsmKey::new(Region::new("us-west-2"), "test2-parameter-name".to_string()),
+                SsmKey::new(
+                    Region::new("us-west-2"),
+                    "1234567890".to_string(),
+                    "test2-parameter-name".to_string(),
+                ),
                 "test2-parameter-value".to_string(),
             ),
             (
-                SsmKey::new(Region::new("us-east-1"), "test3-parameter-name".to_string()),
+                SsmKey::new(
+                    Region::new("us-east-1"),
+                    "1234567890".to_string(),
+                    "test3-parameter-name".to_string(),
+                ),
                 "test3-parameter-value".to_string(),
             ),
         ]);
         let set_parameters = HashMap::from([
             (
-                SsmKey::new(Region::new("us-west-2"), "test1-parameter-name".to_string()),
+                SsmKey::new(
+                    Region::new("us-west-2"),
+                    "1234567890".to_string(),
+                    "test1-parameter-name".to_string(),
+                ),
                 "test1-parameter-value-new".to_string(),
             ),
             (
-                SsmKey::new(Region::new("us-west-2"), "test2-parameter-name".to_string()),
+                SsmKey::new(
+                    Region::new("us-west-2"),
+                    "1234567890".to_string(),
+                    "test2-parameter-name".to_string(),
+                ),
                 "test2-parameter-value-new".to_string(),
             ),
             (
                 SsmKey::new(
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                     "test3-parameter-name-promoted".to_string(),
                 ),
                 "test3-parameter-value".to_string(),
@@ -509,11 +601,19 @@ mod test {
                 Region::new("us-west-2"),
                 HashMap::from([
                     (
-                        SsmKey::new(Region::new("us-west-2"), "test1-parameter-name".to_string()),
+                        SsmKey::new(
+                            Region::new("us-west-2"),
+                            "1234567890".to_string(),
+                            "test1-parameter-name".to_string(),
+                        ),
                         "test1-parameter-value-new".to_string(),
                     ),
                     (
-                        SsmKey::new(Region::new("us-west-2"), "test2-parameter-name".to_string()),
+                        SsmKey::new(
+                            Region::new("us-west-2"),
+                            "1234567890".to_string(),
+                            "test2-parameter-name".to_string(),
+                        ),
                         "test2-parameter-value-new".to_string(),
                     ),
                 ]),
@@ -522,12 +622,17 @@ mod test {
                 Region::new("us-east-1"),
                 HashMap::from([
                     (
-                        SsmKey::new(Region::new("us-east-1"), "test3-parameter-name".to_string()),
+                        SsmKey::new(
+                            Region::new("us-east-1"),
+                            "1234567890".to_string(),
+                            "test3-parameter-name".to_string(),
+                        ),
                         "test3-parameter-value".to_string(),
                     ),
                     (
                         SsmKey::new(
                             Region::new("us-east-1"),
+                            "1234567890".to_string(),
                             "test3-parameter-name-promoted".to_string(),
                         ),
                         "test3-parameter-value".to_string(),

--- a/tools/pubsys/src/aws/publish_ami/mod.rs
+++ b/tools/pubsys/src/aws/publish_ami/mod.rs
@@ -3,8 +3,8 @@
 
 use crate::aws::ami::launch_permissions::{get_launch_permissions, LaunchPermissionDef};
 use crate::aws::ami::wait::{self, wait_for_ami};
-use crate::aws::ami::Image;
-use crate::aws::client::build_client_config;
+use crate::aws::ami::{read_ami_input, AmiInputFile, Image, RegionAccount, RegionAccountImageMap};
+use crate::aws::client::build_client_config_for_role;
 use crate::aws::region_from_string;
 use crate::Args;
 use aws_sdk_ec2::error::ProvideErrorMetadata;
@@ -22,6 +22,7 @@ use futures::future::{join, ready};
 use futures::stream::{self, StreamExt};
 use futures::TryFutureExt;
 use log::{debug, error, info, trace};
+use pubsys_config::AwsConfig as PubsysAwsConfig;
 use pubsys_config::InfraConfig;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::{HashMap, HashSet};
@@ -92,21 +93,6 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
             path: &publish_args.ami_input,
         })?;
 
-    let mut ami_input: HashMap<String, Image> =
-        serde_json::from_slice(&ami_input_bytes).context(error::DeserializeSnafu {
-            path: &publish_args.ami_input,
-        })?;
-    trace!("Parsed AMI input: {ami_input:?}");
-
-    // pubsys will not create a file if it did not create AMIs, so we should only have an empty
-    // file if a user created one manually, and they shouldn't be creating an empty file.
-    ensure!(
-        !ami_input.is_empty(),
-        error::InputSnafu {
-            path: &publish_args.ami_input
-        }
-    );
-
     // If a lock file exists, use that, otherwise use Infra.toml or default
     let infra_config = InfraConfig::from_path_or_lock(&args.infra_config_path, true)
         .context(error::ConfigSnafu)?;
@@ -128,6 +114,24 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
     );
     let base_region = region_from_string(&regions[0]);
 
+    // Parse the AMI input, transparently lifting a legacy (v1) file into the per-account model
+    // (which needs the config + base region resolved above).
+    let mut ami_input: RegionAccountImageMap = read_ami_input(&ami_input_bytes, &aws, &base_region)
+        .await
+        .context(error::ParseAmiInputSnafu {
+            path: &publish_args.ami_input,
+        })?;
+    trace!("Parsed AMI input: {ami_input:?}");
+
+    // pubsys will not create a file if it did not create AMIs, so we should only have an empty
+    // file if a user created one manually, and they shouldn't be creating an empty file.
+    ensure!(
+        !ami_input.is_empty(),
+        error::InputSnafu {
+            path: &publish_args.ami_input
+        }
+    );
+
     // Check that the requested regions are a subset of the regions we *could* publish from the AMI
     // input JSON.
     let requested_regions = HashSet::from_iter(regions.iter());
@@ -142,26 +146,39 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
         }
     );
 
-    // Parse region names
-    let mut amis = HashMap::with_capacity(regions.len());
+    // Flatten the nested region -> account -> image input into a map keyed by (region, account),
+    // restricted to the requested regions.  Each entry is published independently, assuming the
+    // role configured for its account.
+    let mut amis = HashMap::new();
     for name in regions {
-        let image = ami_input
+        let account_images = ami_input
             .remove(&name)
             // This could only happen if someone removes the check above...
             .with_context(|| error::UnknownRegionsSnafu {
                 regions: vec![name.clone()],
             })?;
         let region = region_from_string(&name);
-        amis.insert(region, image);
+        for (account_id, image) in account_images {
+            amis.insert(
+                RegionAccount {
+                    region: region.clone(),
+                    account_id,
+                },
+                image,
+            );
+        }
     }
 
-    // We make a map storing our regional clients because they're used in a future and need to
-    // live until the future is resolved.
+    // We make a map storing our clients because they're used in a future and need to live until
+    // the future is resolved.  Each account in a region gets its own client, assuming the role
+    // that reaches that account.
     let mut ec2_clients = HashMap::with_capacity(amis.len());
-    for region in amis.keys() {
-        let client_config = build_client_config(region, &base_region, &aws).await;
+    for key in amis.keys() {
+        let role = role_for_account(&aws, &key.region, &key.account_id);
+        let client_config =
+            build_client_config_for_role(&key.region, &base_region, &aws, role.as_deref()).await;
         let ec2_client = Ec2Client::new(&client_config);
-        ec2_clients.insert(region.clone(), ec2_client);
+        ec2_clients.insert(key.clone(), ec2_client);
     }
 
     // If AMIs aren't in "available" state, we can get a DescribeImages response that includes
@@ -175,22 +192,33 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
         );
     }
     let mut wait_requests = Vec::with_capacity(amis.len());
-    for (region, image) in &amis {
-        let wait_future = wait_for_ami(&image.id, region, &base_region, "available", 1, &aws);
-        // Store the region and ID so we can include it in errors
-        let info_future = ready((region.clone(), image.id.clone()));
+    for (key, image) in &amis {
+        let role = role_for_account(&aws, &key.region, &key.account_id);
+        let wait_future = wait_for_ami(
+            &image.id,
+            &key.region,
+            &base_region,
+            "available",
+            1,
+            &aws,
+            role,
+        );
+        // Store the key and ID so we can include it in errors
+        let info_future = ready((key.clone(), image.id.clone()));
         wait_requests.push(join(info_future, wait_future));
     }
     // Send requests in parallel and wait for responses, collecting results into a list.
     let request_stream = stream::iter(wait_requests).buffer_unordered(4);
-    let wait_responses: Vec<((Region, String), std::result::Result<(), wait::Error>)> =
-        request_stream.collect().await;
+    let wait_responses: Vec<(
+        (RegionAccount, String),
+        std::result::Result<(), wait::Error>,
+    )> = request_stream.collect().await;
 
     // Make sure waits succeeded and AMIs are available.
-    for ((region, image_id), wait_response) in wait_responses {
+    for ((key, image_id), wait_response) in wait_responses {
         wait_response.context(error::WaitAmiSnafu {
             id: &image_id,
-            region: region.as_ref(),
+            region: key.region.as_ref(),
         })?;
     }
 
@@ -215,20 +243,37 @@ pub(crate) async fn run(args: &Args, publish_args: &Who) -> Result<()> {
     )
     .await?;
 
-    write_amis(
-        &publish_args.ami_input,
-        &amis
-            .into_iter()
-            .map(|(region, image)| (region.to_string(), image))
-            .collect::<HashMap<String, Image>>(),
-    )
-    .await?;
+    // Reassemble the nested region -> account -> image map for output.
+    let mut output: RegionAccountImageMap = HashMap::new();
+    for (key, image) in amis {
+        output
+            .entry(key.region.as_ref().to_string())
+            .or_default()
+            .insert(key.account_id, image);
+    }
+    write_amis(&publish_args.ami_input, &output).await?;
 
     Ok(())
 }
 
-pub(crate) async fn write_amis(path: &PathBuf, amis: &HashMap<String, Image>) -> Result<()> {
-    let json = serde_json::to_string_pretty(&amis).context(error::SerializeSnafu { path })?;
+/// Returns the role to assume in order to reach the given account in the given region.  Returns
+/// `None` if no configured role matches (for example, the AMI was published using the base/global
+/// credentials).
+fn role_for_account(
+    pubsys_aws_config: &PubsysAwsConfig,
+    region: &Region,
+    account_id: &str,
+) -> Option<String> {
+    pubsys_aws_config
+        .region
+        .get(region.as_ref())
+        .and_then(|region_config| region_config.role_for_account(account_id))
+}
+
+pub(crate) async fn write_amis(path: &PathBuf, amis: &RegionAccountImageMap) -> Result<()> {
+    // Wrap the map in a schema-versioned envelope so consumers can detect the format.
+    let envelope = AmiInputFile::new(amis.clone());
+    let json = serde_json::to_string_pretty(&envelope).context(error::SerializeSnafu { path })?;
     fs::write(path, &json).await.context(error::FileSnafu {
         op: "write AMIs to file",
         path,
@@ -309,32 +354,33 @@ pub(crate) async fn get_snapshots(
     Ok(snapshot_ids)
 }
 
-/// Returns a regional mapping of snapshot IDs associated with the given AMIs.
+/// Returns a mapping of (region, account) to the snapshot IDs associated with the given AMIs.
 async fn get_regional_snapshots(
-    amis: &HashMap<Region, Image>,
-    clients: &HashMap<Region, Ec2Client>,
-) -> Result<HashMap<Region, Vec<String>>> {
+    amis: &HashMap<RegionAccount, Image>,
+    clients: &HashMap<RegionAccount, Ec2Client>,
+) -> Result<HashMap<RegionAccount, Vec<String>>> {
     // Build requests for image information.
     let mut snapshots_requests = Vec::with_capacity(amis.len());
-    for (region, image) in amis {
-        let ec2_client = &clients[region];
+    for (key, image) in amis {
+        let ec2_client = &clients[key];
 
-        let snapshots_future = get_snapshots(&image.id, region, ec2_client);
+        let snapshots_future = get_snapshots(&image.id, &key.region, ec2_client);
 
-        // Store the region so we can include it in errors
-        let info_future = ready(region.clone());
+        // Store the key so we can include it in errors
+        let info_future = ready(key.clone());
         snapshots_requests.push(join(info_future, snapshots_future));
     }
 
     // Send requests in parallel and wait for responses, collecting results into a list.
     let request_stream = stream::iter(snapshots_requests).buffer_unordered(4);
-    let snapshots_responses: Vec<(Region, Result<Vec<String>>)> = request_stream.collect().await;
+    let snapshots_responses: Vec<(RegionAccount, Result<Vec<String>>)> =
+        request_stream.collect().await;
 
     // For each described image, get the snapshot IDs from the block device mappings.
     let mut snapshots = HashMap::with_capacity(amis.len());
-    for (region, snapshot_ids) in snapshots_responses {
+    for (key, snapshot_ids) in snapshots_responses {
         let snapshot_ids = snapshot_ids?;
-        snapshots.insert(region, snapshot_ids);
+        snapshots.insert(key, snapshot_ids);
     }
 
     Ok(snapshots)
@@ -390,22 +436,28 @@ pub(crate) async fn modify_snapshots(
 }
 
 /// Modify createVolumePermission for the given users/groups, across all of the snapshots in the
-/// given regional mapping.  The `operation` should be "add" or "remove" to allow/deny permission.
+/// given (region, account) mapping.  The `operation` should be "add" or "remove" to allow/deny
+/// permission.
 pub(crate) async fn modify_regional_snapshots(
     modify_opts: &ModifyOptions,
     operation: &OperationType,
-    snapshots: &HashMap<Region, Vec<String>>,
-    clients: &HashMap<Region, Ec2Client>,
+    snapshots: &HashMap<RegionAccount, Vec<String>>,
+    clients: &HashMap<RegionAccount, Ec2Client>,
 ) -> Result<()> {
     // Build requests to modify snapshot attributes.
     let mut requests = Vec::new();
-    for (region, snapshot_ids) in snapshots {
-        let ec2_client = &clients[region];
-        let modify_snapshot_future =
-            modify_snapshots(modify_opts, operation, snapshot_ids, ec2_client, region);
+    for (key, snapshot_ids) in snapshots {
+        let ec2_client = &clients[key];
+        let modify_snapshot_future = modify_snapshots(
+            modify_opts,
+            operation,
+            snapshot_ids,
+            ec2_client,
+            &key.region,
+        );
 
-        // Store the region and snapshot ID so we can include it in errors
-        let info_future = ready((region.clone(), snapshot_ids.clone()));
+        // Store the key and snapshot ID so we can include it in errors
+        let info_future = ready((key.clone(), snapshot_ids.clone()));
         requests.push(join(info_future, modify_snapshot_future));
     }
 
@@ -413,18 +465,19 @@ pub(crate) async fn modify_regional_snapshots(
     let request_stream = stream::iter(requests).buffer_unordered(4);
 
     #[allow(clippy::type_complexity)]
-    let responses: Vec<((Region, Vec<String>), Result<()>)> = request_stream.collect().await;
+    let responses: Vec<((RegionAccount, Vec<String>), Result<()>)> = request_stream.collect().await;
 
     // Count up successes and failures so we can give a clear total in the final error message.
     let mut error_count = 0u16;
     let mut success_count = 0u16;
-    for ((region, snapshot_ids), response) in responses {
+    for ((key, snapshot_ids), response) in responses {
         match response {
             Ok(()) => {
                 success_count += 1;
                 debug!(
-                    "Modified permissions in {} for snapshots [{}]",
-                    region.as_ref(),
+                    "Modified permissions in {} ({}) for snapshots [{}]",
+                    key.region.as_ref(),
+                    key.account_id,
                     snapshot_ids.join(", "),
                 );
             }
@@ -432,8 +485,9 @@ pub(crate) async fn modify_regional_snapshots(
                 error_count += 1;
                 if let Error::ModifyImageAttribute { source: err, .. } = e {
                     error!(
-                        "Failed to modify permissions in {} for snapshots [{}]: {:?}",
-                        region.as_ref(),
+                        "Failed to modify permissions in {} ({}) for snapshots [{}]: {:?}",
+                        key.region.as_ref(),
+                        key.account_id,
                         snapshot_ids.join(", "),
                         err.as_service_error()
                             .and_then(|e| e.code())
@@ -488,22 +542,23 @@ pub(crate) async fn modify_image(
 }
 
 /// Modify launchPermission for the given users/groups, across all of the images in the given
-/// regional mapping.  The `operation` should be "add" or "remove" to allow/deny permission.
+/// (region, account) mapping.  The `operation` should be "add" or "remove" to allow/deny
+/// permission.
 pub(crate) async fn modify_regional_images(
     modify_opts: &ModifyOptions,
     operation: &OperationType,
-    images: &mut HashMap<Region, Image>,
-    clients: &HashMap<Region, Ec2Client>,
+    images: &mut HashMap<RegionAccount, Image>,
+    clients: &HashMap<RegionAccount, Ec2Client>,
 ) -> Result<()> {
     let mut requests = Vec::new();
-    for (region, image) in &mut *images {
+    for (key, image) in &mut *images {
         let image_id = &image.id;
-        let ec2_client = &clients[region];
+        let ec2_client = &clients[key];
 
         let modify_image_future = modify_image(modify_opts, operation, image_id, ec2_client);
 
-        // Store the region and image ID so we can include it in errors
-        let info_future = ready((region.as_ref().to_string(), image_id.clone()));
+        // Store the key and image ID so we can include it in errors
+        let info_future = ready((key.clone(), image_id.clone()));
         requests.push(join(info_future, modify_image_future));
     }
 
@@ -511,35 +566,37 @@ pub(crate) async fn modify_regional_images(
     let request_stream = stream::iter(requests).buffer_unordered(4);
     #[allow(clippy::type_complexity)]
     let responses: Vec<(
-        (String, String),
+        (RegionAccount, String),
         std::result::Result<ModifyImageAttributeOutput, AwsSdkError<ModifyImageAttributeError>>,
     )> = request_stream.collect().await;
 
     // Count up successes and failures so we can give a clear total in the final error message.
     let mut error_count = 0u16;
     let mut success_count = 0u16;
-    for ((region, image_id), modify_image_response) in responses {
+    for ((key, image_id), modify_image_response) in responses {
         match modify_image_response {
             Ok(_) => {
                 success_count += 1;
-                info!("Modified permissions of image {image_id} in {region}");
+                info!(
+                    "Modified permissions of image {image_id} in {} ({})",
+                    key.region.as_ref(),
+                    key.account_id
+                );
 
                 // Set the `public` and `launch_permissions` fields for the Image object
-                let image = images.get_mut(&Region::new(region.clone())).ok_or(
-                    error::Error::MissingRegion {
-                        region: region.clone(),
-                    },
-                )?;
-                let launch_permissions: Vec<LaunchPermissionDef> = get_launch_permissions(
-                    &clients[&Region::new(region.clone())],
-                    region.as_ref(),
-                    &image_id,
-                )
-                .await
-                .context(error::DescribeImageAttributeSnafu {
-                    image_id: image_id.clone(),
-                    region: region.to_string(),
-                })?;
+                let launch_permissions: Vec<LaunchPermissionDef> =
+                    get_launch_permissions(&clients[&key], key.region.as_ref(), &image_id)
+                        .await
+                        .context(error::DescribeImageAttributeSnafu {
+                            image_id: image_id.clone(),
+                            region: key.region.to_string(),
+                        })?;
+
+                let image = images
+                    .get_mut(&key)
+                    .ok_or_else(|| error::Error::MissingRegion {
+                        region: key.region.as_ref().to_string(),
+                    })?;
 
                 // If the launch permissions contain the group `all` after the modification,
                 // the image is public
@@ -552,9 +609,10 @@ pub(crate) async fn modify_regional_images(
             Err(e) => {
                 error_count += 1;
                 error!(
-                    "Modifying permissions of {} in {} failed: {}",
+                    "Modifying permissions of {} in {} ({}) failed: {}",
                     image_id,
-                    region,
+                    key.region.as_ref(),
+                    key.account_id,
                     e.as_service_error()
                         .and_then(|err| err.code())
                         .unwrap_or("unknown"),
@@ -609,10 +667,10 @@ mod error {
             source: AwsSdkError<DescribeImagesError>,
         },
 
-        #[snafu(display("Failed to deserialize input from '{}': {}", path.display(), source))]
-        Deserialize {
+        #[snafu(display("Failed to parse AMI input from '{}': {}", path.display(), source))]
+        ParseAmiInput {
             path: PathBuf,
-            source: serde_json::Error,
+            source: crate::aws::ami::AmiInputError,
         },
 
         #[snafu(display("Failed to {} '{}': {}", op, path.display(), source))]
@@ -703,7 +761,7 @@ mod error {
                 Error::Config { .. }
                 | Error::DescribeImageAttribute { .. }
                 | Error::DescribeImages { .. }
-                | Error::Deserialize { .. }
+                | Error::ParseAmiInput { .. }
                 | Error::File { .. }
                 | Error::Input { .. }
                 | Error::MissingConfig { .. }

--- a/tools/pubsys/src/aws/ssm/mod.rs
+++ b/tools/pubsys/src/aws/ssm/mod.rs
@@ -8,8 +8,10 @@ pub(crate) mod template;
 use self::template::RenderedParameter;
 use crate::aws::ssm::template::RenderedParametersMap;
 use crate::aws::{
-    ami::public::ami_is_public, ami::Image, client::build_client_config, parse_arch,
-    region_from_string,
+    ami::public::ami_is_public,
+    ami::{read_ami_input, Image, RegionAccount, RegionAccountImageMap},
+    client::build_client_config_for_role,
+    parse_arch, region_from_string,
 };
 use crate::Args;
 use aws_config::SdkConfig;
@@ -20,6 +22,7 @@ use futures::stream::{StreamExt, TryStreamExt};
 use governor::{prelude::*, Quota, RateLimiter};
 use log::{error, info, trace};
 use nonzero_ext::nonzero;
+use pubsys_config::AwsConfig as PubsysAwsConfig;
 use pubsys_config::InfraConfig;
 use serde::Serialize;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -38,7 +41,8 @@ use std::{
         .requires("ssm_parameter_output")
 ))]
 pub(crate) struct SsmArgs {
-    // This is JSON output from `pubsys ami` like `{"us-west-2": "ami-123"}`
+    // This is JSON output from `pubsys ami`, nested by account, like
+    // `{"us-west-2": {"012345678901": {"id": "ami-123", ...}}}`
     /// Path to the JSON file containing regional AMI IDs to modify
     #[arg(long)]
     ami_input: PathBuf,
@@ -112,7 +116,7 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
     );
     let base_region = region_from_string(&regions[0]);
 
-    let amis = parse_ami_input(&regions, ssm_args)?;
+    let amis = parse_ami_input(&regions, ssm_args, &aws, &base_region).await?;
 
     // Template setup   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
@@ -158,28 +162,36 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
         return Ok(());
     }
 
-    // Generate AWS Clients to use for the updates.
+    // Generate AWS Clients to use for the updates.  A single region can host multiple target
+    // accounts, and each account has its own independent SSM parameter store, so we key clients by
+    // (region, account) - assuming the role that reaches each account.  The `ssm::*` functions
+    // fan out over these keys internally, preserving parallelism across both regions and accounts.
     let mut param_update_ops: Vec<SsmParamUpdateOp> = Vec::with_capacity(new_parameters.len());
-    let mut aws_sdk_configs: HashMap<Region, SdkConfig> = HashMap::with_capacity(regions.len());
-    let mut ssm_clients = HashMap::with_capacity(amis.len());
+    let mut aws_sdk_configs: HashMap<RegionAccount, SdkConfig> = HashMap::new();
+    let mut ssm_clients: HashMap<RegionAccount, SsmClient> = HashMap::new();
 
     for parameter in new_parameters.iter() {
-        let region = &parameter.ssm_key.region;
+        let key = RegionAccount {
+            region: parameter.ssm_key.region.clone(),
+            account_id: parameter.ssm_key.account_id.clone(),
+        };
         // Store client configs so that we only have to create them once.
         // The HashMap `entry` API doesn't play well with `async`, so we use a match here instead.
-        let client_config = match aws_sdk_configs.get(region) {
+        let client_config = match aws_sdk_configs.get(&key) {
             Some(client_config) => client_config.clone(),
             None => {
-                let client_config = build_client_config(region, &base_region, &aws).await;
-                aws_sdk_configs.insert(region.clone(), client_config.clone());
+                let role = role_for_account(&aws, &key.region, &key.account_id);
+                let client_config =
+                    build_client_config_for_role(&key.region, &base_region, &aws, role.as_deref())
+                        .await;
+                aws_sdk_configs.insert(key.clone(), client_config.clone());
                 client_config
             }
         };
 
-        let ssm_client = SsmClient::new(&client_config);
-        if !ssm_clients.contains_key(region) {
-            ssm_clients.insert(region.clone(), ssm_client);
-        }
+        ssm_clients
+            .entry(key.clone())
+            .or_insert_with(|| SsmClient::new(&client_config));
 
         let ec2_client = Ec2Client::new(&client_config);
         param_update_ops.push(SsmParamUpdateOp {
@@ -204,9 +216,9 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
         new_parameters.iter().map(|param| &param.ssm_key).collect();
     let result = ssm::get_parameters(&new_parameter_names, &ssm_clients).await;
 
-    // Typically if a user calls GetParameters for a nonexistent parameter, the call will succeed
-    // and simply report the parameter as invalid. However, SSM has a special case error in
-    // GetParameters for keys under the `/aws/` namespace if the service prefix (e.g
+    // Typically if a user calls GetParameters for a nonexistent parameter, the call will
+    // succeed and simply report the parameter as invalid. However, SSM has a special case
+    // error in GetParameters for keys under the `/aws/` namespace if the service prefix (e.g
     // `/aws/service/bottlerocket`) does not contain any keys. This is an expected state when
     // publishing parameters in a new region for the first time. We can assume when we see this
     // error that there are no parameters under the prefix.
@@ -250,6 +262,20 @@ pub(crate) async fn run(args: &Args, ssm_args: &SsmArgs) -> Result<()> {
 
     info!("All parameters match requested values.");
     Ok(())
+}
+
+/// Returns the role to assume in order to reach the given account in the given region.  Returns
+/// `None` if no configured role matches (for example, the AMI was published using the base/global
+/// credentials).
+fn role_for_account(
+    pubsys_aws_config: &PubsysAwsConfig,
+    region: &Region,
+    account_id: &str,
+) -> Option<String> {
+    pubsys_aws_config
+        .region
+        .get(region.as_ref())
+        .and_then(|region_config| region_config.role_for_account(account_id))
 }
 
 fn is_aws_service_access_denied_error(result: &ssm::Result<HashMap<SsmKey, String>>) -> bool {
@@ -337,16 +363,23 @@ async fn check_public_namespace_amis_are_public(
         .all(|is_public| is_public))
 }
 
-/// The key to a unique SSM parameter
+/// The key to a unique SSM parameter. Parameters live in a specific account's parameter store in a
+/// specific region, so the account is part of the key: the same region+name in two different
+/// accounts are distinct parameters.
 #[derive(Debug, Eq, Hash, PartialEq, Clone)]
 pub(crate) struct SsmKey {
     pub(crate) region: Region,
+    pub(crate) account_id: String,
     pub(crate) name: String,
 }
 
 impl SsmKey {
-    pub(crate) fn new(region: Region, name: String) -> Self {
-        Self { region, name }
+    pub(crate) fn new(region: Region, account_id: String, name: String) -> Self {
+        Self {
+            region,
+            account_id,
+            name,
+        }
     }
 
     pub(crate) fn is_in_public_namespace(&self) -> bool {
@@ -372,14 +405,20 @@ pub(crate) struct BuildContext<'a> {
 pub(crate) type SsmParameters = HashMap<SsmKey, String>;
 
 /// Parse the AMI input file
-fn parse_ami_input(regions: &[String], ssm_args: &SsmArgs) -> Result<HashMap<Region, Image>> {
+async fn parse_ami_input(
+    regions: &[String],
+    ssm_args: &SsmArgs,
+    aws: &PubsysAwsConfig,
+    base_region: &Region,
+) -> Result<HashMap<RegionAccount, Image>> {
     info!("Using AMI data from path: {}", ssm_args.ami_input.display());
-    let file = File::open(&ssm_args.ami_input).context(error::FileSnafu {
+    let ami_input_bytes = std::fs::read(&ssm_args.ami_input).context(error::FileSnafu {
         op: "open",
         path: &ssm_args.ami_input,
     })?;
-    let mut ami_input: HashMap<String, Image> =
-        serde_json::from_reader(file).context(error::DeserializeSnafu {
+    let mut ami_input: RegionAccountImageMap = read_ami_input(&ami_input_bytes, aws, base_region)
+        .await
+        .context(error::ParseAmiInputSnafu {
             path: &ssm_args.ami_input,
         })?;
     trace!("Parsed AMI input: {ami_input:#?}");
@@ -407,17 +446,26 @@ fn parse_ami_input(regions: &[String], ssm_args: &SsmArgs) -> Result<HashMap<Reg
         }
     );
 
-    // Parse region names
+    // Flatten the nested region -> account -> image input into a map keyed by (region, account),
+    // restricted to the requested regions.
     let mut amis = HashMap::with_capacity(regions.len());
     for name in regions {
-        let image = ami_input
+        let account_images = ami_input
             .remove(name)
             // This could only happen if someone removes the check above...
             .with_context(|| error::UnknownRegionsSnafu {
                 regions: vec![name.clone()],
             })?;
         let region = region_from_string(name);
-        amis.insert(region.clone(), image);
+        for (account_id, image) in account_images {
+            amis.insert(
+                RegionAccount {
+                    region: region.clone(),
+                    account_id,
+                },
+                image,
+            );
+        }
     }
 
     Ok(amis)
@@ -435,11 +483,11 @@ pub(crate) fn key_difference(wanted: &SsmParameters, current: &SsmParameters) ->
     for key in wanted_keys.difference(&current_keys) {
         let new_value = &wanted[key];
         println!(
-            "{} - {} - new parameter:\n   new value: {}",
-            key.name, key.region, new_value,
+            "{} - {} ({}) - new parameter:\n   new value: {}",
+            key.name, key.region, key.account_id, new_value,
         );
         parameters_to_set.insert(
-            SsmKey::new(key.region.clone(), key.name.clone()),
+            SsmKey::new(key.region.clone(), key.account_id.clone(), key.name.clone()),
             new_value.clone(),
         );
     }
@@ -449,14 +497,17 @@ pub(crate) fn key_difference(wanted: &SsmParameters, current: &SsmParameters) ->
         let new_value = &wanted[key];
 
         if current_value == new_value {
-            println!("{} - {} - no change", key.name, key.region);
+            println!(
+                "{} - {} ({}) - no change",
+                key.name, key.region, key.account_id
+            );
         } else {
             println!(
-                "{} - {} - changing value:\n   old value: {}\n   new value: {}",
-                key.name, key.region, current_value, new_value
+                "{} - {} ({}) - changing value:\n   old value: {}\n   new value: {}",
+                key.name, key.region, key.account_id, current_value, new_value
             );
             parameters_to_set.insert(
-                SsmKey::new(key.region.clone(), key.name.clone()),
+                SsmKey::new(key.region.clone(), key.account_id.clone(), key.name.clone()),
                 new_value.clone(),
             );
         }
@@ -491,10 +542,10 @@ mod error {
             source: crate::aws::ami::public::Error,
         },
 
-        #[snafu(display("Failed to deserialize input from '{}': {}", path.display(), source))]
-        Deserialize {
+        #[snafu(display("Failed to parse AMI input from '{}': {}", path.display(), source))]
+        ParseAmiInput {
             path: PathBuf,
-            source: serde_json::Error,
+            source: crate::aws::ami::AmiInputError,
         },
 
         #[snafu(display("Failed to fetch parameters from SSM: {}", source))]

--- a/tools/pubsys/src/aws/ssm/ssm.rs
+++ b/tools/pubsys/src/aws/ssm/ssm.rs
@@ -1,6 +1,7 @@
 //! The ssm module owns the getting and setting of parameters in SSM.
 
 use super::{SsmKey, SsmParameters};
+use crate::aws::ami::RegionAccount;
 use async_stream::stream;
 use aws_sdk_ssm::error::ProvideErrorMetadata;
 use aws_sdk_ssm::operation::{
@@ -70,34 +71,44 @@ pub async fn rate_limit_ssm_get_parameters(region: &Region) {
     }
 }
 
-/// Fetches the values of the given SSM keys using the given clients
+/// Fetches the values of the given SSM keys using the given clients.
+///
+/// Clients are keyed by `(region, account)` so that parameters destined for different accounts -
+/// even within the same region - are fetched with the correct account's client, in parallel.
 pub(crate) async fn get_parameters<K>(
     requested: &[K],
-    clients: &HashMap<Region, SsmClient>,
+    clients: &HashMap<RegionAccount, SsmClient>,
 ) -> Result<SsmParameters>
 where
     K: AsRef<SsmKey>,
 {
-    // Build requests for parameters; we have to request with a regional client so we split them by
-    // region
+    // Build requests for parameters; each request uses a client for a specific (region, account),
+    // so we split the requested names by that key.
     let mut requests = Vec::with_capacity(requested.len());
-    let mut regional_names: HashMap<Region, Vec<String>> = HashMap::new();
+    let mut grouped_names: HashMap<RegionAccount, Vec<String>> = HashMap::new();
     for key in requested {
-        let SsmKey { region, name } = key.as_ref();
-        regional_names
-            .entry(region.clone())
+        let SsmKey {
+            region,
+            account_id,
+            name,
+        } = key.as_ref();
+        grouped_names
+            .entry(RegionAccount {
+                region: region.clone(),
+                account_id: account_id.clone(),
+            })
             .or_default()
             .push(name.clone());
     }
-    for (region, names) in regional_names {
+    for (key, names) in grouped_names {
         // At most 10 parameters can be requested at a time.
         for names_chunk in names.chunks(10) {
-            let ssm_client = &clients[&region];
+            let ssm_client = &clients[&key];
             let len = names_chunk.len();
 
             let get_future = {
                 let names_chunk = names_chunk.to_vec();
-                let region = region.clone();
+                let region = key.region.clone();
                 async move {
                     rate_limit_ssm_get_parameters(&region).await;
                     trace!("Requesting {names_chunk:?} in {region}");
@@ -110,8 +121,8 @@ where
                 }
             };
 
-            // Store the region so we can include it in errors and the output map
-            let info_future = ready((region.clone(), len));
+            // Store the key so we can include it in errors and the output map
+            let info_future = ready((key.clone(), len));
             requests.push(join(info_future, get_future));
         }
     }
@@ -120,32 +131,32 @@ where
     let request_stream = stream::iter(requests).buffer_unordered(4);
     #[allow(clippy::type_complexity)]
     let responses: Vec<(
-        (Region, usize),
+        (RegionAccount, usize),
         std::result::Result<GetParametersOutput, AwsSdkError<GetParametersError>>,
     )> = request_stream.collect().await;
 
-    // If you're checking parameters in a region you haven't pushed to before, you can get an
-    // error here about the parameter's namespace being new.  We want to treat these as new
-    // parameters rather than failing.  Unfortunately, we don't know which parameter in the region
-    // was considered new, but we expect that most people are publishing all of their parameters
-    // under the same namespace, so treating the whole region as new is OK.  We use this just to
-    // warn the user.
-    let mut new_regions = HashSet::new();
+    // If you're checking parameters in a region/account you haven't pushed to before, you can get
+    // an error here about the parameter's namespace being new.  We want to treat these as new
+    // parameters rather than failing.  Unfortunately, we don't know which parameter was considered
+    // new, but we expect that most people are publishing all of their parameters under the same
+    // namespace, so treating the whole (region, account) as new is OK.  We use this just to warn
+    // the user.
+    let mut new_region_accounts = HashSet::new();
 
     // For each existing parameter in the response, get the name and value for our output map.
     let mut parameters = HashMap::with_capacity(requested.len());
-    for ((region, expected_len), response) in responses {
+    for ((key, expected_len), response) in responses {
         // Get the image description, ensuring we only have one.
         let response = match response {
             Ok(response) => response,
             Err(e) => {
                 // Note: there's no structured error type for this so we have to string match.
                 if e.to_string().contains("is not a valid namespace") {
-                    new_regions.insert(region.clone());
+                    new_region_accounts.insert(key.clone());
                     continue;
                 } else {
                     return Err(e).context(error::GetParametersSnafu {
-                        region: region.as_ref(),
+                        region: key.region.as_ref(),
                     });
                 }
             }
@@ -160,7 +171,7 @@ where
         ensure!(
             total_count == expected_len,
             error::MissingInResponseSnafu {
-                region: region.as_ref(),
+                region: key.region.as_ref(),
                 request_type: "GetParameters",
                 missing: format!("parameters - got {total_count}, expected {expected_len}"),
             }
@@ -171,42 +182,52 @@ where
             if !valid_parameters.is_empty() {
                 for parameter in valid_parameters {
                     let name = parameter.name.context(error::MissingInResponseSnafu {
-                        region: region.as_ref(),
+                        region: key.region.as_ref(),
                         request_type: "GetParameters",
                         missing: "parameter name",
                     })?;
                     let value = parameter.value.context(error::MissingInResponseSnafu {
-                        region: region.as_ref(),
+                        region: key.region.as_ref(),
                         request_type: "GetParameters",
                         missing: format!("value for parameter {name}"),
                     })?;
-                    parameters.insert(SsmKey::new(region.clone(), name), value);
+                    parameters.insert(
+                        SsmKey::new(key.region.clone(), key.account_id.clone(), name),
+                        value,
+                    );
                 }
             }
         }
     }
 
-    for region in new_regions {
-        warn!("Invalid namespace in {region}, this is OK for the first publish in a region");
+    for key in new_region_accounts {
+        warn!(
+            "Invalid namespace in {} ({}), this is OK for the first publish in a region/account",
+            key.region, key.account_id
+        );
     }
 
     Ok(parameters)
 }
 
-/// Fetches all SSM parameters under a given prefix using the given clients
+/// Fetches all SSM parameters under a given prefix using the given clients, keyed by
+/// `(region, account)`.
 pub(crate) async fn get_parameters_by_prefix<'a>(
-    clients: &'a HashMap<Region, SsmClient>,
+    clients: &'a HashMap<RegionAccount, SsmClient>,
     ssm_prefix: &str,
-) -> HashMap<&'a Region, Result<SsmParameters>> {
-    // Build requests for parameters; we have to request with a regional client so we split them by
-    // region
+) -> HashMap<&'a RegionAccount, Result<SsmParameters>> {
+    // Build requests for parameters; each request uses a client for a specific (region, account).
     let mut requests = Vec::with_capacity(clients.len());
-    for region in clients.keys() {
-        trace!("Requesting parameters in {region}");
-        let ssm_client: &SsmClient = &clients[region];
-        let get_future = get_parameters_by_prefix_in_region(region, ssm_client, ssm_prefix);
+    for key in clients.keys() {
+        trace!(
+            "Requesting parameters in {} ({})",
+            key.region,
+            key.account_id
+        );
+        let ssm_client: &SsmClient = &clients[key];
+        let get_future = get_parameters_by_prefix_in_region(key, ssm_client, ssm_prefix);
 
-        requests.push(join(ready(region), get_future));
+        requests.push(join(ready(key), get_future));
     }
 
     // Send requests in parallel and wait for responses, collecting results into a list.
@@ -217,13 +238,14 @@ pub(crate) async fn get_parameters_by_prefix<'a>(
         .await
 }
 
-/// Fetches all SSM parameters under a given prefix in a single region
+/// Fetches all SSM parameters under a given prefix in a single region/account
 pub(crate) async fn get_parameters_by_prefix_in_region(
-    region: &Region,
+    key: &RegionAccount,
     client: &SsmClient,
     ssm_prefix: &str,
 ) -> Result<SsmParameters> {
-    info!("Retrieving SSM parameters in {region}");
+    let region = &key.region;
+    info!("Retrieving SSM parameters in {region} ({})", key.account_id);
     let mut parameters = HashMap::new();
 
     let paginated_response_stream = stream! {
@@ -252,11 +274,12 @@ pub(crate) async fn get_parameters_by_prefix_in_region(
             .parameters()
             .to_owned();
         for parameter in retrieved_parameters {
-            // Insert a new key-value pair into the map, with the key containing region and parameter name
-            // and the value containing the parameter value
+            // Insert a new key-value pair into the map, with the key containing region, account,
+            // and parameter name, and the value containing the parameter value
             parameters.insert(
                 SsmKey::new(
                     region.to_owned(),
+                    key.account_id.clone(),
                     parameter
                         .name()
                         .ok_or(error::Error::MissingField {
@@ -275,14 +298,17 @@ pub(crate) async fn get_parameters_by_prefix_in_region(
             );
         }
     }
-    info!("SSM parameters in {region} have been retrieved");
+    info!(
+        "SSM parameters in {region} ({}) have been retrieved",
+        key.account_id
+    );
     Ok(parameters)
 }
 
-/// Sets the values of the given SSM keys using the given clients
+/// Sets the values of the given SSM keys using the given clients, keyed by `(region, account)`.
 pub(crate) async fn set_parameters(
     parameters_to_set: &SsmParameters,
-    ssm_clients: &HashMap<Region, SsmClient>,
+    ssm_clients: &HashMap<RegionAccount, SsmClient>,
 ) -> Result<()> {
     // Start with a small delay between requests, and increase if we get throttled.
     let mut request_interval = Duration::from_millis(100);
@@ -292,12 +318,12 @@ pub(crate) async fn set_parameters(
 
     // We run all requests in a batch, and any failed requests are added to the next batch for
     // retry
-    let mut failed_parameters: HashMap<Region, Vec<(String, String)>> = HashMap::new();
+    let mut failed_parameters: HashMap<RegionAccount, Vec<(String, String)>> = HashMap::new();
     let max_failures = 5;
 
     /// Stores the values we need to be able to retry requests
     struct RequestContext<'a> {
-        region: &'a Region,
+        key: RegionAccount,
         name: &'a str,
         value: &'a str,
         failures: u8,
@@ -305,9 +331,20 @@ pub(crate) async fn set_parameters(
 
     // Create the initial request contexts
     let mut contexts = Vec::new();
-    for (SsmKey { region, name }, value) in parameters_to_set {
-        contexts.push(RequestContext {
+    for (
+        SsmKey {
             region,
+            account_id,
+            name,
+        },
+        value,
+    ) in parameters_to_set
+    {
+        contexts.push(RequestContext {
+            key: RegionAccount {
+                region: region.clone(),
+                account_id: account_id.clone(),
+            },
             name,
             value,
             failures: 0,
@@ -331,14 +368,14 @@ pub(crate) async fn set_parameters(
             error::ThrottledSnafu { max_interval }
         );
 
-        // Build requests for parameters.  We need to group them by region so we can run each
-        // region in parallel.  Each region's stream will be throttled to run one request per
-        // request_interval.
-        let mut regional_requests = HashMap::new();
+        // Build requests for parameters.  We need to group them by (region, account) so we can
+        // run each group in parallel.  Each group's stream will be throttled to run one request
+        // per request_interval.
+        let mut grouped_requests = HashMap::new();
         // Remove contexts from the list with drain; they get added back in if we retry the
         // request.
         for context in contexts.drain(..) {
-            let ssm_client = &ssm_clients[context.region];
+            let ssm_client = &ssm_clients[&context.key];
 
             let put_future = ssm_client
                 .put_parameter()
@@ -349,18 +386,17 @@ pub(crate) async fn set_parameters(
                 .send()
                 .map_err(AwsSdkError::from);
 
-            let regional_list = regional_requests
-                .entry(context.region)
+            let group_list = grouped_requests
+                .entry(context.key.clone())
                 .or_insert_with(Vec::new);
             // Store the context so we can retry as needed
-            regional_list.push(join(ready(context), put_future));
+            group_list.push(join(ready(context), put_future));
         }
 
-        // Create a throttled stream per region; throttling applies per region.  (Request futures
-        // are already regional, by virtue of being created with a regional client, so we don't
-        // need the region again here.)
+        // Create a throttled stream per (region, account); throttling applies per group.  (Request
+        // futures are already bound to a specific client, so we don't need the key again here.)
         let mut throttled_streams = Vec::new();
-        for (_region, request_list) in regional_requests {
+        for (_key, request_list) in grouped_requests {
             throttled_streams.push(Box::pin(tokio_stream::StreamExt::throttle(
                 stream::iter(request_list),
                 request_interval,
@@ -395,7 +431,7 @@ pub(crate) async fn set_parameters(
                 } else if context.failures >= max_failures - 1 {
                     // Past max failures, store the failure for reporting, don't retry.
                     failed_parameters
-                        .entry(context.region.clone())
+                        .entry(context.key.clone())
                         .or_default()
                         .push((context.name.to_string(), error_type));
                 } else {
@@ -405,8 +441,12 @@ pub(crate) async fn set_parameters(
                         ..context
                     };
                     debug!(
-                        "Request attempt {} of {} failed in {}: {}",
-                        context.failures, max_failures, context.region, error_type
+                        "Request attempt {} of {} failed in {} ({}): {}",
+                        context.failures,
+                        max_failures,
+                        context.key.region,
+                        context.key.account_id,
+                        error_type
                     );
                     contexts.push(context);
                 }
@@ -415,9 +455,12 @@ pub(crate) async fn set_parameters(
     }
 
     if !failed_parameters.is_empty() {
-        for (region, failures) in &failed_parameters {
+        for (key, failures) in &failed_parameters {
             for (parameter, error) in failures {
-                error!("Failed to set {parameter} in {region}: {error}");
+                error!(
+                    "Failed to set {parameter} in {} ({}): {error}",
+                    key.region, key.account_id
+                );
             }
         }
         return error::SetParametersSnafu {
@@ -435,7 +478,7 @@ pub(crate) async fn set_parameters(
 /// Retries validation up to 3 times on any failure, using exponential backoff.
 pub(crate) async fn validate_parameters(
     expected_parameters: &SsmParameters,
-    ssm_clients: &HashMap<Region, SsmClient>,
+    ssm_clients: &HashMap<RegionAccount, SsmClient>,
 ) -> Result<()> {
     let retry_strategy = ExponentialBackoff::from_millis(SSM_VALIDATION_RETRY_EXP_BASE_MILLIS)
         .map(jitter)
@@ -462,7 +505,7 @@ pub(crate) async fn validate_parameters(
 /// Fetch the given parameters, and ensure the live values match the given values
 async fn validate_parameters_inner(
     expected_parameters: &SsmParameters,
-    ssm_clients: &HashMap<Region, SsmClient>,
+    ssm_clients: &HashMap<RegionAccount, SsmClient>,
 ) -> Result<()> {
     // Fetch the given parameter names
     let expected_parameter_names: Vec<&SsmKey> = expected_parameters.keys().collect();
@@ -473,17 +516,18 @@ async fn validate_parameters_inner(
     for (expected_key, expected_value) in expected_parameters {
         let SsmKey {
             region: expected_region,
+            account_id: expected_account,
             name: expected_name,
         } = expected_key;
         // All parameters should have a value, and it should match the given value, otherwise the
         // parameter wasn't updated / created.
         if let Some(updated_value) = updated_parameters.get(expected_key) {
             if updated_value != expected_value {
-                error!("Failed to set {expected_name} in {expected_region}");
+                error!("Failed to set {expected_name} in {expected_region} ({expected_account})");
                 success = false;
             }
         } else {
-            error!("{expected_name} in {expected_region} still doesn't exist");
+            error!("{expected_name} in {expected_region} ({expected_account}) still doesn't exist");
             success = false;
         }
     }

--- a/tools/pubsys/src/aws/ssm/template.rs
+++ b/tools/pubsys/src/aws/ssm/template.rs
@@ -2,7 +2,7 @@
 //! SSM parameter names and values.
 
 use super::{BuildContext, SsmKey, SsmParameters};
-use crate::aws::ami::Image;
+use crate::aws::ami::{Image, RegionAccount};
 use aws_sdk_ssm::config::Region;
 use log::trace;
 use serde::{Deserialize, Serialize};
@@ -93,7 +93,7 @@ impl RenderedParameter {
 /// Render the given template parameters using the data from the given AMIs
 pub(crate) fn render_parameters(
     template_parameters: TemplateParameters,
-    amis: &HashMap<Region, Image>,
+    amis: &HashMap<RegionAccount, Image>,
     ssm_prefix: &str,
     build_context: &BuildContext<'_>,
 ) -> Result<Vec<RenderedParameter>> {
@@ -108,7 +108,8 @@ pub(crate) fn render_parameters(
         region: &'a str,
     }
     let mut new_parameters = Vec::new();
-    for (region, image) in amis {
+    for (key, image) in amis {
+        let region = &key.region;
         let context = TemplateContext {
             variant: build_context.variant,
             arch: build_context.arch,
@@ -137,7 +138,11 @@ pub(crate) fn render_parameters(
 
             new_parameters.push(RenderedParameter {
                 ami: image.clone(),
-                ssm_key: SsmKey::new(region.clone(), join_name(ssm_prefix, &name_suffix)),
+                ssm_key: SsmKey::new(
+                    region.clone(),
+                    key.account_id.clone(),
+                    join_name(ssm_prefix, &name_suffix),
+                ),
                 value,
             });
         }
@@ -292,6 +297,7 @@ mod test {
                 },
                 ssm_key: SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 value: "test1-parameter-value".to_string(),
@@ -305,6 +311,7 @@ mod test {
                 },
                 ssm_key: SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 value: "test2-parameter-value".to_string(),
@@ -318,6 +325,7 @@ mod test {
                 },
                 ssm_key: SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 value: "test3-parameter-value".to_string(),
@@ -364,11 +372,19 @@ mod test {
                 Region::new("us-west-2"),
                 HashMap::from([
                     (
-                        SsmKey::new(Region::new("us-west-2"), "test1-parameter-name".to_string()),
+                        SsmKey::new(
+                            Region::new("us-west-2"),
+                            "1234567890".to_string(),
+                            "test1-parameter-name".to_string(),
+                        ),
                         "test1-parameter-value".to_string(),
                     ),
                     (
-                        SsmKey::new(Region::new("us-west-2"), "test2-parameter-name".to_string()),
+                        SsmKey::new(
+                            Region::new("us-west-2"),
+                            "1234567890".to_string(),
+                            "test2-parameter-name".to_string(),
+                        ),
                         "test2-parameter-value".to_string(),
                     ),
                 ]),
@@ -376,7 +392,11 @@ mod test {
             (
                 Region::new("us-east-1"),
                 HashMap::from([(
-                    SsmKey::new(Region::new("us-east-1"), "test3-parameter-name".to_string()),
+                    SsmKey::new(
+                        Region::new("us-east-1"),
+                        "1234567890".to_string(),
+                        "test3-parameter-name".to_string(),
+                    ),
                     "test3-parameter-value".to_string(),
                 )]),
             ),

--- a/tools/pubsys/src/aws/validate_ssm/mod.rs
+++ b/tools/pubsys/src/aws/validate_ssm/mod.rs
@@ -6,11 +6,13 @@ pub mod results;
 use self::results::{SsmValidationResult, SsmValidationResultStatus, SsmValidationResults};
 use super::ssm::ssm::get_parameters_by_prefix;
 use super::ssm::{SsmKey, SsmParameters};
+use crate::aws::ami::{region_account_id, RegionAccount};
 use crate::aws::client::build_client_config;
 use crate::Args;
 use aws_sdk_ssm::{config::Region, Client as SsmClient};
 use clap::Parser;
 use log::{error, info, trace};
+use pubsys_config::AwsConfig as PubsysAwsConfig;
 use pubsys_config::InfraConfig;
 use snafu::ResultExt;
 use std::collections::{HashMap, HashSet};
@@ -61,55 +63,91 @@ pub async fn validate(
 
     let ssm_prefix = aws.ssm_prefix.as_deref().unwrap_or("");
 
+    // Create a HashMap of SsmClients, one for each (region, account) where validation should
+    // happen.  The account is resolved per region (from its role ARN, or STS).
+    let base_region = Region::new(aws.regions[0].clone());
+
     // Parse the file holding expected parameters
     info!("Parsing expected parameters file");
-    let expected_parameters = parse_parameters(&validate_ssm_args.expected_parameters_path).await?;
+    let expected_parameters = parse_parameters(
+        &validate_ssm_args.expected_parameters_path,
+        &aws,
+        &base_region,
+    )
+    .await?;
 
     info!("Parsed expected parameters file");
 
-    // Create a HashMap of SsmClients, one for each region where validation should happen
-    let base_region = Region::new(aws.regions[0].clone());
     let mut ssm_clients = HashMap::with_capacity(expected_parameters.len());
-
-    for region in expected_parameters.keys() {
+    for (region, region_params) in &expected_parameters {
+        // Every SsmKey in a region carries the same account; grab it from any entry.
+        let account_id = match region_params.keys().next() {
+            Some(key) => key.account_id.clone(),
+            None => region_account_id(region, &aws, &base_region)
+                .await
+                .context(error::ResolveAccountSnafu {
+                    region: region.as_ref().to_string(),
+                })?,
+        };
         let client_config = build_client_config(region, &base_region, &aws).await;
         let ssm_client = SsmClient::new(&client_config);
-        ssm_clients.insert(region.clone(), ssm_client);
+        ssm_clients.insert(
+            RegionAccount {
+                region: region.clone(),
+                account_id,
+            },
+            ssm_client,
+        );
     }
 
-    // Retrieve the SSM parameters using the SsmClients
+    // Retrieve the SSM parameters using the SsmClients, keyed by (region, account) so that
+    // multiple accounts in the same region don't clobber each other's results.
     info!("Retrieving SSM parameters");
     let parameters = get_parameters_by_prefix(&ssm_clients, ssm_prefix)
         .await
         .into_iter()
-        .map(|(region, result)| {
+        .map(|(key, result)| {
+            let key = key.clone();
             (
-                region,
+                key.clone(),
                 result.map_err(|e| {
-                    error!("Failed to retrieve images in region {region}: {e}");
+                    error!(
+                        "Failed to retrieve images in region {} ({}): {e}",
+                        key.region, key.account_id
+                    );
                     error::Error::UnreachableRegion {
-                        region: region.to_string(),
+                        region: key.region.to_string(),
                     }
                 }),
             )
         })
-        .collect::<HashMap<&Region, Result<_>>>();
+        .collect::<HashMap<RegionAccount, Result<_>>>();
 
-    // Validate the retrieved SSM parameters per region
-    info!("Validating SSM parameters");
-    let results: HashMap<Region, HashSet<SsmValidationResult>> = parameters
+    // Re-key the expected parameters by (region, account) so we can line them up with what we
+    // retrieved.  Every SsmKey in a region carries the same account, so grab it from any entry.
+    let expected_by_key: HashMap<RegionAccount, HashMap<SsmKey, String>> = expected_parameters
         .into_iter()
-        .map(|(region, region_result)| {
-            (
-                region.clone(),
-                validate_parameters_in_region(
-                    expected_parameters.get(region).unwrap_or(&HashMap::new()),
-                    &region_result,
-                    validate_ssm_args.check_unexpected,
-                ),
-            )
+        .filter_map(|(region, params)| {
+            let account_id = params.keys().next()?.account_id.clone();
+            Some((region, account_id, params))
         })
-        .collect::<HashMap<Region, HashSet<SsmValidationResult>>>();
+        .map(|(region, account_id, params)| (RegionAccount { region, account_id }, params))
+        .collect();
+
+    // Validate the retrieved SSM parameters per (region, account)
+    info!("Validating SSM parameters");
+    let results: HashMap<RegionAccount, HashSet<SsmValidationResult>> = parameters
+        .into_iter()
+        .map(|(key, region_result)| {
+            let expected = expected_by_key.get(&key).cloned().unwrap_or_default();
+            let region_results = validate_parameters_in_region(
+                &expected,
+                &region_result,
+                validate_ssm_args.check_unexpected,
+            );
+            (key, region_results)
+        })
+        .collect::<HashMap<RegionAccount, HashSet<SsmValidationResult>>>();
 
     let validation_results = SsmValidationResults::new(results);
 
@@ -158,6 +196,7 @@ pub(crate) fn validate_parameters_in_region(
                     Some(ssm_value.clone()),
                     Ok(actual_parameters.get(ssm_key).map(|v| v.to_owned())),
                     ssm_key.region.clone(),
+                    ssm_key.account_id.clone(),
                 ));
                 actual_parameters.remove(ssm_key);
             }
@@ -171,6 +210,7 @@ pub(crate) fn validate_parameters_in_region(
                         None,
                         Ok(Some(ssm_value)),
                         ssm_key.region.clone(),
+                        ssm_key.account_id.clone(),
                     ));
                 }
             }
@@ -186,6 +226,7 @@ pub(crate) fn validate_parameters_in_region(
                         region: ssm_key.region.to_string(),
                     }),
                     ssm_key.region.clone(),
+                    ssm_key.account_id.clone(),
                 )
             })
             .collect(),
@@ -201,6 +242,8 @@ type ParameterValue = String;
 /// value as `String`.
 pub(crate) async fn parse_parameters(
     expected_parameters_file: &PathBuf,
+    aws: &PubsysAwsConfig,
+    base_region: &Region,
 ) -> Result<HashMap<Region, HashMap<SsmKey, String>>> {
     let file_bytes = fs::read(expected_parameters_file.clone()).await.context(
         error::ReadExpectedParameterFileSnafu {
@@ -212,25 +255,27 @@ pub(crate) async fn parse_parameters(
     let expected_parameters: HashMap<RegionName, HashMap<ParameterName, ParameterValue>> =
         serde_json::from_slice(&file_bytes).context(error::ParseExpectedParameterFileSnafu)?;
 
-    // Iterate over the parsed HashMap, converting the nested HashMap into a HashMap of Region
-    // mapped to a HashMap of SsmKey, String
-    let parameter_map = expected_parameters
-        .into_iter()
-        .map(|(region, parameters)| {
-            (
-                Region::new(region.clone()),
-                parameters
-                    .into_iter()
-                    .map(|(parameter_name, parameter_value)| {
-                        (
-                            SsmKey::new(Region::new(region.clone()), parameter_name),
-                            parameter_value,
-                        )
-                    })
-                    .collect::<HashMap<SsmKey, String>>(),
-            )
-        })
-        .collect();
+    // The expected-parameters file has no account dimension, so resolve the single account each
+    // region targets (from its role ARN, or STS) to key the SsmKeys.
+    let mut parameter_map = HashMap::with_capacity(expected_parameters.len());
+    for (region_name, parameters) in expected_parameters {
+        let region = Region::new(region_name.clone());
+        let account_id = region_account_id(&region, aws, base_region).await.context(
+            error::ResolveAccountSnafu {
+                region: region_name.clone(),
+            },
+        )?;
+        let region_params = parameters
+            .into_iter()
+            .map(|(parameter_name, parameter_value)| {
+                (
+                    SsmKey::new(region.clone(), account_id.clone(), parameter_name),
+                    parameter_value,
+                )
+            })
+            .collect::<HashMap<SsmKey, String>>();
+        parameter_map.insert(region, region_params);
+    }
 
     Ok(parameter_map)
 }
@@ -268,6 +313,12 @@ pub(crate) mod error {
         ReadExpectedParameterFile {
             source: std::io::Error,
             path: PathBuf,
+        },
+
+        #[snafu(display("Failed to resolve the account for region {}: {}", region, source))]
+        ResolveAccount {
+            region: String,
+            source: crate::aws::ami::AmiInputError,
         },
 
         #[snafu(display("Failed to serialize validation results to json: {}", source))]
@@ -308,6 +359,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -315,6 +367,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value".to_string(),
@@ -322,6 +375,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value".to_string(),
@@ -331,6 +385,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -338,6 +393,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value".to_string(),
@@ -345,6 +401,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value".to_string(),
@@ -356,18 +413,21 @@ mod test {
                 Some("test3-parameter-value".to_string()),
                 Ok(Some("test3-parameter-value".to_string())),
                 Region::new("us-east-1"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test1-parameter-name".to_string(),
                 Some("test1-parameter-value".to_string()),
                 Ok(Some("test1-parameter-value".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test2-parameter-name".to_string(),
                 Some("test2-parameter-value".to_string()),
                 Ok(Some("test2-parameter-value".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
         ]);
         let results =
@@ -383,6 +443,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -390,6 +451,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value".to_string(),
@@ -397,6 +459,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value".to_string(),
@@ -406,6 +469,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value-wrong".to_string(),
@@ -413,6 +477,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value-wrong".to_string(),
@@ -420,6 +485,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value-wrong".to_string(),
@@ -431,18 +497,21 @@ mod test {
                 Some("test3-parameter-value".to_string()),
                 Ok(Some("test3-parameter-value-wrong".to_string())),
                 Region::new("us-east-1"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test1-parameter-name".to_string(),
                 Some("test1-parameter-value".to_string()),
                 Ok(Some("test1-parameter-value-wrong".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test2-parameter-name".to_string(),
                 Some("test2-parameter-value".to_string()),
                 Ok(Some("test2-parameter-value-wrong".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
         ]);
         let results =
@@ -458,6 +527,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -465,6 +535,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value".to_string(),
@@ -472,6 +543,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value".to_string(),
@@ -484,18 +556,21 @@ mod test {
                 Some("test3-parameter-value".to_string()),
                 Ok(None),
                 Region::new("us-east-1"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test1-parameter-name".to_string(),
                 Some("test1-parameter-value".to_string()),
                 Ok(None),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test2-parameter-name".to_string(),
                 Some("test2-parameter-value".to_string()),
                 Ok(None),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
         ]);
         let results =
@@ -512,6 +587,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -519,6 +595,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value".to_string(),
@@ -526,6 +603,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value".to_string(),
@@ -537,18 +615,21 @@ mod test {
                 None,
                 Ok(Some("test3-parameter-value".to_string())),
                 Region::new("us-east-1"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test1-parameter-name".to_string(),
                 None,
                 Ok(Some("test1-parameter-value".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test2-parameter-name".to_string(),
                 None,
                 Ok(Some("test2-parameter-value".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
         ]);
         let results =
@@ -565,6 +646,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -572,6 +654,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value".to_string(),
@@ -579,6 +662,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value".to_string(),
@@ -588,6 +672,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -595,6 +680,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value-wrong".to_string(),
@@ -602,6 +688,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test4-parameter-name".to_string(),
                 },
                 "test4-parameter-value".to_string(),
@@ -613,24 +700,28 @@ mod test {
                 Some("test3-parameter-value".to_string()),
                 Ok(None),
                 Region::new("us-east-1"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test1-parameter-name".to_string(),
                 Some("test1-parameter-value".to_string()),
                 Ok(Some("test1-parameter-value".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test2-parameter-name".to_string(),
                 Some("test2-parameter-value".to_string()),
                 Ok(Some("test2-parameter-value-wrong".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test4-parameter-name".to_string(),
                 None,
                 Ok(Some("test4-parameter-value".to_string())),
                 Region::new("us-east-1"),
+                "1234567890".to_string(),
             ),
         ]);
         let results =
@@ -647,6 +738,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -654,6 +746,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value".to_string(),
@@ -661,6 +754,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value".to_string(),
@@ -670,6 +764,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -677,6 +772,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value-wrong".to_string(),
@@ -684,6 +780,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test4-parameter-name".to_string(),
                 },
                 "test4-parameter-value".to_string(),
@@ -695,18 +792,21 @@ mod test {
                 Some("test3-parameter-value".to_string()),
                 Ok(None),
                 Region::new("us-east-1"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test1-parameter-name".to_string(),
                 Some("test1-parameter-value".to_string()),
                 Ok(Some("test1-parameter-value".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test2-parameter-name".to_string(),
                 Some("test2-parameter-value".to_string()),
                 Ok(Some("test2-parameter-value-wrong".to_string())),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
         ]);
         let results =
@@ -722,6 +822,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test1-parameter-name".to_string(),
                 },
                 "test1-parameter-value".to_string(),
@@ -729,6 +830,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
                     name: "test2-parameter-name".to_string(),
                 },
                 "test2-parameter-value".to_string(),
@@ -736,6 +838,7 @@ mod test {
             (
                 SsmKey {
                     region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
                     name: "test3-parameter-name".to_string(),
                 },
                 "test3-parameter-value".to_string(),
@@ -749,6 +852,7 @@ mod test {
                     region: "us-west-2".to_string(),
                 }),
                 Region::new("us-east-1"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test1-parameter-name".to_string(),
@@ -757,6 +861,7 @@ mod test {
                     region: "us-west-2".to_string(),
                 }),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
             SsmValidationResult::new(
                 "test2-parameter-name".to_string(),
@@ -765,6 +870,7 @@ mod test {
                     region: "us-west-2".to_string(),
                 }),
                 Region::new("us-west-2"),
+                "1234567890".to_string(),
             ),
         ]);
         let results = validate_parameters_in_region(

--- a/tools/pubsys/src/aws/validate_ssm/results.rs
+++ b/tools/pubsys/src/aws/validate_ssm/results.rs
@@ -1,5 +1,6 @@
 //! The results module owns the reporting of SSM validation results.
 
+use crate::aws::ami::RegionAccount;
 use crate::aws::validate_ssm::Result;
 use aws_sdk_ssm::config::Region;
 use serde::{Deserialize, Serialize};
@@ -46,6 +47,9 @@ pub struct SsmValidationResult {
     #[serde(serialize_with = "serialize_region")]
     pub(crate) region: Region,
 
+    /// The account the parameter resides in
+    pub(crate) account_id: String,
+
     /// The validation status of the parameter
     pub(crate) status: SsmValidationResultStatus,
 }
@@ -63,6 +67,7 @@ impl SsmValidationResult {
         expected_value: Option<String>,
         actual_value: Result<Option<String>>,
         region: Region,
+        account_id: String,
     ) -> SsmValidationResult {
         // Determine the validation status based on equality, presence, and absence of expected and
         // actual parameter values
@@ -80,6 +85,7 @@ impl SsmValidationResult {
             expected_value,
             actual_value: actual_value.unwrap_or_default(),
             region,
+            account_id,
             status,
         }
     }
@@ -119,7 +125,7 @@ impl From<&HashSet<SsmValidationResult>> for SsmValidationRegionSummary {
 /// Represents all SSM validation results
 #[derive(Debug)]
 pub struct SsmValidationResults {
-    pub(crate) results: HashMap<Region, HashSet<SsmValidationResult>>,
+    pub(crate) results: HashMap<RegionAccount, HashSet<SsmValidationResult>>,
 }
 
 impl Default for SsmValidationResults {
@@ -130,15 +136,16 @@ impl Default for SsmValidationResults {
 
 impl Display for SsmValidationResults {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Create a summary for each region, counting the number of parameters per status
-        let region_validations: HashMap<Region, SsmValidationRegionSummary> =
+        // Create a summary for each (region, account), counting the number of parameters per
+        // status
+        let validations: HashMap<RegionAccount, SsmValidationRegionSummary> =
             self.get_results_summary();
 
         // Represent the HashMap of summaries as a `Table`
         let table = Table::new(
-            region_validations
+            validations
                 .iter()
-                .map(|(region, results)| (region.to_string(), results))
+                .map(|(key, results)| (format!("{} ({})", key.region, key.account_id), results))
                 .collect::<Vec<(String, &SsmValidationRegionSummary)>>(),
         )
         .to_string();
@@ -147,7 +154,7 @@ impl Display for SsmValidationResults {
 }
 
 impl SsmValidationResults {
-    pub fn new(results: HashMap<Region, HashSet<SsmValidationResult>>) -> Self {
+    pub fn new(results: HashMap<RegionAccount, HashSet<SsmValidationResult>>) -> Self {
         SsmValidationResults { results }
     }
 
@@ -178,14 +185,11 @@ impl SsmValidationResults {
         results
     }
 
-    fn get_results_summary(&self) -> HashMap<Region, SsmValidationRegionSummary> {
+    fn get_results_summary(&self) -> HashMap<RegionAccount, SsmValidationRegionSummary> {
         self.results
             .iter()
-            .map(|(region, region_result)| {
-                (
-                    region.clone(),
-                    SsmValidationRegionSummary::from(region_result),
-                )
+            .map(|(key, region_result)| {
+                (key.clone(), SsmValidationRegionSummary::from(region_result))
             })
             .collect()
     }
@@ -194,7 +198,7 @@ impl SsmValidationResults {
         serde_json::json!(self
             .get_results_summary()
             .into_iter()
-            .map(|(region, results)| (region.to_string(), results))
+            .map(|(key, results)| (format!("{} ({})", key.region, key.account_id), results))
             .collect::<HashMap<String, SsmValidationRegionSummary>>())
     }
 }
@@ -203,6 +207,7 @@ impl SsmValidationResults {
 mod test {
     use std::collections::{HashMap, HashSet};
 
+    use crate::aws::ami::RegionAccount;
     use crate::aws::validate_ssm::results::{
         SsmValidationResult, SsmValidationResultStatus, SsmValidationResults,
     };
@@ -214,8 +219,20 @@ mod test {
     #[test]
     fn get_results_for_status_empty() {
         let results = SsmValidationResults::new(HashMap::from([
-            (Region::new("us-west-2"), HashSet::from([])),
-            (Region::new("us-east-1"), HashSet::from([])),
+            (
+                RegionAccount {
+                    region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
+                },
+                HashSet::from([]),
+            ),
+            (
+                RegionAccount {
+                    region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
+                },
+                HashSet::from([]),
+            ),
         ]));
         let results_filtered = results.get_results_for_status(&[
             SsmValidationResultStatus::Correct,
@@ -232,60 +249,74 @@ mod test {
     fn get_results_for_status_correct() {
         let results = SsmValidationResults::new(HashMap::from([
             (
-                Region::new("us-west-2"),
+                RegionAccount {
+                    region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([
                     SsmValidationResult::new(
                         "test3-parameter-name".to_string(),
                         Some("test3-parameter-value".to_string()),
                         Ok(None),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Ok(Some("test1-parameter-value".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Ok(Some("test2-parameter-value-wrong".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Ok(Some("test4-parameter-value".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                 ]),
             ),
             (
-                Region::new("us-east-1"),
+                RegionAccount {
+                    region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([
                     SsmValidationResult::new(
                         "test3-parameter-name".to_string(),
                         Some("test3-parameter-value".to_string()),
                         Ok(None),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Ok(Some("test1-parameter-value".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Ok(Some("test2-parameter-value-wrong".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Ok(Some("test4-parameter-value".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                 ]),
             ),
@@ -301,12 +332,14 @@ mod test {
                     Some("test1-parameter-value".to_string()),
                     Ok(Some("test1-parameter-value".to_string())),
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test1-parameter-name".to_string(),
                     Some("test1-parameter-value".to_string()),
                     Ok(Some("test1-parameter-value".to_string())),
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                 )
             ])
         );
@@ -317,60 +350,74 @@ mod test {
     fn get_results_for_status_correct_incorrect() {
         let results = SsmValidationResults::new(HashMap::from([
             (
-                Region::new("us-west-2"),
+                RegionAccount {
+                    region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([
                     SsmValidationResult::new(
                         "test3-parameter-name".to_string(),
                         Some("test3-parameter-value".to_string()),
                         Ok(None),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Ok(Some("test1-parameter-value".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Ok(Some("test2-parameter-value-wrong".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Ok(Some("test4-parameter-value".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                 ]),
             ),
             (
-                Region::new("us-east-1"),
+                RegionAccount {
+                    region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([
                     SsmValidationResult::new(
                         "test3-parameter-name".to_string(),
                         Some("test3-parameter-value".to_string()),
                         Ok(None),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Ok(Some("test1-parameter-value".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Ok(Some("test2-parameter-value-wrong".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Ok(Some("test4-parameter-value".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                 ]),
             ),
@@ -388,24 +435,28 @@ mod test {
                     Some("test1-parameter-value".to_string()),
                     Ok(Some("test1-parameter-value".to_string())),
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test1-parameter-name".to_string(),
                     Some("test1-parameter-value".to_string()),
                     Ok(Some("test1-parameter-value".to_string())),
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test2-parameter-name".to_string(),
                     Some("test2-parameter-value".to_string()),
                     Ok(Some("test2-parameter-value-wrong".to_string())),
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test2-parameter-name".to_string(),
                     Some("test2-parameter-value".to_string()),
                     Ok(Some("test2-parameter-value-wrong".to_string())),
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                 )
             ])
         );
@@ -416,65 +467,82 @@ mod test {
     fn get_results_for_status_all() {
         let results = SsmValidationResults::new(HashMap::from([
             (
-                Region::new("us-west-2"),
+                RegionAccount {
+                    region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([
                     SsmValidationResult::new(
                         "test3-parameter-name".to_string(),
                         Some("test3-parameter-value".to_string()),
                         Ok(None),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Ok(Some("test1-parameter-value".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Ok(Some("test2-parameter-value-wrong".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Ok(Some("test4-parameter-value".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                 ]),
             ),
             (
-                Region::new("us-east-1"),
+                RegionAccount {
+                    region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([
                     SsmValidationResult::new(
                         "test3-parameter-name".to_string(),
                         Some("test3-parameter-value".to_string()),
                         Ok(None),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Ok(Some("test1-parameter-value".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Ok(Some("test2-parameter-value-wrong".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Ok(Some("test4-parameter-value".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                 ]),
             ),
             (
-                Region::new("us-east-2"),
+                RegionAccount {
+                    region: Region::new("us-east-2"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([SsmValidationResult::new(
                     "test3-parameter-name".to_string(),
                     Some("test3-parameter-value".to_string()),
@@ -482,6 +550,7 @@ mod test {
                         region: "us-east-2".to_string(),
                     }),
                     Region::new("us-east-2"),
+                    "1234567890".to_string(),
                 )]),
             ),
         ]));
@@ -501,48 +570,56 @@ mod test {
                     Some("test1-parameter-value".to_string()),
                     Ok(Some("test1-parameter-value".to_string())),
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test1-parameter-name".to_string(),
                     Some("test1-parameter-value".to_string()),
                     Ok(Some("test1-parameter-value".to_string())),
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test2-parameter-name".to_string(),
                     Some("test2-parameter-value".to_string()),
                     Ok(Some("test2-parameter-value-wrong".to_string())),
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test2-parameter-name".to_string(),
                     Some("test2-parameter-value".to_string()),
                     Ok(Some("test2-parameter-value-wrong".to_string())),
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test3-parameter-name".to_string(),
                     Some("test3-parameter-value".to_string()),
                     Ok(None),
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test4-parameter-name".to_string(),
                     None,
                     Ok(Some("test4-parameter-value".to_string())),
                     Region::new("us-west-2"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test3-parameter-name".to_string(),
                     Some("test3-parameter-value".to_string()),
                     Ok(None),
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test4-parameter-name".to_string(),
                     None,
                     Ok(Some("test4-parameter-value".to_string())),
                     Region::new("us-east-1"),
+                    "1234567890".to_string(),
                 ),
                 &SsmValidationResult::new(
                     "test3-parameter-name".to_string(),
@@ -551,6 +628,7 @@ mod test {
                         region: "us-east-2".to_string()
                     }),
                     Region::new("us-east-2"),
+                    "1234567890".to_string(),
                 ),
             ])
         );
@@ -561,48 +639,60 @@ mod test {
     fn get_results_for_status_missing_none() {
         let results = SsmValidationResults::new(HashMap::from([
             (
-                Region::new("us-west-2"),
+                RegionAccount {
+                    region: Region::new("us-west-2"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Ok(Some("test1-parameter-value".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Ok(Some("test2-parameter-value-wrong".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Ok(Some("test4-parameter-value".to_string())),
                         Region::new("us-west-2"),
+                        "1234567890".to_string(),
                     ),
                 ]),
             ),
             (
-                Region::new("us-east-1"),
+                RegionAccount {
+                    region: Region::new("us-east-1"),
+                    account_id: "1234567890".to_string(),
+                },
                 HashSet::from([
                     SsmValidationResult::new(
                         "test1-parameter-name".to_string(),
                         Some("test1-parameter-value".to_string()),
                         Ok(Some("test1-parameter-value".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test2-parameter-name".to_string(),
                         Some("test2-parameter-value".to_string()),
                         Ok(Some("test2-parameter-value-wrong".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                     SsmValidationResult::new(
                         "test4-parameter-name".to_string(),
                         None,
                         Ok(Some("test4-parameter-value".to_string())),
                         Region::new("us-east-1"),
+                        "1234567890".to_string(),
                     ),
                 ]),
             ),


### PR DESCRIPTION
**Issue number:**

Closes #678

**Description of changes:**

pubsys: support publishing one AMI into multiple accounts per region
Previously pubsys assumed one account per region (a single role per
[aws.region.*]), so registering a single built AMI into separate
preprod/prod accounts in the same region required dynamically generated
per-account spec files.

This adds a `roles` list to [aws.region.*] alongside the existing
`role`. We register the AMI once in the base account, then copy + share
it into each additional target account (reusing the existing
modify_snapshots/modify_image + copy_image machinery), and publish a
separate set of SSM parameters per account.

The intermediate --ami-input JSON produced by `pubsys ami` and consumed
by `pubsys ssm` / `pubsys publish-ami` is now nested by account
(region -> account -> image). SSM get/set/validate run once per account
since each account has its own parameter store.

**Testing done:**

- `cargo test` passes for pubsys and pubsys-config packages.
- Added several tests to verify that `role` takes precedence over `roles`, we will allow an empty or missing `roles` vector, duplicate roles across both fields are de-duplicated and accepted, and that the modified `--ami-input` field works across the ssm tool.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
