### PR TITLE
fix(buildsys): include EIF artifacts in copy_guest_image_artifacts

### DIFF
--- a/tests/integration-tests/src/guest_images_helper.rs
+++ b/tests/integration-tests/src/guest_images_helper.rs
@@ -14,7 +14,7 @@ fn helper_path() -> PathBuf {
 
 /// Build a synthetic guest image directory mimicking the layout produced by a real variant
 /// build. Includes:
-///   - the bootable image artifacts that should be copied
+///   - the bootable image artifacts that should be copied (standard + EIF)
 ///   - the build-metadata files that must NOT be copied (the bug we're guarding against)
 ///   - a stable-name symlink (`os_image.img.lz4` -> `bottlerocket-…img.lz4`)
 fn populate_synthetic_guest_dir(dir: &Path) {
@@ -31,10 +31,24 @@ fn populate_synthetic_guest_dir(dir: &Path) {
         std::fs::write(dir.join(f), b"image-bytes").unwrap();
     }
 
-    // Stable-name symlink. After copy it should still point at the right target name.
+    // EIF artifacts produced by rpm2eif (hyphen-separated names).
+    for f in [
+        "bottlerocket-inner-x86_64-1.0.0-0.eif",
+        "bottlerocket-inner-x86_64-1.0.0-0-disk.img",
+        "bottlerocket-inner-x86_64-1.0.0-0-kernel",
+    ] {
+        std::fs::write(dir.join(f), b"eif-bytes").unwrap();
+    }
+
+    // Stable-name symlinks.
     std::os::unix::fs::symlink(
         "bottlerocket-inner-x86_64-1.0.0-0.img.lz4",
         dir.join("os_image.img.lz4"),
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(
+        "bottlerocket-inner-x86_64-1.0.0-0.eif",
+        dir.join("latest.eif"),
     )
     .unwrap();
 
@@ -56,13 +70,15 @@ fn populate_synthetic_guest_dir(dir: &Path) {
 /// for inspection.
 fn run_copy(src: &Path, dst: &Path) -> std::process::Output {
     let helper = helper_path();
-    // `guest-images-helper` requires `IMAGE_ARTIFACT_SUFFIXES` to be pre-set (normally by
-    // sourcing `imghelper`, which is not safe to source here because it hard-fails on
-    // missing build-env vars). Declare the array directly to exercise just the helper.
+    // `guest-images-helper` requires `IMAGE_ARTIFACT_SUFFIXES` and `IMAGE_ARTIFACT_GLOBS`
+    // to be pre-set (normally by sourcing `imghelper`, which is not safe to source here
+    // because it hard-fails on missing build-env vars). Declare both arrays directly to
+    // exercise just the helper.
     let script = format!(
         r#"
         set -euo pipefail
-        IMAGE_ARTIFACT_SUFFIXES=(img.lz4 qcow2 vmdk ova ext4.lz4 verity.lz4)
+        IMAGE_ARTIFACT_SUFFIXES=(img.lz4 qcow2 vmdk ova ext4.lz4 verity.lz4 eif)
+        IMAGE_ARTIFACT_GLOBS=("*-disk.img" "*-kernel")
         source "{helper}"
         copy_guest_image_artifacts "{src}" "{dst}"
         "#,
@@ -103,7 +119,7 @@ fn test_copy_guest_image_artifacts_filters_metadata_and_sboms() {
 
     let copied = entries_in(&dst);
 
-    // Required: every bootable artifact + the symlink. Order independent.
+    // Required: every bootable artifact + EIF artifacts + symlinks. Order independent.
     for required in [
         "bottlerocket-inner-x86_64-1.0.0-0.img.lz4",
         "bottlerocket-inner-x86_64-1.0.0-0-data.img.lz4",
@@ -112,7 +128,11 @@ fn test_copy_guest_image_artifacts_filters_metadata_and_sboms() {
         "bottlerocket-inner-x86_64-1.0.0-0-root.verity.lz4",
         "bottlerocket-inner-x86_64-1.0.0-0.qcow2",
         "bottlerocket-inner-x86_64-1.0.0-0.vmdk",
+        "bottlerocket-inner-x86_64-1.0.0-0.eif",
+        "bottlerocket-inner-x86_64-1.0.0-0-disk.img",
+        "bottlerocket-inner-x86_64-1.0.0-0-kernel",
         "os_image.img.lz4",
+        "latest.eif",
     ] {
         assert!(
             copied.iter().any(|n| n == required),

--- a/twoliter/embedded/guest-images-helper
+++ b/twoliter/embedded/guest-images-helper
@@ -30,6 +30,16 @@ copy_guest_image_artifacts() {
   for suffix in "${IMAGE_ARTIFACT_SUFFIXES[@]}"; do
     find_args+=( -o -name "*.${suffix}" )
   done
+  # EIF artifacts use hyphen-separated names (`*-disk.img`, `*-kernel`) that
+  # cannot be expressed as dot-suffix patterns. Include them via the separate
+  # globs array when it is defined (it lives in `imghelper` alongside the
+  # suffixes array).
+  local glob
+  if [[ -n "${IMAGE_ARTIFACT_GLOBS+x}" ]]; then
+    for glob in "${IMAGE_ARTIFACT_GLOBS[@]}"; do
+      find_args+=( -o -name "${glob}" )
+    done
+  fi
   find_args+=( \) -print0 )
   local copied=0 file
   while IFS= read -r -d '' file; do

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -27,6 +27,18 @@ IMAGE_ARTIFACT_SUFFIXES=(
   "ova"
   "ext4.lz4"
   "verity.lz4"
+  "eif"
+)
+
+# Additional find-name globs for artifacts that do not follow the `*.suffix`
+# dot-separated convention. `rpm2eif` produces `{prefix}-disk.img` and
+# `{prefix}-kernel` using a hyphen separator rather than a dot, so they cannot
+# be expressed as entries in IMAGE_ARTIFACT_SUFFIXES. These patterns are used
+# only by `copy_guest_image_artifacts` in `guest-images-helper`; they are NOT
+# validated by `compress_image` (which only handles dot-suffixed extensions).
+IMAGE_ARTIFACT_GLOBS=(
+  "*-disk.img"
+  "*-kernel"
 )
 
 OS_IMAGE_NAME="${FILENAME_PREFIX}"

--- a/twoliter/embedded/tests/test_guest_images_helper.sh
+++ b/twoliter/embedded/tests/test_guest_images_helper.sh
@@ -58,7 +58,7 @@ fail() { fail_count=$((fail_count + 1)); echo "  FAIL: $1" >&2; }
     echo "IMAGE_ARTIFACT_SUFFIXES not declared" >&2; exit 1;
   }
   # At minimum, the canonical set. New entries are allowed; missing entries fail.
-  required=("img.lz4" "qcow2" "vmdk" "ova" "ext4.lz4" "verity.lz4")
+  required=("img.lz4" "qcow2" "vmdk" "ova" "ext4.lz4" "verity.lz4" "eif")
   for want in "${required[@]}"; do
     found=no
     for have in "${IMAGE_ARTIFACT_SUFFIXES[@]}"; do
@@ -142,10 +142,15 @@ src="${tmp}/src"; dst="${tmp}/dst"
 mkdir -p "${src}" "${dst}"
 
 # Two bootable artifacts (one per allowlisted suffix), one stable-name symlink,
-# and three sidecar-metadata files that must be rejected.
+# EIF artifacts (eif, disk.img, kernel), and three sidecar-metadata files that
+# must be rejected.
 touch "${src}/bottlerocket-1.0.0.img.lz4"
 touch "${src}/bottlerocket-1.0.0.ext4.lz4"
 ln -s "bottlerocket-1.0.0.img.lz4" "${src}/os_image.img.lz4"
+touch "${src}/bottlerocket-1.0.0.eif"
+touch "${src}/bottlerocket-1.0.0-disk.img"
+touch "${src}/bottlerocket-1.0.0-kernel"
+ln -s "bottlerocket-1.0.0.eif" "${src}/latest.eif"
 touch "${src}/application-inventory.json"
 touch "${src}/spdx-sbom.json"
 touch "${src}/artifact-metadata.json"
@@ -163,7 +168,9 @@ if [[ "${rc}" -ne 0 ]]; then
   fail "copy_guest_image_artifacts returned ${rc} on a valid source dir"
 else
   # Verify allowlisted artifacts landed at the destination.
-  wanted=("bottlerocket-1.0.0.img.lz4" "bottlerocket-1.0.0.ext4.lz4" "os_image.img.lz4")
+  wanted=("bottlerocket-1.0.0.img.lz4" "bottlerocket-1.0.0.ext4.lz4" "os_image.img.lz4"
+          "bottlerocket-1.0.0.eif" "bottlerocket-1.0.0-disk.img" "bottlerocket-1.0.0-kernel"
+          "latest.eif")
   missing=""
   for f in "${wanted[@]}"; do
     [[ -e "${dst}/${f}" ]] || missing+=" ${f}"


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

rpm2eif produces three artifacts that use naming conventions
incompatible with the existing dot-suffix allowlist: {prefix}.eif,
{prefix}-disk.img, and {prefix}-kernel.

Without this fix, `copy_guest_image_artifacts` silently drops all
EIF outputs when embedding a guest variant into a host image, because
the find glob `*.${suffix}` never matches the hyphen-separated
names.

Add `eif` to IMAGE_ARTIFACT_SUFFIXES and introduce a new
IMAGE_ARTIFACT_GLOBS array for patterns that cannot be expressed as
dot-suffixes. Update guest-images-helper to iterate both arrays when
building the find command. Update shell and Rust integration tests to
cover the new artifact types.

**Testing done:**

Built a variant with these changes, `image-format = "eif"`, `standalone-image = true`, and https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/944

After building the host variant, extracted its EROFS root partition and checked the guest embed paths:

```
$ dump.erofs --ls --path /…/usr/share/bottlerocket/guests/enclave /tmp/host-root.img

NID TYPE  FILENAME
26123648    1  bottlerocket-aws-dev-enclave-x86_64-1.63.0-7e3a523f-disk.img
26140035    1  bottlerocket-aws-dev-enclave-x86_64-1.63.0-7e3a523f-kernel
26146876    1  bottlerocket-aws-dev-enclave-x86_64-1.63.0-7e3a523f.eif
26153717    7  latest-disk.img
26153721    7  latest-kernel
 7463527    7  latest.eif
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
