### PR TITLE
feat(buildsys): rename first-party-stack image feature to standalone-image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* New `first-party-stack` image feature (default `true`): controls whether the
-  Bottlerocket-provided software stack (orchestrator integration, settings
-  system, in-place updates, BOTTLEROCKET-PRIVATE / BOTTLEROCKET-DATA partitions)
-  is built into the image. Setting `first-party-stack = false` produces a
-  stripped-down OS image with a single bank of partitions (BIOS-BOOT,
+* New `standalone-image` image feature (default `false`): opt-in flag that
+  produces a stripped-down OS image without the Bottlerocket-provided software
+  stack (orchestrator integration, settings system, in-place updates,
+  BOTTLEROCKET-PRIVATE / BOTTLEROCKET-DATA partitions). Setting
+  `standalone-image = true` produces a single bank of partitions (BIOS-BOOT,
   EFI-SYSTEM, BOOT-A, ROOT-A, HASH-A), no RESERVED, PRIVATE, or DATA
   partitions, defaulting to a 1 GiB total disk size. Requires
   `partition-plan = "unified"`, and is incompatible with `uefi-secure-boot`,
   `encrypted-storage`, `in-place-updates`, `host-containers`, and
   `partition-plan = "split"`; the build fails fast with a clear message in
   those cases. The metadata RPM provides
-  `image-feature(first-party-stack)` or `image-feature(no-first-party-stack)`
+  `image-feature(standalone-image)` or `image-feature(no-standalone-image)`
   accordingly.
 
 [unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.20.0...HEAD

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -286,11 +286,11 @@ impl VariantBuildArgs {
         );
 
         for image_feature in self.image_features.iter() {
-            // `first-party-stack` is the inverted, default-true feature: pass
+            // `standalone-image` is the opt-in stripped-image feature: pass
             // `yes` to bash so the Dockerfile can pipe the value through to
-            // `--with-first-party-stack=`. All other features stay on the
+            // `--with-standalone-image=`. All other features stay on the
             // simple `1`-presence convention.
-            let value = if matches!(image_feature, ImageFeature::FirstPartyStack) {
+            let value = if matches!(image_feature, ImageFeature::StandaloneImage) {
                 "yes"
             } else {
                 "1"
@@ -340,7 +340,7 @@ impl RepackVariantBuildArgs {
         args.build_arg("VERSION_ID", &self.version_image);
 
         for image_feature in self.image_features.iter() {
-            let value = if matches!(image_feature, ImageFeature::FirstPartyStack) {
+            let value = if matches!(image_feature, ImageFeature::StandaloneImage) {
                 "yes"
             } else {
                 "1"
@@ -479,7 +479,7 @@ impl DockerBuild {
         let image_layout = resolved_image_layout(&raw_layout, &features, image_format);
         // Defense in depth: re-run the image feature validator here so that
         // any future code path that constructs a `DockerBuild` cannot bypass
-        // the gate that `main.rs::validate_first_party_stack_or_warn` provides.
+        // the gate that `main.rs::validate_standalone_image_or_warn` provides.
         validate_image_features(&features, &image_layout, image_format)
             .context(error::GraphSnafu)?;
         let os_image_size_gib = image_layout.os_image_size_gib();
@@ -604,7 +604,7 @@ impl DockerBuild {
         let image_layout = resolved_image_layout(&raw_layout, &features, image_format);
         // Defense in depth: re-run the image feature validator here so that
         // any future code path that constructs a `DockerBuild` cannot bypass
-        // the gate that `main.rs::validate_first_party_stack_or_warn` provides.
+        // the gate that `main.rs::validate_standalone_image_or_warn` provides.
         validate_image_features(&features, &image_layout, image_format)
             .context(error::GraphSnafu)?;
         let os_image_size_gib = image_layout.os_image_size_gib();

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -268,7 +268,7 @@ fn build_variant(args: BuildVariantArgs) -> Result<()> {
     .context(error::ManifestParseSnafu)?;
 
     check_arch_support(manifest.info(), args.common.arch);
-    validate_first_party_stack_or_warn(manifest.info())?;
+    validate_standalone_image_or_warn(manifest.info())?;
 
     // Resolve declared guest-images and emit a rerun-if-changed for each guest's image
     // directory, so rebuilding a guest variant triggers a rebuild of this host variant.
@@ -304,7 +304,7 @@ fn repack_variant(args: RepackVariantArgs) -> Result<()> {
     .context(error::ManifestParseSnafu)?;
 
     check_arch_support(manifest.info(), args.common.arch);
-    validate_first_party_stack_or_warn(manifest.info())?;
+    validate_standalone_image_or_warn(manifest.info())?;
 
     if args.common.cicd_hack {
         return Ok(());
@@ -331,20 +331,20 @@ fn check_arch_support(manifest: &ManifestInfo, arch: SupportedArch) {
 }
 
 /// Re-validate image features against the resolved image layout, and emit a
-/// multi-line warning when `first-party-stack = false` so that build logs
+/// multi-line warning when `standalone-image = true` so that build logs
 /// make the implications obvious.
-fn validate_first_party_stack_or_warn(manifest: &ManifestInfo) -> Result<()> {
+fn validate_standalone_image_or_warn(manifest: &ManifestInfo) -> Result<()> {
     let features = manifest.image_features().unwrap_or_default();
     let raw_layout = manifest.image_layout().cloned().unwrap_or_default();
     let image_format = manifest.image_format();
     let layout = resolved_image_layout(&raw_layout, &features, image_format);
     validate_image_features(&features, &layout, image_format).context(error::ImageFeaturesSnafu)?;
 
-    if !features.contains(&ImageFeature::FirstPartyStack) {
+    if features.contains(&ImageFeature::StandaloneImage) {
         // `cargo:warning` is line-oriented, so emit one line per call.
         for line in [
-            "WARNING: image feature `first-party-stack` is disabled.",
-            "With `first-party-stack = false`, the resulting image will NOT contain the",
+            "WARNING: image feature `standalone-image` is enabled.",
+            "With `standalone-image = true`, the resulting image will NOT contain the",
             "Bottlerocket datastore, settings subsystem, host-containers, or any",
             "first-party Bottlerocket management software. You are responsible for",
             "owning all system configuration yourself. The image will not have a",

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -124,9 +124,9 @@ minimal GPT disk image and a bare kernel. EIF is inherently a
 stripped-down layout — no BOTTLEROCKET-DATA, PRIVATE, or RESERVED
 partitions, no second bank of OS partitions, no in-place updates — so
 the following features are automatically dropped from the silent
-default seed for an EIF variant: `first-party-stack`, `in-place-updates`,
+default seed for an EIF variant: `in-place-updates`,
 `host-containers`. The following combinations are rejected at build
-time (in the same style as `first-party-stack = false`):
+time (in the same style as `standalone-image = true`):
 `uefi-secure-boot`, `encrypted-storage`, `in-place-updates`,
 `host-containers`, and `partition-plan = "split"`. The
 `os-image-size-gib` default is 1 GiB (vs. 2 GiB for a full image), and
@@ -269,29 +269,30 @@ only be enabled for variants that can guarantee that a TPM 2.0 device will be pr
 encrypted-storage = true
 ```
 
-`first-party-stack` controls whether the Bottlerocket-provided software stack — the
-orchestrator integration (kubelet, containerd, host-containers, admin-containers), the
-settings system (apiserver, datastore, settings rendering, migrations), in-place updates, and
-the BOTTLEROCKET-PRIVATE / BOTTLEROCKET-DATA partitions — is built into the image. The
-default is `true`.
+`standalone-image` controls whether the image is a stripped-down OS without the
+Bottlerocket-provided software stack. The default is `false` (full Bottlerocket image).
 
-When `first-party-stack = false`, the image is reduced to the kernel, base userspace,
-dm-verity-protected rootfs, and the update mechanism. The OS image has a single bank of OS
-partitions (BIOS-BOOT, EFI-SYSTEM, BOOT-A, ROOT-A, HASH-A) with no `RESERVED-A` partition;
-ROOT-A absorbs the slack. The default OS image size becomes 1 GiB unless `os-image-size-gib`
-is explicitly set. The variant author owns all system configuration; if Bottlerocket
-components that expect persistent storage at `partlabel=BOTTLEROCKET-DATA` are shipped, such
-a volume may optionally be attached at runtime.
+When `standalone-image = true`, the Bottlerocket-provided software stack — the orchestrator
+integration (kubelet, containerd, host-containers, admin-containers), the settings system
+(apiserver, datastore, settings rendering, migrations), in-place updates, and the
+BOTTLEROCKET-PRIVATE / BOTTLEROCKET-DATA partitions — is NOT built into the image. The image
+is reduced to the kernel, base userspace, dm-verity-protected rootfs, and the update mechanism.
+The OS image has a single bank of OS partitions (BIOS-BOOT, EFI-SYSTEM, BOOT-A, ROOT-A,
+HASH-A) with no `RESERVED-A` partition; ROOT-A absorbs the slack. The default OS image size
+becomes 1 GiB unless `os-image-size-gib` is explicitly set. The variant author owns all
+system configuration; if Bottlerocket components that expect persistent storage at
+`partlabel=BOTTLEROCKET-DATA` are shipped, such a volume may optionally be attached at
+runtime.
 
-`first-party-stack = false` requires `partition-plan = "unified"`, and is incompatible with
+`standalone-image = true` requires `partition-plan = "unified"`, and is incompatible with
 `uefi-secure-boot`, `encrypted-storage`, `in-place-updates`, and `host-containers`; the build
-will fail fast in those cases. Setting `first-party-stack = false` also turns off the silent
+will fail fast in those cases. Setting `standalone-image = true` also turns off the silent
 defaults for `in-place-updates` and `host-containers` so that, once `partition-plan = "unified"`
-is set, toggling `first-party-stack = false` is sufficient to produce a stripped-down image.
+is set, toggling `standalone-image = true` is sufficient to produce a stripped-down image.
 
 ```ignore
 [package.metadata.build-variant.image-features]
-first-party-stack = false
+standalone-image = true
 
 [package.metadata.build-variant.image-layout]
 partition-plan = "unified"
@@ -631,31 +632,32 @@ impl ManifestInfo {
     /// Convenience method to return the enabled image features for this variant.
     pub fn image_features(&self) -> Option<HashSet<ImageFeature>> {
         let variant = self.build_variant()?;
-        // If the user explicitly disabled `first-party-stack`, drop the silent
-        // defaults for `in-place-updates` and `host-containers` (and
-        // `first-party-stack` itself). An explicit `in-place-updates = true`
-        // is still rejected later by the validator.
+        // If the user explicitly enabled `standalone-image`, drop the silent
+        // defaults for `in-place-updates` and `host-containers` since they
+        // are incompatible with the stripped-down image. An explicit
+        // `in-place-updates = true` is still rejected later by the validator.
         //
-        // `image-format = "eif"` is treated the same as `first-party-stack =
-        // false` for seeding purposes: an EIF is inherently a stripped-down
+        // `image-format = "eif"` is treated the same as `standalone-image =
+        // true` for seeding purposes: an EIF is inherently a stripped-down
         // single-bank image, so shipping the second bank / host-containers /
         // BOTTLEROCKET-DATA subsystems by default only invites silent
         // misconfiguration when the Dockerfile drops those flags on the way
         // to `rpm2eif`. The validator will still reject an *explicit*
         // conflicting feature set with a clear error.
-        let first_party_stack_explicitly_disabled = variant
+        let standalone_image_explicitly_enabled = variant
             .image_features
             .as_ref()
-            .and_then(|m| m.get(&ImageFeature::FirstPartyStack))
+            .and_then(|m| m.get(&ImageFeature::StandaloneImage))
             .copied()
-            .map(|enabled| !enabled)
             .unwrap_or(false);
         let is_eif = matches!(variant.image_format, Some(ImageFormat::Eif));
-        let mut features = if first_party_stack_explicitly_disabled || is_eif {
-            HashSet::from([ImageFeature::ExternalKmodDevelopment])
+        let mut features = if standalone_image_explicitly_enabled || is_eif {
+            HashSet::from([
+                ImageFeature::StandaloneImage,
+                ImageFeature::ExternalKmodDevelopment,
+            ])
         } else {
             HashSet::from([
-                ImageFeature::FirstPartyStack,
                 ImageFeature::InPlaceUpdates,
                 ImageFeature::HostContainers,
                 ImageFeature::ExternalKmodDevelopment,
@@ -1017,9 +1019,9 @@ pub struct ImageLayout {
 /// These are the historical defaults for all variants, before we added support
 /// for customizing these properties.
 static DEFAULT_OS_IMAGE_SIZE_GIB: ImageSize = ImageSize(2);
-/// Default OS image size when `first-party-stack = false` and the manifest
+/// Default OS image size when `standalone-image = true` and the manifest
 /// does not specify `os-image-size-gib`.
-static DEFAULT_NO_FIRST_PARTY_OS_IMAGE_SIZE_GIB: ImageSize = ImageSize(1);
+static DEFAULT_STANDALONE_IMAGE_OS_IMAGE_SIZE_GIB: ImageSize = ImageSize(1);
 static DEFAULT_DATA_IMAGE_SIZE_GIB: ImageSize = ImageSize(1);
 static DEFAULT_PUBLISH_IMAGE_SIZE_HINT_GIB: ImageSize = ImageSize(22);
 static DEFAULT_PARTITION_PLAN: PartitionPlan = PartitionPlan::Split;
@@ -1124,7 +1126,7 @@ pub enum ImageFeature {
     HostContainers,
     ExternalKmodDevelopment,
     EncryptedStorage,
-    FirstPartyStack,
+    StandaloneImage,
 }
 
 const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[&ImageFeature::EncryptedStorage];
@@ -1137,8 +1139,8 @@ const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
 /// Returns an [`ImageLayout`] with fields adjusted for the given feature set
 /// and image format.
 ///
-/// - If `first-party-stack` is disabled (or the image format is `eif`, which
-///   is inherently first-party-stack-free) and the manifest did not
+/// - If `standalone-image` is enabled (or the image format is `eif`, which
+///   is inherently a standalone-image image) and the manifest did not
 ///   explicitly set `os-image-size-gib`, the default OS image size is
 ///   reduced from 2 GiB to 1 GiB.
 /// - If the image format is `eif`, the partition plan is forced to
@@ -1151,7 +1153,7 @@ const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
 ///
 /// `image_format` is optional so that call sites which don't yet have access
 /// to the manifest's image format (or don't care) can pass `None` and get
-/// the pre-existing `first-party-stack`-only behavior.
+/// the pre-existing `standalone-image`-only behavior.
 pub fn resolved_image_layout(
     layout: &ImageLayout,
     features: &HashSet<ImageFeature>,
@@ -1159,9 +1161,9 @@ pub fn resolved_image_layout(
 ) -> ImageLayout {
     let mut resolved = *layout;
     let is_eif = matches!(image_format, Some(ImageFormat::Eif));
-    let stripped = !features.contains(&ImageFeature::FirstPartyStack) || is_eif;
+    let stripped = features.contains(&ImageFeature::StandaloneImage) || is_eif;
     if stripped && !layout.os_image_size_gib_was_set() {
-        resolved.os_image_size_gib = Some(DEFAULT_NO_FIRST_PARTY_OS_IMAGE_SIZE_GIB);
+        resolved.os_image_size_gib = Some(DEFAULT_STANDALONE_IMAGE_OS_IMAGE_SIZE_GIB);
     }
     if is_eif {
         resolved.partition_plan = PartitionPlan::Unified;
@@ -1171,12 +1173,12 @@ pub fn resolved_image_layout(
 
 /// Validate that the requested image features and layout are compatible.
 ///
-/// This enforces that disabling `first-party-stack` is not combined with any
+/// This enforces that enabling `standalone-image` is not combined with any
 /// of `uefi-secure-boot`, `encrypted-storage`, `in-place-updates`,
 /// `host-containers`, `xfs-data-partition`, or with a `split` partition plan.
 ///
 /// An `image-format = "eif"` build is subject to the same constraints
-/// regardless of the `first-party-stack` toggle: an EIF is a single-bank,
+/// regardless of the `standalone-image` toggle: an EIF is a single-bank,
 /// dm-verity-protected, partitionless (no DATA/PRIVATE/RESERVED) image, and
 /// `rpm2eif` silently ignores every one of those knobs. Enforcing the
 /// constraints up-front turns a subtle "build succeeds, image is wrong"
@@ -1200,86 +1202,75 @@ pub fn validate_image_features(
     image_format: Option<&ImageFormat>,
 ) -> Result<()> {
     let is_eif = matches!(image_format, Some(ImageFormat::Eif));
-    // With `first-party-stack` enabled *and* a non-EIF format, every
-    // combination is legal.
-    if features.contains(&ImageFeature::FirstPartyStack) && !is_eif {
+    // Without `standalone-image` enabled *and* a non-EIF format, every
+    // combination is legal (full Bottlerocket image).
+    if !features.contains(&ImageFeature::StandaloneImage) && !is_eif {
         return Ok(());
     }
 
-    // Explain conflicts as either a first-party-stack violation or an EIF
+    // Explain conflicts as either a standalone-image violation or an EIF
     // violation, whichever applies. EIF takes precedence in the message
     // because it's the more surprising case (the format silently strips
-    // features rather than an explicit `first-party-stack = false`).
+    // features rather than an explicit `standalone-image = true`).
     let context: &str = if is_eif {
         "`image-format = \"eif\"`"
     } else {
-        "`first-party-stack = false`"
+        "`standalone-image = true`"
     };
     let reason_secure_boot: String = if is_eif {
         "secure boot is not supported by the EIF pipeline; `rpm2eif` does not sign shim/grub/vmlinuz".to_string()
     } else {
-        "secure boot relies on signed first-party artifacts that are not present when `first-party-stack = false`".to_string()
+        "secure boot relies on signed first-party artifacts that are not present when `standalone-image = true`".to_string()
     };
     let reason_encrypted_storage: String = if is_eif {
         "encrypted storage requires the BOTTLEROCKET-PRIVATE/DATA partitions, which an EIF image does not have".to_string()
     } else {
-        "encrypted storage requires the BOTTLEROCKET-PRIVATE/DATA partitions, which are not built when `first-party-stack = false`".to_string()
+        "encrypted storage requires the BOTTLEROCKET-PRIVATE/DATA partitions, which are not built when `standalone-image = true`".to_string()
     };
     let reason_ipu: String = if is_eif {
         "in-place updates require two banks of OS partitions; an EIF ships a single ROOT-A/HASH-A pair".to_string()
     } else {
-        "in-place updates require two banks of OS partitions, which are not built when `first-party-stack = false`".to_string()
+        "in-place updates require two banks of OS partitions, which are not built when `standalone-image = true`".to_string()
     };
     let reason_host_containers: String = if is_eif {
         "host-containers require the BOTTLEROCKET-DATA partition, which an EIF image does not have"
             .to_string()
     } else {
-        "host-containers require the BOTTLEROCKET-DATA partition, which is not built when `first-party-stack = false`".to_string()
+        "host-containers require the BOTTLEROCKET-DATA partition, which is not built when `standalone-image = true`".to_string()
     };
-    let reason_first_party_stack =
-        "the EIF pipeline is inherently stripped down; `rpm2eif` requires `first-party-stack = false`";
+    let reason_standalone_image_missing =
+        "the EIF pipeline is inherently stripped down; `rpm2eif` requires `standalone-image = true`";
     let reason_xfs_data_partition: String = if is_eif {
         "xfs-data-partition requires the BOTTLEROCKET-DATA partition, which an EIF image does not have".to_string()
     } else {
-        "xfs-data-partition requires the BOTTLEROCKET-DATA partition, which is not built when `first-party-stack = false`".to_string()
+        "xfs-data-partition requires the BOTTLEROCKET-DATA partition, which is not built when `standalone-image = true`".to_string()
     };
 
-    let conflicts: &[(ImageFeature, &str, &str, bool)] = &[
-        (
-            ImageFeature::FirstPartyStack,
-            "first-party-stack",
-            reason_first_party_stack,
-            true,
-        ),
+    let conflicts: &[(ImageFeature, &str, &str)] = &[
         (
             ImageFeature::XfsDataPartition,
             "xfs-data-partition",
             &reason_xfs_data_partition,
-            false,
         ),
         (
             ImageFeature::UefiSecureBoot,
             "uefi-secure-boot",
             &reason_secure_boot,
-            false,
         ),
         (
             ImageFeature::EncryptedStorage,
             "encrypted-storage",
             &reason_encrypted_storage,
-            false,
         ),
         (
             ImageFeature::InPlaceUpdates,
             "in-place-updates",
             &reason_ipu,
-            false,
         ),
         (
             ImageFeature::HostContainers,
             "host-containers",
             &reason_host_containers,
-            false,
         ),
     ];
 
@@ -1289,16 +1280,24 @@ pub fn validate_image_features(
     // wrote and the error messages produced by the shell-side validators.
     let mut conflict_messages: Vec<String> = conflicts
         .iter()
-        .filter(|(feature, _, _, eif_only)| features.contains(feature) && (!eif_only || is_eif))
-        .map(|(_, name, reason, _)| format!("`{name}`: {reason}"))
+        .filter(|(feature, _, _)| features.contains(feature))
+        .map(|(_, name, reason)| format!("`{name}`: {reason}"))
         .collect();
+
+    // EIF requires standalone-image to be present in the feature set.
+    if is_eif && !features.contains(&ImageFeature::StandaloneImage) {
+        conflict_messages.insert(
+            0,
+            format!("`standalone-image`: {reason_standalone_image_missing}"),
+        );
+    }
 
     if matches!(layout.partition_plan, PartitionPlan::Split) {
         let reason = if is_eif {
             "`partition-plan=split`: an EIF is a single unified disk; the split \
              layout has no meaning"
         } else {
-            "`partition-plan=split`: when `first-party-stack = false`, the image uses a \
+            "`partition-plan=split`: when `standalone-image = true`, the image uses a \
              single unified disk with no separate data image"
         };
         conflict_messages.push(reason.to_string());
@@ -1329,7 +1328,7 @@ impl TryFrom<String> for ImageFeature {
             "host-containers" => Ok(ImageFeature::HostContainers),
             "external-kmod-development" => Ok(ImageFeature::ExternalKmodDevelopment),
             "encrypted-storage" => Ok(ImageFeature::EncryptedStorage),
-            "first-party-stack" => Ok(ImageFeature::FirstPartyStack),
+            "standalone-image" => Ok(ImageFeature::StandaloneImage),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
     }
@@ -1342,20 +1341,20 @@ impl TryFrom<String> for ImageFeature {
 ///
 /// | Layer                              | Representation       | Example          |
 /// |------------------------------------|----------------------|------------------|
-/// | Rust enum variant                  | UpperCamelCase       | `FirstPartyStack` |
-/// | Manifest TOML key (TryFrom impl)   | kebab-case           | `first-party-stack` |
-/// | Display impl (env var name)        | UPPER_SNAKE_CASE     | `FIRST_PARTY_STACK` |
-/// | Dockerfile `--build-arg` value     | `1` (truthy) or `yes` | `FIRST_PARTY_STACK=yes` |
-/// | Shell script `--with-X=` value     | `yes` / `no`         | `--with-first-party-stack=no` |
-/// | Runtime `image-features.env` value | `true` / `false`     | `FIRST_PARTY_STACK=true` |
+/// | Rust enum variant                  | UpperCamelCase       | `StandaloneImage` |
+/// | Manifest TOML key (TryFrom impl)   | kebab-case           | `standalone-image` |
+/// | Display impl (env var name)        | UPPER_SNAKE_CASE     | `STANDALONE_IMAGE` |
+/// | Dockerfile `--build-arg` value     | `1` (truthy) or `yes` | `STANDALONE_IMAGE=yes` |
+/// | Shell script `--with-X=` value     | `yes` / `no`         | `--with-standalone-image=yes` |
+/// | Runtime `image-features.env` value | `true` / `false`     | `STANDALONE_IMAGE=true` |
 ///
 /// Each layer's representation is intentional: the Dockerfile uses `1` so
 /// that bash's `${VAR:+...}` expansion can convert presence to a flag, the
 /// shell scripts use `yes`/`no` to be readable in build logs, and the
 /// runtime env file uses `true`/`false` to be parseable by configuration
-/// loaders. `FirstPartyStack` is the exception: since it is default-true
-/// and inverted, its build-arg is `yes` so the Dockerfile can pipe the
-/// value directly to `--with-first-party-stack=`. See
+/// loaders. `StandaloneImage` is the exception: since it is default-false
+/// and opt-in, its build-arg is `yes` so the Dockerfile can pipe the
+/// value directly to `--with-standalone-image=`. See
 /// `tools/buildsys/src/builder.rs`, `twoliter/embedded/build.Dockerfile`,
 /// and `twoliter/embedded/rpm2img` for the conversions between layers.
 impl fmt::Display for ImageFeature {
@@ -1371,7 +1370,7 @@ impl fmt::Display for ImageFeature {
             ImageFeature::HostContainers => write!(f, "HOST_CONTAINERS"),
             ImageFeature::ExternalKmodDevelopment => write!(f, "EXTERNAL_KMOD_DEVELOPMENT"),
             ImageFeature::EncryptedStorage => write!(f, "ENCRYPTED_STORAGE"),
-            ImageFeature::FirstPartyStack => write!(f, "FIRST_PARTY_STACK"),
+            ImageFeature::StandaloneImage => write!(f, "STANDALONE_IMAGE"),
         }
     }
 }
@@ -1522,7 +1521,7 @@ mod test {
         assert_eq!(kit_list, expected);
     }
 
-    fn first_party_stack_disabled_layout(os_size: Option<u16>, plan: PartitionPlan) -> ImageLayout {
+    fn standalone_image_layout(os_size: Option<u16>, plan: PartitionPlan) -> ImageLayout {
         ImageLayout {
             os_image_size_gib: os_size.map(ImageSize),
             data_image_size_gib: DEFAULT_DATA_IMAGE_SIZE_GIB,
@@ -1532,114 +1531,120 @@ mod test {
     }
 
     #[test]
-    fn first_party_stack_disabled_default_os_size_is_one_gib() {
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
-        // No FirstPartyStack in the set → stripped image, default 1 GiB.
-        let features: HashSet<ImageFeature> = HashSet::new();
+    fn standalone_image_enabled_default_os_size_is_one_gib() {
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
+        // StandaloneImage in the set → stripped image, default 1 GiB.
+        let features = HashSet::from([ImageFeature::StandaloneImage]);
         let resolved = resolved_image_layout(&layout, &features, None);
         assert_eq!(resolved.os_image_size_gib().0, 1);
     }
 
     #[test]
-    fn first_party_stack_disabled_respects_explicit_os_size() {
-        let layout = first_party_stack_disabled_layout(Some(4), PartitionPlan::Unified);
-        let features: HashSet<ImageFeature> = HashSet::new();
+    fn standalone_image_enabled_respects_explicit_os_size() {
+        let layout = standalone_image_layout(Some(4), PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::StandaloneImage]);
         let resolved = resolved_image_layout(&layout, &features, None);
         assert_eq!(resolved.os_image_size_gib().0, 4);
     }
 
     #[test]
-    fn first_party_stack_default_os_size_is_two_gib() {
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
-        let features = HashSet::from([ImageFeature::FirstPartyStack]);
+    fn standalone_image_absent_default_os_size_is_two_gib() {
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
+        let features: HashSet<ImageFeature> = HashSet::new();
         let resolved = resolved_image_layout(&layout, &features, None);
         assert_eq!(resolved.os_image_size_gib().0, 2);
     }
 
     #[test]
-    fn first_party_stack_disabled_alone_passes_validation() {
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
-        let features: HashSet<ImageFeature> = HashSet::new();
+    fn standalone_image_enabled_alone_passes_validation() {
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::StandaloneImage]);
         validate_image_features(&features, &layout, None)
-            .expect("first-party-stack=false + unified should validate");
+            .expect("standalone-image=true + unified should validate");
     }
 
     #[test]
-    fn first_party_stack_disabled_rejects_secure_boot() {
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
-        let features = HashSet::from([ImageFeature::UefiSecureBoot]);
+    fn standalone_image_enabled_rejects_secure_boot() {
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::StandaloneImage, ImageFeature::UefiSecureBoot]);
         assert!(validate_image_features(&features, &layout, None).is_err());
     }
 
     #[test]
-    fn first_party_stack_disabled_rejects_encrypted_storage() {
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
-        let features = HashSet::from([ImageFeature::EncryptedStorage]);
-        assert!(validate_image_features(&features, &layout, None).is_err());
-    }
-
-    #[test]
-    fn first_party_stack_disabled_rejects_in_place_updates() {
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
-        let features = HashSet::from([ImageFeature::InPlaceUpdates]);
-        assert!(validate_image_features(&features, &layout, None).is_err());
-    }
-
-    #[test]
-    fn first_party_stack_disabled_rejects_split_partition_plan() {
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Split);
-        let features: HashSet<ImageFeature> = HashSet::new();
-        assert!(validate_image_features(&features, &layout, None).is_err());
-    }
-
-    #[test]
-    fn validation_is_noop_when_first_party_stack_enabled() {
-        // With `first-party-stack` enabled, the validator should accept any
-        // combination.
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Split);
+    fn standalone_image_enabled_rejects_encrypted_storage() {
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
         let features = HashSet::from([
-            ImageFeature::FirstPartyStack,
+            ImageFeature::StandaloneImage,
+            ImageFeature::EncryptedStorage,
+        ]);
+        assert!(validate_image_features(&features, &layout, None).is_err());
+    }
+
+    #[test]
+    fn standalone_image_enabled_rejects_in_place_updates() {
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::StandaloneImage, ImageFeature::InPlaceUpdates]);
+        assert!(validate_image_features(&features, &layout, None).is_err());
+    }
+
+    #[test]
+    fn standalone_image_enabled_rejects_split_partition_plan() {
+        let layout = standalone_image_layout(None, PartitionPlan::Split);
+        let features = HashSet::from([ImageFeature::StandaloneImage]);
+        assert!(validate_image_features(&features, &layout, None).is_err());
+    }
+
+    #[test]
+    fn validation_is_noop_when_standalone_image_absent() {
+        // Without `standalone-image`, the validator should accept any
+        // combination (full image).
+        let layout = standalone_image_layout(None, PartitionPlan::Split);
+        let features = HashSet::from([
             ImageFeature::UefiSecureBoot,
             ImageFeature::EncryptedStorage,
             ImageFeature::InPlaceUpdates,
         ]);
         validate_image_features(&features, &layout, None)
-            .expect("validation should be no-op with first-party-stack enabled");
+            .expect("validation should be no-op without standalone-image");
     }
 
     #[test]
-    fn first_party_stack_disabled_rejects_host_containers() {
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
-        let features = HashSet::from([ImageFeature::HostContainers]);
+    fn standalone_image_enabled_rejects_host_containers() {
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([ImageFeature::StandaloneImage, ImageFeature::HostContainers]);
         assert!(validate_image_features(&features, &layout, None).is_err());
     }
 
     #[test]
-    fn first_party_stack_disabled_rejects_xfs_data_partition() {
-        // `first-party-stack = false` skips building the BOTTLEROCKET-DATA
+    fn standalone_image_enabled_rejects_xfs_data_partition() {
+        // `standalone-image = true` skips building the BOTTLEROCKET-DATA
         // partition, so opting into `xfs-data-partition` on top of it would
         // silently do nothing. Reject the combination at build time.
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
-        let features = HashSet::from([ImageFeature::XfsDataPartition]);
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
+        let features = HashSet::from([
+            ImageFeature::StandaloneImage,
+            ImageFeature::XfsDataPartition,
+        ]);
         let err = validate_image_features(&features, &layout, None)
-            .expect_err("first-party-stack=false + xfs-data-partition must fail validation");
+            .expect_err("standalone-image=true + xfs-data-partition must fail validation");
         let msg = format!("{err}");
         assert!(
             msg.contains("xfs-data-partition"),
             "missing 'xfs-data-partition' in: {msg}",
         );
         assert!(
-            msg.contains("first-party-stack = false"),
-            "message should reference first-party-stack=false: {msg}",
+            msg.contains("standalone-image = true"),
+            "message should reference standalone-image=true: {msg}",
         );
     }
 
     #[test]
-    fn first_party_stack_disabled_reports_all_conflicts_at_once() {
+    fn standalone_image_enabled_reports_all_conflicts_at_once() {
         // The validator should report every conflict in a single error so the
         // user does not have to fix them one at a time across multiple builds.
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Split);
+        let layout = standalone_image_layout(None, PartitionPlan::Split);
         let features = HashSet::from([
+            ImageFeature::StandaloneImage,
             ImageFeature::UefiSecureBoot,
             ImageFeature::EncryptedStorage,
             ImageFeature::InPlaceUpdates,
@@ -1695,44 +1700,45 @@ name = "test-variant"
     }
 
     #[test]
-    fn image_features_first_party_stack_disabled_drops_silent_defaults() {
-        // `first-party-stack = false` alone should drop the silent
-        // `in-place-updates` and `host-containers` defaults (and remove
-        // `first-party-stack` itself from the seed).
+    fn image_features_standalone_image_enabled_drops_silent_defaults() {
+        // `standalone-image = true` alone should drop the silent
+        // `in-place-updates` and `host-containers` defaults and add
+        // `standalone-image` to the seed.
         let toml = variant_manifest_with_image_features(
-            "[package.metadata.build-variant.image-features]\nfirst-party-stack = false",
+            "[package.metadata.build-variant.image-features]\nstandalone-image = true",
         );
         let info = manifest_info_from_toml(&toml);
         let features = info.image_features().expect("variant has image-features");
-        assert!(!features.contains(&ImageFeature::FirstPartyStack));
+        assert!(features.contains(&ImageFeature::StandaloneImage));
         assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));
         assert!(!features.contains(&ImageFeature::InPlaceUpdates));
         assert!(!features.contains(&ImageFeature::HostContainers));
     }
 
     #[test]
-    fn image_features_first_party_stack_disabled_with_host_containers_keeps_both() {
+    fn image_features_standalone_image_enabled_with_host_containers_keeps_both() {
         // The seed-set logic adds host-containers back if it's explicitly set
         // to `true`, so that the validator can later reject the combination
         // with a clear error rather than silently producing a confused image.
         let toml = variant_manifest_with_image_features(
             "[package.metadata.build-variant.image-features]\n\
-             first-party-stack = false\n\
+             standalone-image = true\n\
              host-containers = true",
         );
         let info = manifest_info_from_toml(&toml);
         let features = info.image_features().expect("variant has image-features");
-        assert!(!features.contains(&ImageFeature::FirstPartyStack));
+        assert!(features.contains(&ImageFeature::StandaloneImage));
         assert!(features.contains(&ImageFeature::HostContainers));
         // Validator should reject this combination.
-        let layout = first_party_stack_disabled_layout(None, PartitionPlan::Unified);
+        let layout = standalone_image_layout(None, PartitionPlan::Unified);
         assert!(validate_image_features(&features, &layout, None).is_err());
     }
 
     #[test]
-    fn image_features_default_seed_includes_first_party_stack() {
-        // No `image-features` at all → the default seed includes
-        // `first-party-stack` along with the historical silent defaults.
+    fn image_features_default_seed_does_not_include_standalone_image() {
+        // No `image-features` at all → the default seed does NOT include
+        // `standalone-image` (full image) and includes the historical
+        // silent defaults.
         let toml = r#"
 [package]
 name = "test-variant"
@@ -1743,22 +1749,22 @@ name = "test-variant"
         let features = info
             .image_features()
             .expect("variant has build-variant section");
-        assert!(features.contains(&ImageFeature::FirstPartyStack));
+        assert!(!features.contains(&ImageFeature::StandaloneImage));
         assert!(features.contains(&ImageFeature::InPlaceUpdates));
         assert!(features.contains(&ImageFeature::HostContainers));
         assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));
     }
 
     #[test]
-    fn image_features_explicit_first_party_stack_true_preserves_defaults() {
-        // Explicit `first-party-stack = true` is a no-op vs. the default; the
+    fn image_features_explicit_standalone_image_false_preserves_defaults() {
+        // Explicit `standalone-image = false` is a no-op vs. the default; the
         // historical silent defaults remain.
         let toml = variant_manifest_with_image_features(
-            "[package.metadata.build-variant.image-features]\nfirst-party-stack = true",
+            "[package.metadata.build-variant.image-features]\nstandalone-image = false",
         );
         let info = manifest_info_from_toml(&toml);
         let features = info.image_features().expect("variant has image-features");
-        assert!(features.contains(&ImageFeature::FirstPartyStack));
+        assert!(!features.contains(&ImageFeature::StandaloneImage));
         assert!(features.contains(&ImageFeature::InPlaceUpdates));
         assert!(features.contains(&ImageFeature::HostContainers));
         assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));
@@ -1767,9 +1773,9 @@ name = "test-variant"
     #[test]
     fn image_features_omitted_uses_default_image() {
         // A variant that omits the `[image-features]` section entirely
-        // produces the standard Bottlerocket image: `first-party-stack` is in
-        // the silent default seed, and the resolved layout uses the historical
-        // 2 GiB OS size.
+        // produces the standard Bottlerocket image: `standalone-image` is NOT
+        // in the silent default seed, and the resolved layout uses the
+        // historical 2 GiB OS size.
         let toml = r#"
 [package]
 name = "test-variant"
@@ -1816,9 +1822,9 @@ name = "test-variant"
     // ---------------------------------------------------------------------
     // `image-format = "eif"` validation and layout-resolution tests.
     //
-    // These mirror the `first_party_stack_disabled_*` tests but with the EIF
+    // These mirror the `standalone_image_enabled_*` tests but with the EIF
     // image format as the trigger instead of an explicit
-    // `first-party-stack = false`. EIF is inherently a stripped-down,
+    // `standalone-image = true`. EIF is inherently a stripped-down,
     // single-bank image; the validator must reject conflicting features so
     // that misconfiguration surfaces at build time rather than silently
     // producing a broken artifact via `rpm2eif`'s reduced pipeline.
@@ -1826,7 +1832,7 @@ name = "test-variant"
 
     #[test]
     fn eif_format_default_os_size_is_one_gib() {
-        // Same rationale as `first_party_stack_disabled_default_os_size_is_one_gib`:
+        // Same rationale as `standalone_image_enabled_default_os_size_is_one_gib`:
         // a stripped-down layout doesn't need 2 GiB of slack.
         let layout = ImageLayout::default();
         let features = HashSet::from([ImageFeature::ExternalKmodDevelopment]);
@@ -1849,14 +1855,17 @@ name = "test-variant"
 
     #[test]
     fn eif_format_alone_passes_validation() {
-        // The minimal EIF feature set (just ExternalKmodDevelopment, the
-        // only default not stripped) with `partition-plan = unified` should
+        // The minimal EIF feature set (StandaloneImage +
+        // ExternalKmodDevelopment) with `partition-plan = unified` should
         // validate successfully.
         let layout = ImageLayout {
             partition_plan: PartitionPlan::Unified,
             ..ImageLayout::default()
         };
-        let features = HashSet::from([ImageFeature::ExternalKmodDevelopment]);
+        let features = HashSet::from([
+            ImageFeature::StandaloneImage,
+            ImageFeature::ExternalKmodDevelopment,
+        ]);
         validate_image_features(&features, &layout, Some(&ImageFormat::Eif))
             .expect("EIF + minimal features + unified should validate");
     }
@@ -1914,15 +1923,16 @@ name = "test-variant"
     }
 
     #[test]
-    fn eif_format_rejects_first_party_stack_alone() {
+    fn eif_format_rejects_missing_standalone_image() {
+        // EIF requires standalone-image to be present (stripped image).
         let layout = ImageLayout {
             partition_plan: PartitionPlan::Unified,
             ..ImageLayout::default()
         };
-        let features = HashSet::from([ImageFeature::FirstPartyStack]);
+        let features: HashSet<ImageFeature> = HashSet::new();
         let err = validate_image_features(&features, &layout, Some(&ImageFormat::Eif))
-            .expect_err("EIF + first-party-stack must fail validation");
-        assert!(format!("{err}").contains("first-party-stack"));
+            .expect_err("EIF without standalone-image must fail validation");
+        assert!(format!("{err}").contains("standalone-image"));
     }
 
     #[test]
@@ -1950,8 +1960,8 @@ name = "test-variant"
     }
 
     #[test]
-    fn eif_format_rejects_first_party_stack_true() {
-        // Even if the user explicitly enables `first-party-stack = true`,
+    fn eif_format_rejects_in_place_updates_even_without_standalone_image() {
+        // Even if the user does not explicitly enable `standalone-image`,
         // `image-format = "eif"` must still reject the conflicting features.
         // Without this the EIF path could silently ignore, e.g.,
         // `in-place-updates = true` and produce an image the author did not
@@ -1960,23 +1970,22 @@ name = "test-variant"
             partition_plan: PartitionPlan::Unified,
             ..ImageLayout::default()
         };
-        let features = HashSet::from([ImageFeature::FirstPartyStack, ImageFeature::InPlaceUpdates]);
+        let features = HashSet::from([ImageFeature::InPlaceUpdates]);
         assert!(
             validate_image_features(&features, &layout, Some(&ImageFormat::Eif)).is_err(),
-            "EIF must reject conflicts even when first-party-stack is explicitly enabled"
+            "EIF must reject conflicts even when standalone-image is not explicitly set"
         );
     }
 
     #[test]
     fn eif_format_reports_all_conflicts_at_once() {
-        // Same "don't play whack-a-mole" guarantee as the first-party-stack
+        // Same "don't play whack-a-mole" guarantee as the standalone-image
         // validator: reject everything in one build cycle.
         let layout = ImageLayout {
             partition_plan: PartitionPlan::Split,
             ..ImageLayout::default()
         };
         let features = HashSet::from([
-            ImageFeature::FirstPartyStack,
             ImageFeature::XfsDataPartition,
             ImageFeature::UefiSecureBoot,
             ImageFeature::EncryptedStorage,
@@ -1987,7 +1996,7 @@ name = "test-variant"
             .expect_err("multi-conflict EIF should fail validation");
         let msg = format!("{err}");
         for keyword in [
-            "first-party-stack",
+            "standalone-image",
             "xfs-data-partition",
             "uefi-secure-boot",
             "encrypted-storage",
@@ -2002,8 +2011,8 @@ name = "test-variant"
     #[test]
     fn eif_format_seeds_stripped_defaults() {
         // A variant with `image-format = "eif"` and no `[image-features]`
-        // section must NOT get the silent first-party-stack / IPU /
-        // host-containers defaults. Otherwise the EIF validator would
+        // section must get `standalone-image` seeded and NOT get the silent
+        // IPU / host-containers defaults. Otherwise the EIF validator would
         // immediately reject an otherwise-valid manifest.
         let toml = r#"
 [package]
@@ -2016,7 +2025,7 @@ image-format = "eif"
         let features = info
             .image_features()
             .expect("variant has build-variant section");
-        assert!(!features.contains(&ImageFeature::FirstPartyStack));
+        assert!(features.contains(&ImageFeature::StandaloneImage));
         assert!(!features.contains(&ImageFeature::InPlaceUpdates));
         assert!(!features.contains(&ImageFeature::HostContainers));
         assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -229,7 +229,7 @@ ARG HOST_CONTAINERS
 ARG FIPS
 ARG EXTERNAL_KMOD_DEVELOPMENT
 ARG ENCRYPTED_STORAGE
-ARG FIRST_PARTY_STACK
+ARG STANDALONE_IMAGE
 
 USER builder
 WORKDIR /home/builder
@@ -254,7 +254,7 @@ RUN \
    && echo -e -n "${HOST_CONTAINERS:+%bcond_without host_containers\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${EXTERNAL_KMOD_DEVELOPMENT:+%bcond_without external_kmod_development\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${ENCRYPTED_STORAGE:+%bcond_without encrypted_storage\n}" >> "${RPM_BCONDS}" \
-   && echo -e -n "${FIRST_PARTY_STACK:+%bcond_without first_party_stack\n}" >> "${RPM_BCONDS}"
+   && echo -e -n "${STANDALONE_IMAGE:+%bcond_without standalone_image\n}" >> "${RPM_BCONDS}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Creates an RPM repository from packages created in Section 1 and kits from Section 2.
@@ -366,7 +366,7 @@ ARG EROFS_ROOT_PARTITION
 ARG UEFI_SECURE_BOOT
 ARG IN_PLACE_UPDATES
 ARG ENCRYPTED_STORAGE
-ARG FIRST_PARTY_STACK
+ARG STANDALONE_IMAGE
 ARG PROJECT_VENDOR
 ARG TWOLITER_VERSION
 ARG GUEST_IMAGES
@@ -417,7 +417,7 @@ RUN --mount=target=/host \
         ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
         ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
         ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} \
-        --with-first-party-stack="${FIRST_PARTY_STACK:-no}" ; \
+        --with-standalone-image="${STANDALONE_IMAGE:-no}" ; \
     else \
       /host/build/tools/rpm2img \
         --package-dir=/local/rpms \
@@ -437,7 +437,7 @@ RUN --mount=target=/host \
         ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
         ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
         ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} \
-        --with-first-party-stack="${FIRST_PARTY_STACK:-no}" ; \
+        --with-standalone-image="${STANDALONE_IMAGE:-no}" ; \
     fi && \
     rm -rf /local/rpms && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
@@ -558,7 +558,7 @@ ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG UEFI_SECURE_BOOT
 ARG EROFS_ROOT_PARTITION
 ARG IN_PLACE_UPDATES
-ARG FIRST_PARTY_STACK
+ARG STANDALONE_IMAGE
 ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
 WORKDIR /root
@@ -597,7 +597,7 @@ RUN --mount=target=/host \
       ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
       ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
-      --with-first-party-stack="${FIRST_PARTY_STACK:-no}" && \
+      --with-standalone-image="${STANDALONE_IMAGE:-no}" && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
     rm /bypass && \

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -10,11 +10,11 @@ EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
 # img2img does not currently parse `--with-encrypted-storage`, but we initialize
-# the variable so the first-party-stack validation below treats it consistently
+# the variable so the standalone-image validation below treats it consistently
 # with rpm2img. If a future change adds a flag for it, the validation below will
-# already enforce mutual exclusion when `first-party-stack = false`.
+# already enforce mutual exclusion when `standalone-image = true`.
 ENCRYPTED_STORAGE="no"
-FIRST_PARTY_STACK="yes"
+STANDALONE_IMAGE="no"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -31,7 +31,7 @@ for opt in "$@"; do
   --with-erofs-root-partition=*) EROFS_ROOT_PARTITION="${optarg}" ;;
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
-  --with-first-party-stack=*) FIRST_PARTY_STACK="${optarg}" ;;
+  --with-standalone-image=*) STANDALONE_IMAGE="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -123,20 +123,20 @@ sanity_checks \
 # repack-variant, so we cannot rely on buildsys to have already enforced these.
 # Keep this list in sync with `rpm2img` and with `validate_image_features` in
 # `tools/buildsys/src/manifest.rs`.
-if [[ "${FIRST_PARTY_STACK}" == "no" ]]; then
-  declare -A first_party_stack_conflicts=(
+if [[ "${STANDALONE_IMAGE}" == "yes" ]]; then
+  declare -A standalone_image_conflicts=(
     [UEFI_SECURE_BOOT]="uefi-secure-boot"
     [IN_PLACE_UPDATES]="in-place-updates"
     [ENCRYPTED_STORAGE]="encrypted-storage"
   )
-  for f in "${!first_party_stack_conflicts[@]}"; do
+  for f in "${!standalone_image_conflicts[@]}"; do
     if [[ "${!f}" == "yes" ]]; then
-      echo "\`first-party-stack = false\` is incompatible with '${first_party_stack_conflicts[${f}]}'" >&2
+      echo "\`standalone-image = true\` is incompatible with '${standalone_image_conflicts[${f}]}'" >&2
       exit 1
     fi
   done
   if [[ "${PARTITION_PLAN}" == "split" ]]; then
-    echo "\`first-party-stack = false\` is incompatible with 'partition-plan=split'" >&2
+    echo "\`standalone-image = true\` is incompatible with 'partition-plan=split'" >&2
     exit 1
   fi
 fi
@@ -163,14 +163,14 @@ SELINUX_FILE_CONTEXTS="${ROOT_MOUNT}/${SELINUX_ROOT}/${SELINUX_POLICY}/contexts/
 
 # Collect partition sizes and offsets from the partition plan.
 # The caller is responsible for resolving any feature-dependent default
-# for OS_IMAGE_SIZE_GIB (e.g., 1 GiB when `first-party-stack = false`) before invoking
+# for OS_IMAGE_SIZE_GIB (e.g., 1 GiB when `standalone-image = true`) before invoking
 # this script; we use the value as-is. See `resolved_image_layout` in
 # `tools/buildsys/src/manifest.rs` for the canonical resolver.
 declare -A partsize partoff
 set_partition_sizes \
   "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
   "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
-  partsize partoff "${FIRST_PARTY_STACK}"
+  partsize partoff "${STANDALONE_IMAGE}"
 
 # Process and stage the input images to the working directory.
 declare OS_IMAGE DATA_IMAGE

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -66,10 +66,10 @@ Provides: %{_cross_os}image-feature(encrypted-storage)
 Provides: %{_cross_os}image-feature(no-encrypted-storage)
 %endif
 
-%if %{with first_party_stack}
-Provides: %{_cross_os}image-feature(first-party-stack)
+%if %{with standalone_image}
+Provides: %{_cross_os}image-feature(standalone-image)
 %else
-Provides: %{_cross_os}image-feature(no-first-party-stack)
+Provides: %{_cross_os}image-feature(no-standalone-image)
 %endif
 
 %description

--- a/twoliter/embedded/partyplanner
+++ b/twoliter/embedded/partyplanner
@@ -135,7 +135,7 @@ PRIVATE_SCALE_FACTOR="24"
 # Postlude | GPT footer               1 MiB  | GPT is fixed, private partition grows.
 #          +---------------------------------+
 
-# Layout for an OS image with `first-party-stack = false` (default 1 GiB):
+# Layout for an OS image with `standalone-image = true` (default 1 GiB):
 # single bank, no RESERVED, no PRIVATE, no DATA. ROOT-A absorbs all the slack
 # that would otherwise go to those partitions. The variant has no
 # Bottlerocket-managed datastore or settings subsystem, so there is nothing
@@ -215,22 +215,22 @@ get_partition_sizes() {
 #   $1  os_image_gib       OS image size in GiB. Required, must be a positive
 #                          integer. The caller is responsible for resolving
 #                          any feature-dependent default (e.g. 1 GiB when
-#                          `first-party-stack = false`) before invoking this
+#                          `standalone-image = true`) before invoking this
 #                          function; we use the value as-is.
 #   $2  data_image_gib     Data image size in GiB. Required even when
-#                          `first_party_stack=no` (where it is unused) so
+#                          `standalone_image=yes` (where it is unused) so
 #                          that the parameter list remains stable.
 #   $3  partition_plan     "split" or "unified".
-#   $4  in_place_updates   "yes" or "no". Ignored when `first_party_stack=no`;
+#   $4  in_place_updates   "yes" or "no". Ignored when `standalone_image=yes`;
 #                          the two are validated as mutually exclusive below.
 #   $5  pp_size            (nameref) bash assoc-array to populate with sizes.
 #   $6  pp_offset          (nameref) bash assoc-array to populate with offsets.
-#   $7  first_party_stack  (optional, default "yes") "yes" or "no". When
-#                          "no", a single-bank stripped-down layout is
+#   $7  standalone_image  (optional, default "no") "yes" or "no". When
+#                          "yes", a single-bank stripped-down layout is
 #                          produced with no RESERVED, PRIVATE, or DATA
 #                          partitions.
 set_partition_sizes() {
-  local os_image_gib data_image_gib partition_plan in_place_updates first_party_stack
+  local os_image_gib data_image_gib partition_plan in_place_updates standalone_image
   local -n pp_size pp_offset
   os_image_gib="${1:?}"
   data_image_gib="${2:?}"
@@ -250,11 +250,11 @@ set_partition_sizes() {
   # Table for partition offsets from start of disk, in MiB.
   pp_offset="${6:?}"
 
-  # Whether we're building the standard Bottlerocket image (the first-party
-  # software stack and its supporting partitions) or the stripped-down image
-  # without those. Defaults to "yes" if not provided so existing direct
+  # Whether we're building the stripped-down image (standalone configuration
+  # without the first-party Bottlerocket software stack) or the standard
+  # Bottlerocket image. Defaults to "no" if not provided so existing direct
   # callers continue to get the standard layout unchanged.
-  first_party_stack="${7:-yes}"
+  standalone_image="${7:-no}"
 
   # Most of the partitions on the main image scale with the overall size.
   local boot_mib root_mib hash_mib reserved_mib private_mib
@@ -262,21 +262,21 @@ set_partition_sizes() {
   root_mib="$((os_image_gib * ROOT_SCALE_FACTOR))"
   hash_mib="$((os_image_gib * HASH_SCALE_FACTOR))"
 
-  # Fast-path the stripped-down layout (`first-party-stack = false`). Single
+  # Fast-path the stripped-down layout (`standalone-image = true`). Single
   # bank, no RESERVED-A, no PRIVATE, no DATA-A/B; ROOT-A is sized so that
   # the partitions exactly fill the nominal image size and the GPT footer
   # is preserved.
-  if [[ "${first_party_stack}" == "no" ]]; then
+  if [[ "${standalone_image}" == "yes" ]]; then
     # Defense-in-depth: the buildsys validator and the rpm2img/img2img
     # entry-point checks already reject these combinations, but a stale or
     # buggy direct caller of this function should also fail loudly rather
     # than silently producing an unexpected layout.
     if [[ "${in_place_updates}" == "yes" ]]; then
-      echo "set_partition_sizes: first_party_stack=no is incompatible with in_place_updates=yes" >&2
+      echo "set_partition_sizes: standalone_image=yes is incompatible with in_place_updates=yes" >&2
       exit 1
     fi
     if [[ "${partition_plan}" == "split" ]]; then
-      echo "set_partition_sizes: first_party_stack=no is incompatible with partition_plan=split" >&2
+      echo "set_partition_sizes: standalone_image=yes is incompatible with partition_plan=split" >&2
       exit 1
     fi
 
@@ -301,7 +301,7 @@ set_partition_sizes() {
     local root_a_mib
     root_a_mib="$(( total_mib - 1 - BIOS_MIB - (EFI_MIB * 2) - (boot_mib * 2) - (hash_mib * 2) - 1 ))"
     if (( root_a_mib <= 0 )); then
-      echo "image size ${os_image_gib} GiB is too small for first_party_stack=no partition layout" >&2
+      echo "image size ${os_image_gib} GiB is too small for standalone_image=yes partition layout" >&2
       exit 1
     fi
     pp_offset["ROOT-A"]="${offset}"
@@ -314,7 +314,7 @@ set_partition_sizes() {
 
     # Sanity check: offsets + GPT footer must equal total_mib.
     if (( offset + 1 != total_mib )); then
-      echo "first_party_stack=no partition layout offset mismatch: offset=${offset}, total=${total_mib}" >&2
+      echo "standalone_image=yes partition layout offset mismatch: offset=${offset}, total=${total_mib}" >&2
       exit 1
     fi
     return 0
@@ -424,7 +424,7 @@ set_partition_sizes() {
 # separate entry point (rather than a mode of `set_partition_sizes`) so
 # that:
 #   - The math stays simple to read and easy to test in isolation.
-#   - The existing `first_party_stack=no` path continues to size ROOT-A
+#   - The existing `standalone_image=yes` path continues to size ROOT-A
 #     against the nominal image size (residual), while EIF sizes the disk
 #     image against the *actual* content plus optional padding.
 #   - Direct callers of `set_partition_sizes` cannot accidentally invoke

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -42,8 +42,8 @@ Optional:
     --with-uefi-secure-boot=yes      Rejected: EIF does not sign shim/grub.
     --with-in-place-updates=yes      Rejected: EIF is single-bank.
     --with-encrypted-storage=yes     Rejected: EIF has no PRIVATE/DATA.
-    --with-first-party-stack=no      Required (default). Any value other than
-                                     'no' is rejected.
+    --with-standalone-image=yes      Required (default). Any value other than
+                                     'yes' is rejected.
 
 The rejected flags are accepted by the argument parser (so the Dockerfile can
 pass the same flag set to rpm2eif and rpm2img) and then validated against a
@@ -68,7 +68,7 @@ EROFS_ROOT_PARTITION="yes"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
 ENCRYPTED_STORAGE="no"
-FIRST_PARTY_STACK="no"
+STANDALONE_IMAGE="yes"
 
 for arg in "$@"; do
     case "${arg}" in
@@ -82,7 +82,7 @@ for arg in "$@"; do
         --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${arg#*=}" ;;
         --with-in-place-updates=*) IN_PLACE_UPDATES="${arg#*=}" ;;
         --with-encrypted-storage=*) ENCRYPTED_STORAGE="${arg#*=}" ;;
-        --with-first-party-stack=*) FIRST_PARTY_STACK="${arg#*=}" ;;
+        --with-standalone-image=*) STANDALONE_IMAGE="${arg#*=}" ;;
         *) echo "Unknown argument: ${arg}"; usage ;;
     esac
 done
@@ -103,7 +103,7 @@ declare -A eif_flag_allowlist=(
     [UEFI_SECURE_BOOT]="no"
     [IN_PLACE_UPDATES]="no"
     [ENCRYPTED_STORAGE]="no"
-    [FIRST_PARTY_STACK]="no"
+    [STANDALONE_IMAGE]="yes"
 )
 declare -A eif_flag_names=(
     [XFS_DATA_PARTITION]="xfs-data-partition"
@@ -111,7 +111,7 @@ declare -A eif_flag_names=(
     [UEFI_SECURE_BOOT]="uefi-secure-boot"
     [IN_PLACE_UPDATES]="in-place-updates"
     [ENCRYPTED_STORAGE]="encrypted-storage"
-    [FIRST_PARTY_STACK]="first-party-stack"
+    [STANDALONE_IMAGE]="standalone-image"
 )
 eif_flag_errors=0
 for flag in "${!eif_flag_allowlist[@]}"; do
@@ -119,8 +119,8 @@ for flag in "${!eif_flag_allowlist[@]}"; do
     have="${!flag}"
     if [[ "${have}" != "${want}" ]]; then
         name="${eif_flag_names[${flag}]}"
-        if [[ "${flag}" == "FIRST_PARTY_STACK" ]]; then
-            echo "ERROR: \`image-format = \"eif\"\` requires \`--with-${name}=no\` (got '${have}'); EIF is inherently a stripped-down image." >&2
+        if [[ "${flag}" == "STANDALONE_IMAGE" ]]; then
+            echo "ERROR: \`image-format = \"eif\"\` requires \`--with-${name}=yes\` (got '${have}'); EIF is inherently a stripped-down image." >&2
         elif [[ "${flag}" == "EROFS_ROOT_PARTITION" ]]; then
             echo "ERROR: \`image-format = \"eif\"\` requires \`--with-${name}=yes\` (got '${have}'); EIF pipeline always builds an erofs root." >&2
         else
@@ -338,12 +338,12 @@ generate_application_inventory \
 echo "=== Writing image-features.env ==="
 # Mirror rpm2img: write /usr/share/bottlerocket/image-features.env with the
 # canonical boolean values for the features an EIF image ships with. This
-# is a fixed profile -- EIF is inherently first-party-stack=false with an
+# is a fixed profile -- EIF is inherently standalone-image=true with an
 # ext4 (would-be) data partition filesystem, no IPU, no encrypted storage
 # -- but writing the file makes downstream userspace consumers (e.g.,
-# `prepare-local-fs.service`) see a "set to false" value rather than an
+# `prepare-local-fs.service`) see a consistent value rather than an
 # unset variable, matching the behavior of a non-EIF stripped-down image
-# built with `first-party-stack = false`.
+# built with `standalone-image = true`.
 #
 # The file lives in `/${SYS_ROOT}/usr/share/bottlerocket/...` on non-EIF
 # variants because of the cross-compile SDK layout; on EIF variants,
@@ -355,7 +355,7 @@ cat >"${IMAGE_FEATURES_ENV_DIR}/image-features.env" <<'EOF'
 DATA_PARTITION_FILESYSTEM=ext4
 IN_PLACE_UPDATES=false
 ENCRYPTED_STORAGE=false
-FIRST_PARTY_STACK=false
+STANDALONE_IMAGE=true
 EOF
 
 echo "=== Creating rootfs.erofs ==="

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -11,7 +11,7 @@ EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
 ENCRYPTED_STORAGE="no"
-FIRST_PARTY_STACK="yes"
+STANDALONE_IMAGE="no"
 GUEST_IMAGES=""
 
 for opt in "$@"; do
@@ -32,7 +32,7 @@ for opt in "$@"; do
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   --with-encrypted-storage=*) ENCRYPTED_STORAGE="${optarg}" ;;
-  --with-first-party-stack=*) FIRST_PARTY_STACK="${optarg}" ;;
+  --with-standalone-image=*) STANDALONE_IMAGE="${optarg}" ;;
   --guest-images=*) GUEST_IMAGES="${optarg}" ;;
   --sbom-package-dir=*) SBOM_PACKAGE_DIR="${optarg}" ;;
   *)
@@ -61,20 +61,20 @@ sanity_checks \
 # repack-variant, so we cannot rely on buildsys to have already enforced these.
 # Keep this list in sync with `img2img` and with `validate_image_features` in
 # `tools/buildsys/src/manifest.rs`.
-if [[ "${FIRST_PARTY_STACK}" == "no" ]]; then
-  declare -A first_party_stack_conflicts=(
+if [[ "${STANDALONE_IMAGE}" == "yes" ]]; then
+  declare -A standalone_image_conflicts=(
     [UEFI_SECURE_BOOT]="uefi-secure-boot"
     [IN_PLACE_UPDATES]="in-place-updates"
     [ENCRYPTED_STORAGE]="encrypted-storage"
   )
-  for f in "${!first_party_stack_conflicts[@]}"; do
+  for f in "${!standalone_image_conflicts[@]}"; do
     if [[ "${!f}" == "yes" ]]; then
-      echo "\`first-party-stack = false\` is incompatible with '${first_party_stack_conflicts[${f}]}'" >&2
+      echo "\`standalone-image = true\` is incompatible with '${standalone_image_conflicts[${f}]}'" >&2
       exit 1
     fi
   done
   if [[ "${PARTITION_PLAN}" == "split" ]]; then
-    echo "\`first-party-stack = false\` is incompatible with 'partition-plan=split'" >&2
+    echo "\`standalone-image = true\` is incompatible with 'partition-plan=split'" >&2
     exit 1
   fi
 fi
@@ -124,11 +124,11 @@ split)
   ;;
 unified)
   # The caller is responsible for resolving any feature-dependent default
-  # for OS_IMAGE_SIZE_GIB (e.g., 1 GiB when `first-party-stack = false`)
+  # for OS_IMAGE_SIZE_GIB (e.g., 1 GiB when `standalone-image = true`)
   # before invoking
   # this script; we use the value as-is. See `resolved_image_layout` in
   # `tools/buildsys/src/manifest.rs` for the canonical resolver.
-  if [[ "${FIRST_PARTY_STACK}" == "no" ]]; then
+  if [[ "${STANDALONE_IMAGE}" == "yes" ]]; then
     # Stripped-down images do not have a DATA partition, so do not pad the
     # OS image with the would-be data image space.
     truncate -s "${OS_IMAGE_SIZE_GIB}G" "${OS_IMAGE}"
@@ -146,7 +146,7 @@ declare -A partlabel parttype partguid partsize partoff
 set_partition_sizes \
   "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
   "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
-  partsize partoff "${FIRST_PARTY_STACK}"
+  partsize partoff "${STANDALONE_IMAGE}"
 set_partition_labels partlabel
 set_partition_types parttype
 set_partition_uuids partguid "${PARTITION_PLAN}"
@@ -154,7 +154,7 @@ set_partition_uuids partguid "${PARTITION_PLAN}"
 declare -a partitions
 partitions=(BIOS)
 partitions+=(EFI-A BOOT-A ROOT-A HASH-A)
-if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+if [[ "${STANDALONE_IMAGE}" == "no" ]]; then
   partitions+=(RESERVED-A)
   if [[ "${IN_PLACE_UPDATES}" == "yes" ]]; then
     partitions+=(EFI-B BOOT-B ROOT-B HASH-B RESERVED-B)
@@ -195,7 +195,7 @@ done
 sgdisk --clear "${partargs[@]}" --sort --print "${OS_IMAGE}"
 
 # Partition the separate data disk, if we're using the split layout.
-if [[ "${FIRST_PARTY_STACK}" == "yes" && "${PARTITION_PLAN}" == "split" ]]; then
+if [[ "${STANDALONE_IMAGE}" == "no" && "${PARTITION_PLAN}" == "split" ]]; then
   data_start="${partoff["DATA-B"]}"
   data_end=$((data_start + partsize["DATA-A"]))
   data_end=$((data_end * 2048 - 1))
@@ -479,7 +479,7 @@ EOF
 # Set the BOTTLEROCKET-DATA Filesystem for creating/mounting. This is
 # written unconditionally so that `prepare-local-fs.service` can format an
 # attached data volume with `systemd-makefs` even for stripped-down images
-# (`first-party-stack = false`) that don't bake in a DATA partition.
+# (`standalone-image = true`) that don't bake in a DATA partition.
 if [[ "${XFS_DATA_PARTITION}" == "yes" ]]; then
   printf "%s\n" "DATA_PARTITION_FILESYSTEM=xfs" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 else
@@ -500,11 +500,11 @@ else
   printf "%s\n" "ENCRYPTED_STORAGE=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 fi
 
-# Set first-party-stack flag
-if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
-  printf "%s\n" "FIRST_PARTY_STACK=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+# Set standalone-image flag
+if [[ "${STANDALONE_IMAGE}" == "yes" ]]; then
+  printf "%s\n" "STANDALONE_IMAGE=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 else
-  printf "%s\n" "FIRST_PARTY_STACK=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+  printf "%s\n" "STANDALONE_IMAGE=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 fi
 
 # BOTTLEROCKET-ROOT-A
@@ -538,9 +538,9 @@ dd if="${VERITY_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff["HAS
 
 # write GRUB config
 # Include the parameters that support Boot Config. Stripped-down images
-# (`first-party-stack = false`) have no PRIVATE partition to hold
+# (`standalone-image = true`) have no PRIVATE partition to hold
 # bootconfig.data, so omit these entries entirely.
-if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+if [[ "${STANDALONE_IMAGE}" == "no" ]]; then
   BOOTCONFIG='bootconfig'
   INITRD="initrd (\$private)/bootconfig.data"
 else
@@ -632,7 +632,7 @@ boot_usage=$(get_ext4_usage "${BOOT_IMAGE}" "BOOT-A")
 echo "${root_usage}" "${boot_usage}" | jq -s 'add | {disk_usage: .}' > "${OUTPUT_DIR}/artifact-metadata.json"
 
 # BOTTLEROCKET-PRIVATE
-if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+if [[ "${STANDALONE_IMAGE}" == "no" ]]; then
   # Generate bootconfig file for the image.
   touch "${PRIVATE_MOUNT}/bootconfig.data"
   bootconfig -a "${BOOTCONFIG_INPUT}" "${PRIVATE_MOUNT}/bootconfig.data"
@@ -656,7 +656,7 @@ if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
 fi
 
 # BOTTLEROCKET-DATA-A and BOTTLEROCKET-DATA-B
-if [[ "${FIRST_PARTY_STACK}" == "yes" ]]; then
+if [[ "${STANDALONE_IMAGE}" == "no" ]]; then
   # If we build on a host with SELinux enabled, we could end up with labels that
   # do not match our policy. Since we allow replacing the data volume at runtime,
   # we can't count on these labels being correct in any case, and it's better to

--- a/twoliter/embedded/tests/test_partyplanner.sh
+++ b/twoliter/embedded/tests/test_partyplanner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test the `first-party-stack` partition-layout math in `partyplanner` by
+# Test the `standalone-image` partition-layout math in `partyplanner` by
 # sourcing the script into a sub-shell and asserting on the populated
 # `pp_size`/`pp_offset` tables. This complements the Rust-side validator
 # tests in `tools/buildsys/src/manifest.rs`, which cover the high-level
@@ -75,7 +75,7 @@ assert_fails() {
 }
 
 ###############################################################################
-# Test 1: 1 GiB stripped-down image (first_party_stack=no) produces the
+# Test 1: 1 GiB stripped-down image (standalone_image=yes) produces the
 # expected partition table.
 #
 # With BIOS_MIB=4, EFI_MIB=5, BOOT_SCALE_FACTOR=20, HASH_SCALE_FACTOR=5:
@@ -88,9 +88,9 @@ assert_fails() {
 #   HASH-A     = 10  (5 * 2)
 #   GPT footer = 1
 ###############################################################################
-echo "Test 1: first_party_stack=no 1 GiB layout"
+echo "Test 1: standalone_image=yes 1 GiB layout"
 declare -A partsize partoff
-set_partition_sizes 1 1 unified no partsize partoff no
+set_partition_sizes 1 1 unified no partsize partoff yes
 
 assert_eq "${partoff[BIOS]}"   "1"   "BIOS offset"
 assert_eq "${partsize[BIOS]}"  "4"   "BIOS size"
@@ -123,9 +123,9 @@ assert_eq "${total_used}" "1023" "partitions fill image up to GPT footer"
 # HASH-A     = 20  (5 * 2 * 2 GiB)
 # ROOT-A     = 2048 - 1 - 4 - 10 - 80 - 20 - 1 = 1932
 ###############################################################################
-echo "Test 2: first_party_stack=no 2 GiB layout"
+echo "Test 2: standalone_image=yes 2 GiB layout"
 declare -A partsize2 partoff2
-set_partition_sizes 2 1 unified no partsize2 partoff2 no
+set_partition_sizes 2 1 unified no partsize2 partoff2 yes
 
 assert_eq "${partsize2[BIOS]}"   "4"    "2GiB BIOS size"
 assert_eq "${partsize2[EFI-A]}"  "10"   "2GiB EFI-A size"
@@ -134,32 +134,32 @@ assert_eq "${partsize2[HASH-A]}" "20"   "2GiB HASH-A size"
 assert_eq "${partsize2[ROOT-A]}" "1932" "2GiB ROOT-A size (residual)"
 
 ###############################################################################
-# Test 3: defense-in-depth — first_party_stack=no + in_place_updates=yes is
+# Test 3: defense-in-depth — standalone_image=yes + in_place_updates=yes is
 # rejected.
 #
 # Run in a sub-shell so the `exit 1` inside `set_partition_sizes` does not
 # kill the test runner.
 ###############################################################################
-echo "Test 3: first_party_stack=no rejects in_place_updates=yes"
-assert_fails "set_partition_sizes 1 1 unified yes <size> <off> no" \
+echo "Test 3: standalone_image=yes rejects in_place_updates=yes"
+assert_fails "set_partition_sizes 1 1 unified yes <size> <off> yes" \
   bash -c '
     set -eu -o pipefail
     . "'"${PARTYPLANNER}"'"
     declare -A s o
-    set_partition_sizes 1 1 unified yes s o no
+    set_partition_sizes 1 1 unified yes s o yes
   '
 
 ###############################################################################
-# Test 4: defense-in-depth — first_party_stack=no + partition_plan=split is
+# Test 4: defense-in-depth — standalone_image=yes + partition_plan=split is
 # rejected.
 ###############################################################################
-echo "Test 4: first_party_stack=no rejects partition_plan=split"
-assert_fails "set_partition_sizes 1 1 split no <size> <off> no" \
+echo "Test 4: standalone_image=yes rejects partition_plan=split"
+assert_fails "set_partition_sizes 1 1 split no <size> <off> yes" \
   bash -c '
     set -eu -o pipefail
     . "'"${PARTYPLANNER}"'"
     declare -A s o
-    set_partition_sizes 1 1 split no s o no
+    set_partition_sizes 1 1 split no s o yes
   '
 
 ###############################################################################
@@ -168,36 +168,36 @@ assert_fails "set_partition_sizes 1 1 split no <size> <off> no" \
 # We force a too-small image by overriding BOOT_SCALE_FACTOR so that ROOT-A
 # would be non-positive.
 ###############################################################################
-echo "Test 5: too-small first_party_stack=no image is rejected"
-assert_fails "first_party_stack=no 1 GiB with absurd boot scale factor" \
+echo "Test 5: too-small standalone_image=yes image is rejected"
+assert_fails "standalone_image=yes 1 GiB with absurd boot scale factor" \
   bash -c '
     set -eu -o pipefail
     . "'"${PARTYPLANNER}"'"
     BOOT_SCALE_FACTOR=10000
     declare -A s o
-    set_partition_sizes 1 1 unified no s o no
+    set_partition_sizes 1 1 unified no s o yes
   '
 
 ###############################################################################
 # Test 6: backward-compat / default — omitting the 7th arg defaults to
-# first_party_stack=yes and produces the standard layout (with PRIVATE/DATA
-# partitions). This is the polarity-flipped default: direct callers that do
-# not pass the flag get the full Bottlerocket layout, matching the new Rust
-# default of `first-party-stack = true`.
+# standalone_image=no and produces the standard layout (with PRIVATE/DATA
+# partitions). Direct callers that do not pass the flag get the full
+# Bottlerocket layout, matching the new Rust default of
+# `standalone-image = false`.
 ###############################################################################
-echo "Test 6: first_party_stack defaults to 'yes' for the standard layout"
+echo "Test 6: standalone_image defaults to 'no' for the standard layout"
 declare -A partsize3 partoff3
 set_partition_sizes 2 1 unified no partsize3 partoff3
 # We expect PRIVATE to exist in the standard layout.
 if [[ -v "partsize3[PRIVATE]" ]]; then
-  pass "PRIVATE partition present when first_party_stack is omitted"
+  pass "PRIVATE partition present when standalone_image is omitted"
 else
-  fail "PRIVATE partition should exist when first_party_stack is omitted"
+  fail "PRIVATE partition should exist when standalone_image is omitted"
 fi
 if [[ -v "partsize3[DATA-A]" ]]; then
-  pass "DATA-A partition present when first_party_stack is omitted"
+  pass "DATA-A partition present when standalone_image is omitted"
 else
-  fail "DATA-A partition should exist when first_party_stack is omitted"
+  fail "DATA-A partition should exist when standalone_image is omitted"
 fi
 
 ###############################################################################

--- a/twoliter/embedded/tests/test_rpm2eif_args.sh
+++ b/twoliter/embedded/tests/test_rpm2eif_args.sh
@@ -78,7 +78,7 @@ BASE=(
   --package-dir=/tmp/rpm2eif-test-no-such-dir
   --output-dir=/tmp/rpm2eif-test-out
   --external-kits-path=/tmp/rpm2eif-test-kits
-  --with-first-party-stack=no
+  --with-standalone-image=yes
 )
 
 echo "Test 1: legal minimal flags pass validation"
@@ -105,9 +105,9 @@ assert_rejects_with "xfs-data-partition=yes rejected" "xfs-data-partition" \
   "${BASE[@]}" --with-xfs-data-partition=yes
 
 echo
-echo "Test 6: reject first-party-stack=yes"
-assert_rejects_with "first-party-stack=yes rejected" "first-party-stack" \
-  "${BASE[@]/--with-first-party-stack=no/--with-first-party-stack=yes}"
+echo "Test 6: reject standalone-image=no"
+assert_rejects_with "standalone-image=no rejected" "standalone-image" \
+  "${BASE[@]/--with-standalone-image=yes/--with-standalone-image=no}"
 
 echo
 echo "Test 7: reject non-yes erofs-root-partition"
@@ -158,7 +158,7 @@ echo "Test 13: all conflicts reported in a single run"
 # Regression guard: rpm2eif should report every failing flag, not stop at
 # the first. The user should see the full picture in one build cycle.
 out=$(run_rpm2eif \
-  "${BASE[@]/--with-first-party-stack=no/--with-first-party-stack=yes}" \
+  "${BASE[@]/--with-standalone-image=yes/--with-standalone-image=no}" \
   --with-uefi-secure-boot=yes \
   --with-in-place-updates=yes \
   --with-encrypted-storage=yes)
@@ -167,7 +167,7 @@ for needle in \
     "uefi-secure-boot" \
     "in-place-updates" \
     "encrypted-storage" \
-    "first-party-stack"
+    "standalone-image"
 do
   if [[ "${out}" != *"${needle}"* ]]; then
     missing+=("${needle}")

--- a/twoliter/src/tool-crates/embedded-bundle/tests/partyplanner.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/tests/partyplanner.rs
@@ -2,8 +2,8 @@
 //!
 //! The actual assertions live in `embedded/tests/test_partyplanner.sh`,
 //! which sources `partyplanner` as a library and exercises the
-//! `set_partition_sizes` helper across standard and stripped-down (first-party-stack
-//! disabled) layouts. This
+//! `set_partition_sizes` helper across standard and stripped-down (standalone-image
+//! enabled) layouts. This
 //! Rust wrapper exists so the bash tests run under `cargo test` alongside
 //! the validator tests in the `buildsys` crate.
 


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Rename the image feature from `first-party-stack` to `standalone-image` with inverted polarity: standalone-imagenfig=true means the image is a standalone/unmanaged guest (stripped, no in-place updates). This aligns the feature name with its semantic meaning rather than its origin.


**Testing done:**

Built aws-dev AMI with https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/944 and 

```
[package.metadata.build-variant.image-features]
standalone-config = true
...
```

Confirmed partitions

```
sgdisk --print  build/images/x86_64-aws-dev-sandbox/1.63.0-2c1f631e/bottlerocket-aws-dev-sandbox-x86_64-1.63.0-2c1f631e.img
Disk build/images/x86_64-aws-dev-sandbox/1.63.0-2c1f631e/bottlerocket-aws-dev-sandbox-x86_64-1.63.0-2c1f631e.img: 2097152 sectors, 1024.0 MiB
Sector size (logical): 512 bytes
Disk identifier (GUID): 1928570E-6382-4188-AE87-EC3EF43E1899
Partition table holds up to 128 entries
Main partition table begins at sector 2 and ends at sector 33
First usable sector is 34, last usable sector is 2097118
Partitions will be aligned on 2048-sector boundaries
Total free space is 4029 sectors (2.0 MiB)

Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           10239   4.0 MiB     EF02  BIOS-BOOT
   2           10240           30719   10.0 MiB    EF00  EFI-SYSTEM
   3           30720          112639   40.0 MiB    FFFF  BOTTLEROCKET-BOOT-A
   4          112640         2074623   958.0 MiB   FFFF  BOTTLEROCKET-ROOT-A
   5         2074624         2095103   10.0 MiB    FFFF  BOTTLEROCKET-HASH-A
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
