### PR TITLE
feat(eif): populate ImageVersion and BuildTime in EIF metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.22.0...HEAD
 
+### Fixed
+* Populate ImageVersion and BuildTime in EIF Metadata ([#692])
+
 ## [0.22.0] - 2026-07-29
 
 ### Added

--- a/tools/buildsys/src/args.rs
+++ b/tools/buildsys/src/args.rs
@@ -164,6 +164,15 @@ pub(crate) struct BuildVariantArgs {
     #[arg(long, env = "BUILDSYS_VERSION_BUILD")]
     pub(crate) version_build: String,
 
+    /// Timestamp of the latest project commit (Unix seconds). Consumed by
+    /// `rpm2eif` inside the buildkit sandbox to derive a reproducible RFC 3339
+    /// `BuildTime` for the EIF METADATA section, mirroring what
+    /// `BuildPackageArgs` already forwards for RPM release strings. Same
+    /// value in both places so a rebuilt EIF's `BuildTime` and the timestamp
+    /// baked into its `KernelVersion` (`.<ts>.<sha>.br1`) agree.
+    #[arg(long, env = "BUILDSYS_VERSION_BUILD_TIMESTAMP")]
+    pub(crate) version_build_timestamp: String,
+
     #[arg(long, env = "BUILDSYS_VERSION_IMAGE")]
     pub(crate) version_image: String,
 

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -236,6 +236,12 @@ struct VariantBuildArgs {
     variant_platform: String,
     variant_runtime: String,
     version_build: String,
+    /// Unix seconds of the latest project commit. Forwarded to the buildkit
+    /// sandbox as `BUILD_ID_TIMESTAMP` so `rpm2eif` can derive a reproducible
+    /// RFC 3339 `BuildTime` for the EIF METADATA section. Same source of
+    /// truth as the timestamp baked into the RPM `dist` release string (see
+    /// `PackageBuildArgs::build_args`).
+    version_build_timestamp: String,
     version_image: String,
     /// Newline-delimited list of `<guest>:<install_path>:<host_image_dir>` triples describing
     /// guest variant images that the host image build should embed into its rootfs.
@@ -250,6 +256,7 @@ impl VariantBuildArgs {
             self.data_image_publish_size_gib.to_string(),
         );
         args.build_arg("BUILD_ID", &self.version_build);
+        args.build_arg("BUILD_ID_TIMESTAMP", &self.version_build_timestamp);
         args.build_arg("DATA_IMAGE_SIZE_GIB", &self.data_image_size_gib);
         args.build_arg("IMAGE_FORMAT", &self.image_format);
         args.build_arg("IMAGE_NAME", &self.name);
@@ -569,6 +576,7 @@ impl DockerBuild {
                 variant_platform,
                 variant_runtime,
                 version_build: args.version_build,
+                version_build_timestamp: args.version_build_timestamp,
                 version_image: args.version_image,
                 guest_images: guest_images
                     .iter()

--- a/tools/eif-builder/src/lib.rs
+++ b/tools/eif-builder/src/lib.rs
@@ -114,14 +114,23 @@ pub enum EifError {
 /// still works normally: the hypervisor measures the kernel, cmdline, and
 /// (dm-verity-anchored) rootfs handoff into PCRs at launch. See
 /// `README.md` for details.
-fn build_metadata(build_tool_version: &str, kernel_version: &str) -> String {
+fn build_metadata(
+    build_tool_version: &str,
+    kernel_version: &str,
+    image_version: &str,
+    build_time: &str,
+) -> String {
     // `serde_json` handles escaping so we can safely embed values that may
     // contain characters requiring escaping (e.g. dashes, colons, quotes).
+    //
+    // Empty-string values are preserved (not omitted). The upstream
+    // `EifIdentityInfo` / `EifBuildInfo` structs use `String`, not
+    // `Option<String>`, so consumers expect the keys to always exist.
     serde_json::json!({
         "ImageName": "bottlerocket-sidecar",
-        "ImageVersion": "",
+        "ImageVersion": image_version,
         "BuildMetadata": {
-            "BuildTime": "",
+            "BuildTime": build_time,
             "BuildTool": "twoliter",
             "BuildToolVersion": build_tool_version,
             "OperatingSystem": "Linux",
@@ -131,6 +140,33 @@ fn build_metadata(build_tool_version: &str, kernel_version: &str) -> String {
         "CustomMetadata": serde_json::Value::Null,
     })
     .to_string()
+}
+
+/// Bundle of caller-supplied metadata fields for the EIF METADATA section.
+///
+/// Every field is optional (empty string = unknown); the JSON keys
+/// themselves are always emitted so the NE hypervisor's `EifIdentityInfo`
+/// / `EifBuildInfo` deserializers (which use `String`, not
+/// `Option<String>`) accept the output.
+#[derive(Debug, Default, Clone)]
+pub struct MetadataFields<'a> {
+    /// `BuildMetadata.BuildToolVersion` — semver of the tool producing the
+    /// EIF (twoliter). rpm2eif forwards `TWOLITER_VERSION` here.
+    pub build_tool_version: &'a str,
+    /// `BuildMetadata.KernelVersion` — RPM `VERSION-RELEASE` of the kernel
+    /// package that owns the vmlinuz. rpm2eif derives it from
+    /// `rpm --whatprovides`.
+    pub kernel_version: &'a str,
+    /// `ImageVersion` (top-level, not nested under BuildMetadata) — the
+    /// user-facing release version. Bottlerocket sets this to `VERSION_ID`
+    /// (`1.63.0` etc.), matching upstream nitro-cli's `--image-version` flag.
+    pub image_version: &'a str,
+    /// `BuildMetadata.BuildTime` — RFC 3339 UTC timestamp string. Upstream
+    /// nitro-cli uses `Utc::now()` here (non-reproducible). Our pipeline
+    /// prefers determinism: rpm2eif passes the git commit timestamp
+    /// (`BUILD_ID_TIMESTAMP`) formatted as RFC 3339, which is the same
+    /// timestamp already baked into `KernelVersion`. Empty = "unknown".
+    pub build_time: &'a str,
 }
 
 fn write_section(eif: &mut Vec<u8>, section_type: u16, data: &[u8]) {
@@ -146,10 +182,10 @@ fn write_section(eif: &mut Vec<u8>, section_type: u16, data: &[u8]) {
 /// it must match the kernel image at `kernel_path` (cross-arch builds are
 /// legitimate and expected in cross-compile pipelines).
 ///
-/// `build_tool_version` and `kernel_version` populate the corresponding fields
-/// in the METADATA section's `BuildMetadata` object. Pass empty strings if
-/// unknown; the keys themselves are always present in the JSON to match the
-/// NE hypervisor's expected schema.
+/// `metadata` populates the METADATA section. Every field is optional
+/// (empty string = unknown); the JSON keys themselves are always emitted so
+/// the NE hypervisor's `EifIdentityInfo` / `EifBuildInfo` deserializers
+/// (which use `String`, not `Option<String>`) accept the output.
 #[allow(clippy::too_many_arguments)]
 pub fn build_eif(
     kernel_path: &Path,
@@ -159,8 +195,7 @@ pub fn build_eif(
     default_cpus: u64,
     pcie_flags: u16,
     target_arch: TargetArch,
-    build_tool_version: &str,
-    kernel_version: &str,
+    metadata: &MetadataFields<'_>,
 ) -> Result<(), EifError> {
     let kernel_data = fs::read(kernel_path).context(ReadKernelSnafu { path: kernel_path })?;
     ensure!(!kernel_data.is_empty(), EmptyKernelSnafu);
@@ -181,8 +216,13 @@ pub fn build_eif(
     // (e.g. anything computing PCR2 over concatenated ramdisks) will see empty
     // input here. Our custom launcher handles this correctly.
     let ramdisk_data: &[u8] = &[];
-    let metadata = build_metadata(build_tool_version, kernel_version);
-    let metadata_data = metadata.as_bytes();
+    let metadata_json = build_metadata(
+        metadata.build_tool_version,
+        metadata.kernel_version,
+        metadata.image_version,
+        metadata.build_time,
+    );
+    let metadata_data = metadata_json.as_bytes();
 
     let num_sections: u16 = 4;
     debug_assert!(
@@ -287,8 +327,12 @@ mod tests {
             2,
             DEFAULT_PCIE_FLAGS,
             TargetArch::X86_64,
-            "0.20.0",
-            "6.1.152-0.br1",
+            &MetadataFields {
+                build_tool_version: "0.20.0",
+                kernel_version: "6.1.152-0.br1",
+                image_version: "",
+                build_time: "",
+            },
         )
         .unwrap();
 
@@ -324,8 +368,7 @@ mod tests {
             2,
             0,
             TargetArch::X86_64,
-            "",
-            "",
+            &MetadataFields::default(),
         );
         assert!(matches!(result, Err(EifError::EmptyKernel)));
     }
@@ -335,10 +378,10 @@ mod tests {
         // Verify the metadata JSON has all keys the NE hypervisor expects,
         // including nested BuildMetadata sub-keys, and that caller-supplied
         // values are embedded verbatim.
-        let json = build_metadata("0.20.0", "6.1.152-0.br1");
+        let json = build_metadata("0.20.0", "6.1.152-0.br1", "1.63.0", "2026-07-28T22:20:54Z");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(v.get("ImageName").is_some());
-        assert!(v.get("ImageVersion").is_some());
+        assert_eq!(v.get("ImageVersion").unwrap(), "1.63.0");
         assert!(v.get("DockerInfo").is_some());
         assert!(v.get("CustomMetadata").is_some());
         let bm = v.get("BuildMetadata").unwrap();
@@ -346,18 +389,20 @@ mod tests {
         assert_eq!(bm.get("BuildToolVersion").unwrap(), "0.20.0");
         assert_eq!(bm.get("KernelVersion").unwrap(), "6.1.152-0.br1");
         assert_eq!(bm.get("OperatingSystem").unwrap(), "Linux");
-        assert!(bm.get("BuildTime").is_some());
+        assert_eq!(bm.get("BuildTime").unwrap(), "2026-07-28T22:20:54Z");
     }
 
     #[test]
     fn test_metadata_empty_values() {
         // Empty strings must still round-trip through the schema (keys present,
         // values empty) rather than being omitted.
-        let json = build_metadata("", "");
+        let json = build_metadata("", "", "", "");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v.get("ImageVersion").unwrap(), "");
         let bm = v.get("BuildMetadata").unwrap();
         assert_eq!(bm.get("BuildToolVersion").unwrap(), "");
         assert_eq!(bm.get("KernelVersion").unwrap(), "");
+        assert_eq!(bm.get("BuildTime").unwrap(), "");
     }
 
     #[test]
@@ -407,7 +452,17 @@ mod tests {
             (TargetArch::X86_64, EIF_ARCH_X86_64, &x86_kernel),
             (TargetArch::Aarch64, EIF_ARCH_AARCH64, &arm_kernel),
         ] {
-            build_eif(kernel_path, "", &output, 512 << 20, 2, 0, arch, "", "").unwrap();
+            build_eif(
+                kernel_path,
+                "",
+                &output,
+                512 << 20,
+                2,
+                0,
+                arch,
+                &MetadataFields::default(),
+            )
+            .unwrap();
             let eif = fs::read(&output).unwrap();
             // flags is u16 at offset 6; PCIE bits are 0 here so the full value
             // equals just the arch bits.
@@ -437,8 +492,7 @@ mod tests {
             2,
             0,
             TargetArch::Aarch64,
-            "",
-            "",
+            &MetadataFields::default(),
         )
         .unwrap_err();
         assert!(matches!(err, EifError::PrepareKernel { .. }), "err={err:?}");

--- a/tools/eif-builder/src/main.rs
+++ b/tools/eif-builder/src/main.rs
@@ -3,8 +3,8 @@
 use clap::Parser;
 use eif_builder::kernel::prepare_kernel;
 use eif_builder::{
-    build_eif, EifError, PrepareKernelSnafu, ReadKernelSnafu, TargetArch, WritePreparedKernelSnafu,
-    DEFAULT_CMDLINE, DEFAULT_PCIE_FLAGS,
+    build_eif, EifError, MetadataFields, PrepareKernelSnafu, ReadKernelSnafu, TargetArch,
+    WritePreparedKernelSnafu, DEFAULT_CMDLINE, DEFAULT_PCIE_FLAGS,
 };
 use snafu::{report, ResultExt};
 use std::path::{Path, PathBuf};
@@ -53,6 +53,24 @@ struct Args {
     #[arg(long, default_value = "")]
     kernel_version: String,
 
+    /// User-facing image version to embed in EIF metadata (populates the
+    /// top-level `ImageVersion` field). rpm2eif passes `VERSION_ID`
+    /// (Bottlerocket release, e.g. `1.63.0`); eif2eif carries forward the
+    /// value from the input EIF. Optional; empty by default.
+    #[arg(long, default_value = "")]
+    image_version: String,
+
+    /// Build time to embed in EIF metadata as RFC 3339 UTC
+    /// (populates `BuildMetadata.BuildTime`). Optional; empty by default.
+    /// Callers that want reproducible EIFs should pass a fixed timestamp
+    /// derived from a stable input (rpm2eif uses `BUILD_ID_TIMESTAMP`, the
+    /// git commit Unix seconds, which is the same timestamp already baked
+    /// into `KernelVersion`). Upstream nitro-cli uses `Utc::now()` here,
+    /// but we do not default to that on purpose — determinism is a
+    /// buildsys-wide convention.
+    #[arg(long, default_value = "")]
+    build_time: String,
+
     /// Optional: also write the *prepared* kernel bytes (the exact byte
     /// stream embedded in the EIF's kernel section) to this path. Intended
     /// for local dev smoke-tests; the EIF itself is written unchanged. See
@@ -86,6 +104,12 @@ fn write_prepared_kernel(
 #[report]
 fn main() -> Result<(), EifError> {
     let args = Args::parse();
+    let metadata = MetadataFields {
+        build_tool_version: &args.build_tool_version,
+        kernel_version: &args.kernel_version,
+        image_version: &args.image_version,
+        build_time: &args.build_time,
+    };
     build_eif(
         &args.kernel,
         &args.cmdline,
@@ -94,8 +118,7 @@ fn main() -> Result<(), EifError> {
         args.cpus,
         args.pcie_flags,
         args.arch,
-        &args.build_tool_version,
-        &args.kernel_version,
+        &metadata,
     )?;
     println!("Created {}", args.output.display());
 

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -370,8 +370,17 @@ ARG STANDALONE_IMAGE
 ARG PROJECT_VENDOR
 ARG TWOLITER_VERSION
 ARG GUEST_IMAGES
+# BUILD_ID_TIMESTAMP: git commit Unix seconds. Set by buildsys (see
+# `Builder::build_arg` in tools/buildsys/src/builder.rs). Consumed by
+# `rpm2eif` to derive the reproducible RFC 3339 `BuildTime` written into
+# the EIF METADATA section. Also baked into the RPM `dist` release string
+# in the earlier `rpmbuild` stage — we forward it here separately because
+# `imgbuild` inherits from `repobuild`, not from `rpmbuild`, so the
+# rpmbuild ENV does not reach this stage.
+ARG BUILD_ID_TIMESTAMP
 ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
+    BUILD_ID_TIMESTAMP=${BUILD_ID_TIMESTAMP} \
     PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
     KERNEL_PARAMETERS=${KERNEL_PARAMETERS} \
     TWOLITER_VERSION=${TWOLITER_VERSION}

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -481,6 +481,25 @@ EIF_TMP="$(mktemp)"
 # still embeds the same prepared kernel, so this file is byte-identical to
 # what the enclave would load.
 PREPARED_KERNEL_TMP="$(mktemp)"
+
+# BuildTime: format the git-commit Unix timestamp (BUILD_ID_TIMESTAMP, set
+# by buildsys via build.Dockerfile ARG) as RFC 3339 UTC. This is the same
+# timestamp baked into the RPM `dist` release string that ends up inside
+# `KernelVersion`, so BuildTime and KernelVersion agree on when this EIF's
+# inputs were built. Using the commit time (rather than `date +%s` at
+# build time) keeps EIFs reproducible: same commit -> same BuildTime ->
+# byte-identical METADATA section. See utils/identity.rs in the upstream
+# `aws-nitro-enclaves-image-format` crate for the reference format
+# (`DateTime::to_rfc3339()`); `date -u -d @N` produces the same shape.
+#
+# Fallback to empty string if BUILD_ID_TIMESTAMP is unset or non-numeric;
+# an empty BuildTime is still schema-valid (see `build_metadata` in
+# tools/eif-builder/src/lib.rs).
+BUILD_TIME_RFC3339=""
+if [[ "${BUILD_ID_TIMESTAMP:-}" =~ ^[0-9]+$ ]]; then
+    BUILD_TIME_RFC3339="$(date -u -d "@${BUILD_ID_TIMESTAMP}" +%Y-%m-%dT%H:%M:%SZ)"
+fi
+
 /host/build/tools/eif-builder \
     --kernel "${KERNEL_LOCAL}" \
     --cmdline "${KERNEL_CMDLINE}" \
@@ -488,6 +507,8 @@ PREPARED_KERNEL_TMP="$(mktemp)"
     --arch "${ARCH}" \
     --build-tool-version "${TWOLITER_VERSION:-}" \
     --kernel-version "${KERNEL_VERSION}" \
+    --image-version "${VERSION_ID}" \
+    --build-time "${BUILD_TIME_RFC3339}" \
     --out-prepared-kernel "${PREPARED_KERNEL_TMP}"
 
 echo "=== Generating SBOMs ==="


### PR DESCRIPTION
The METADATA section's top-level `ImageVersion` and nested `BuildMetadata.BuildTime` were previously written as empty strings. Populate them so a consumer inspecting a built EIF (or `nitro-cli describe-eif` output) can identify the Bottlerocket release and the build's commit timestamp.

* `eif-builder` (lib + CLI): widen the metadata surface via a new `MetadataFields` struct passed to `build_eif` / `build_signed_eif` / `prepare_payload`, and expose `--image-version` and `--build-time` flags on the CLI. Empty strings preserve the schema-keys-always-present invariant the NE hypervisor's `EifIdentityInfo` / `EifBuildInfo` deserializers rely on.
* `buildsys`: forward the git commit timestamp (`BUILDSYS_VERSION_BUILD_TIMESTAMP`) into the buildkit sandbox as a `BUILD_ID_TIMESTAMP` build-arg — same source of truth as the timestamp baked into the RPM `dist` release string that ends up inside `KernelVersion`, so `BuildTime` and `KernelVersion` agree on when the EIF's inputs were built.
* `rpm2eif`: format `BUILD_ID_TIMESTAMP` as RFC 3339 UTC and pass it along with `VERSION_ID` on the `eif-builder` invocation. Using the commit time (not `date +%s` at build time) keeps EIFs reproducible: same commit -> byte-identical METADATA section.
