### PR TITLE
twoliter: add ephemeral-encryption-keys image feature

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -1126,10 +1126,14 @@ pub enum ImageFeature {
     HostContainers,
     ExternalKmodDevelopment,
     EncryptedStorage,
+    EphemeralEncryptionKeys,
     StandaloneImage,
 }
 
-const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[&ImageFeature::EncryptedStorage];
+const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[
+    &ImageFeature::EncryptedStorage,
+    &ImageFeature::EphemeralEncryptionKeys,
+];
 
 const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
     &ImageFeature::GrubSetPrivateVar,
@@ -1201,6 +1205,17 @@ pub fn validate_image_features(
     layout: &ImageLayout,
     image_format: Option<&ImageFormat>,
 ) -> Result<()> {
+    // `ephemeral-encryption-keys` only makes sense on top of encrypted storage.
+    if features.contains(&ImageFeature::EphemeralEncryptionKeys)
+        && !features.contains(&ImageFeature::EncryptedStorage)
+    {
+        return error::IncompatibleImageFeaturesSnafu {
+            context: "`ephemeral-encryption-keys = true`",
+            reason: "ephemeral encryption keys require `encrypted-storage = true`".to_string(),
+        }
+        .fail()?;
+    }
+
     let is_eif = matches!(image_format, Some(ImageFormat::Eif));
     // Without `standalone-image` enabled *and* a non-EIF format, every
     // combination is legal (full Bottlerocket image).
@@ -1226,6 +1241,11 @@ pub fn validate_image_features(
         "encrypted storage requires the BOTTLEROCKET-PRIVATE/DATA partitions, which an EIF image does not have".to_string()
     } else {
         "encrypted storage requires the BOTTLEROCKET-PRIVATE/DATA partitions, which are not built when `standalone-image = true`".to_string()
+    };
+    let reason_ephemeral_keys: String = if is_eif {
+        "ephemeral encryption keys require the BOTTLEROCKET-PRIVATE/DATA partitions, which an EIF image does not have".to_string()
+    } else {
+        "ephemeral encryption keys require the BOTTLEROCKET-PRIVATE/DATA partitions, which are not built when `standalone-image = true`".to_string()
     };
     let reason_ipu: String = if is_eif {
         "in-place updates require two banks of OS partitions; an EIF ships a single ROOT-A/HASH-A pair".to_string()
@@ -1261,6 +1281,11 @@ pub fn validate_image_features(
             ImageFeature::EncryptedStorage,
             "encrypted-storage",
             &reason_encrypted_storage,
+        ),
+        (
+            ImageFeature::EphemeralEncryptionKeys,
+            "ephemeral-encryption-keys",
+            &reason_ephemeral_keys,
         ),
         (
             ImageFeature::InPlaceUpdates,
@@ -1328,6 +1353,7 @@ impl TryFrom<String> for ImageFeature {
             "host-containers" => Ok(ImageFeature::HostContainers),
             "external-kmod-development" => Ok(ImageFeature::ExternalKmodDevelopment),
             "encrypted-storage" => Ok(ImageFeature::EncryptedStorage),
+            "ephemeral-encryption-keys" => Ok(ImageFeature::EphemeralEncryptionKeys),
             "standalone-image" => Ok(ImageFeature::StandaloneImage),
             _ => error::ParseImageFeatureSnafu { what: s }.fail()?,
         }
@@ -1370,6 +1396,7 @@ impl fmt::Display for ImageFeature {
             ImageFeature::HostContainers => write!(f, "HOST_CONTAINERS"),
             ImageFeature::ExternalKmodDevelopment => write!(f, "EXTERNAL_KMOD_DEVELOPMENT"),
             ImageFeature::EncryptedStorage => write!(f, "ENCRYPTED_STORAGE"),
+            ImageFeature::EphemeralEncryptionKeys => write!(f, "EPHEMERAL_ENCRYPTION_KEYS"),
             ImageFeature::StandaloneImage => write!(f, "STANDALONE_IMAGE"),
         }
     }
@@ -1768,6 +1795,24 @@ name = "test-variant"
         assert!(features.contains(&ImageFeature::InPlaceUpdates));
         assert!(features.contains(&ImageFeature::HostContainers));
         assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));
+    }
+
+    #[test]
+    fn ephemeral_encryption_keys_requires_encrypted_storage() {
+        let layout = ImageLayout::default();
+        let features = HashSet::from([ImageFeature::EphemeralEncryptionKeys]);
+        let err = validate_image_features(&features, &layout, None)
+            .expect_err("must fail without encrypted-storage");
+        let msg = format!("{err}");
+        assert!(msg.contains("ephemeral-encryption-keys"));
+        assert!(msg.contains("encrypted-storage"));
+    }
+
+    #[test]
+    fn ephemeral_encryption_keys_requires_encrypted_storage() {
+        let layout = ImageLayout::default();
+        let features = HashSet::from([ImageFeature::EphemeralEncryptionKeys, ImageFeature::EncryptedStorage]);
+        assert!(validate_image_features(&features, &layout, None).is_ok());
     }
 
     #[test]

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -229,6 +229,7 @@ ARG HOST_CONTAINERS
 ARG FIPS
 ARG EXTERNAL_KMOD_DEVELOPMENT
 ARG ENCRYPTED_STORAGE
+ARG EPHEMERAL_ENCRYPTION_KEYS
 ARG STANDALONE_IMAGE
 
 USER builder
@@ -254,6 +255,7 @@ RUN \
    && echo -e -n "${HOST_CONTAINERS:+%bcond_without host_containers\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${EXTERNAL_KMOD_DEVELOPMENT:+%bcond_without external_kmod_development\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${ENCRYPTED_STORAGE:+%bcond_without encrypted_storage\n}" >> "${RPM_BCONDS}" \
+   && echo -e -n "${EPHEMERAL_ENCRYPTION_KEYS:+%bcond_without ephemeral_encryption_keys\n}" >> "${RPM_BCONDS}" \
    && echo -e -n "${STANDALONE_IMAGE:+%bcond_without standalone_image\n}" >> "${RPM_BCONDS}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
@@ -366,6 +368,7 @@ ARG EROFS_ROOT_PARTITION
 ARG UEFI_SECURE_BOOT
 ARG IN_PLACE_UPDATES
 ARG ENCRYPTED_STORAGE
+ARG EPHEMERAL_ENCRYPTION_KEYS
 ARG STANDALONE_IMAGE
 ARG PROJECT_VENDOR
 ARG TWOLITER_VERSION
@@ -426,6 +429,7 @@ RUN --mount=target=/host \
         ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
         ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
         ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} \
+        ${EPHEMERAL_ENCRYPTION_KEYS:+--with-ephemeral-encryption-keys=yes} \
         --with-standalone-image="${STANDALONE_IMAGE:-no}" ; \
     else \
       /host/build/tools/rpm2img \
@@ -446,6 +450,7 @@ RUN --mount=target=/host \
         ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
         ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
         ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} \
+        ${EPHEMERAL_ENCRYPTION_KEYS:+--with-ephemeral-encryption-keys=yes} \
         --with-standalone-image="${STANDALONE_IMAGE:-no}" ; \
     fi && \
     rm -rf /local/rpms && \

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -9,11 +9,13 @@ OVF_TEMPLATE=""
 EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
-# img2img does not currently parse `--with-encrypted-storage`, but we initialize
-# the variable so the standalone-image validation below treats it consistently
-# with rpm2img. If a future change adds a flag for it, the validation below will
-# already enforce mutual exclusion when `standalone-image = true`.
+# img2img does not currently parse `--with-encrypted-storage`,
+# `--with-ephemeral-encryption-keys` but we initialize the variables so the
+# standalone-image validation below treats it consistently with rpm2img.
+# If a future change adds a flag for it, the validation below will already
+# enforce mutual exclusion when `standalone-image = true`.
 ENCRYPTED_STORAGE="no"
+EPHEMERAL_ENCRYPTION_KEYS="no"
 STANDALONE_IMAGE="no"
 
 for opt in "$@"; do
@@ -128,6 +130,7 @@ if [[ "${STANDALONE_IMAGE}" == "yes" ]]; then
     [UEFI_SECURE_BOOT]="uefi-secure-boot"
     [IN_PLACE_UPDATES]="in-place-updates"
     [ENCRYPTED_STORAGE]="encrypted-storage"
+    [EPHEMERAL_ENCRYPTION_KEYS]="ephemeral-encryption-keys"
   )
   for f in "${!standalone_image_conflicts[@]}"; do
     if [[ "${!f}" == "yes" ]]; then

--- a/twoliter/embedded/metadata.spec
+++ b/twoliter/embedded/metadata.spec
@@ -66,6 +66,12 @@ Provides: %{_cross_os}image-feature(encrypted-storage)
 Provides: %{_cross_os}image-feature(no-encrypted-storage)
 %endif
 
+%if %{with ephemeral_encryption_keys}
+Provides: %{_cross_os}image-feature(ephemeral-encryption-keys)
+%else
+Provides: %{_cross_os}image-feature(no-ephemeral-encryption-keys)
+%endif
+
 %if %{with standalone_image}
 Provides: %{_cross_os}image-feature(standalone-image)
 %else

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -24,26 +24,27 @@ usage() {
 Usage: $0 --package-dir=DIR --output-dir=DIR --external-kits-path=DIR [OPTIONS]
 
 Required:
-    --package-dir=DIR                Directory containing RPMs to install
-    --output-dir=DIR                 Output directory for artifacts
-    --external-kits-path=DIR         Directory containing external kit RPMs and metadata
+    --package-dir=DIR                     Directory containing RPMs to install
+    --output-dir=DIR                      Output directory for artifacts
+    --external-kits-path=DIR              Directory containing external kit RPMs and metadata
 
 Optional:
-    --sbom-package-dir=DIR           Directory containing SBOM RPMs
-    --os-image-size-gib=N            Target disk-image size in GiB. When set,
-                                     the GPT disk image is padded to exactly
-                                     this size (ROOT-A absorbs the padding).
-                                     When omitted or 0, the disk image is
-                                     tight-fitted to the rootfs+verity content.
-    --with-erofs-root-partition=yes  Accepted for parity with rpm2img (EIF
-                                     always uses erofs; any value other than
-                                     'yes' is rejected).
-    --with-xfs-data-partition=yes    Rejected: EIF has no data partition.
-    --with-uefi-secure-boot=yes      Rejected: EIF does not sign shim/grub.
-    --with-in-place-updates=yes      Rejected: EIF is single-bank.
-    --with-encrypted-storage=yes     Rejected: EIF has no PRIVATE/DATA.
-    --with-standalone-image=yes      Required (default). Any value other than
-                                     'yes' is rejected.
+    --sbom-package-dir=DIR                Directory containing SBOM RPMs
+    --os-image-size-gib=N                 Target disk-image size in GiB. When set,
+                                          the GPT disk image is padded to exactly
+                                          this size (ROOT-A absorbs the padding).
+                                          When omitted or 0, the disk image is
+                                          tight-fitted to the rootfs+verity content.
+    --with-erofs-root-partition=yes       Accepted for parity with rpm2img (EIF
+                                          always uses erofs; any value other than
+                                          'yes' is rejected).
+    --with-xfs-data-partition=yes         Rejected: EIF has no data partition.
+    --with-uefi-secure-boot=yes           Rejected: EIF does not sign shim/grub.
+    --with-in-place-updates=yes           Rejected: EIF is single-bank.
+    --with-encrypted-storage=yes          Rejected: EIF has no PRIVATE/DATA.
+    --with-ephemeral-encryption-keys=yes  Rejected: EIF has no PRIVATE/DATA.
+    --with-standalone-image=yes           Required (default). Any value other than
+                                          'yes' is rejected.
 
 The rejected flags are accepted by the argument parser (so the Dockerfile can
 pass the same flag set to rpm2eif and rpm2img) and then validated against a
@@ -68,6 +69,7 @@ EROFS_ROOT_PARTITION="yes"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
 ENCRYPTED_STORAGE="no"
+EPHEMERAL_ENCRYPTION_KEYS="no"
 STANDALONE_IMAGE="yes"
 
 for arg in "$@"; do
@@ -82,6 +84,7 @@ for arg in "$@"; do
         --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${arg#*=}" ;;
         --with-in-place-updates=*) IN_PLACE_UPDATES="${arg#*=}" ;;
         --with-encrypted-storage=*) ENCRYPTED_STORAGE="${arg#*=}" ;;
+        --with-ephemeral-encryption-keys=*) EPHEMERAL_ENCRYPTION_KEYS="${arg#*=}" ;;
         --with-standalone-image=*) STANDALONE_IMAGE="${arg#*=}" ;;
         *) echo "Unknown argument: ${arg}"; usage ;;
     esac
@@ -103,6 +106,7 @@ declare -A eif_flag_allowlist=(
     [UEFI_SECURE_BOOT]="no"
     [IN_PLACE_UPDATES]="no"
     [ENCRYPTED_STORAGE]="no"
+    [EPHEMERAL_ENCRYPTION_KEYS]="no"
     [STANDALONE_IMAGE]="yes"
 )
 declare -A eif_flag_names=(
@@ -111,6 +115,7 @@ declare -A eif_flag_names=(
     [UEFI_SECURE_BOOT]="uefi-secure-boot"
     [IN_PLACE_UPDATES]="in-place-updates"
     [ENCRYPTED_STORAGE]="encrypted-storage"
+    [EPHEMERAL_ENCRYPTION_KEYS]="ephemeral-encryption-keys"
     [STANDALONE_IMAGE]="standalone-image"
 )
 eif_flag_errors=0

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -11,6 +11,7 @@ EROFS_ROOT_PARTITION="no"
 UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
 ENCRYPTED_STORAGE="no"
+EPHEMERAL_ENCRYPTION_KEYS="no"
 STANDALONE_IMAGE="no"
 GUEST_IMAGES=""
 
@@ -32,6 +33,7 @@ for opt in "$@"; do
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   --with-encrypted-storage=*) ENCRYPTED_STORAGE="${optarg}" ;;
+  --with-ephemeral-encryption-keys=*) EPHEMERAL_ENCRYPTION_KEYS="${optarg}" ;;
   --with-standalone-image=*) STANDALONE_IMAGE="${optarg}" ;;
   --guest-images=*) GUEST_IMAGES="${optarg}" ;;
   --sbom-package-dir=*) SBOM_PACKAGE_DIR="${optarg}" ;;
@@ -66,6 +68,7 @@ if [[ "${STANDALONE_IMAGE}" == "yes" ]]; then
     [UEFI_SECURE_BOOT]="uefi-secure-boot"
     [IN_PLACE_UPDATES]="in-place-updates"
     [ENCRYPTED_STORAGE]="encrypted-storage"
+    [EPHEMERAL_ENCRYPTION_KEYS]="ephemeral-encryption-keys"
   )
   for f in "${!standalone_image_conflicts[@]}"; do
     if [[ "${!f}" == "yes" ]]; then
@@ -500,6 +503,13 @@ else
   printf "%s\n" "ENCRYPTED_STORAGE=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
 fi
 
+# Set ephemeral encryption keys flag
+if [[ "${EPHEMERAL_ENCRYPTION_KEYS}" == "yes" ]]; then
+  printf "%s\n" "EPHEMERAL_ENCRYPTION_KEYS=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+else
+  printf "%s\n" "EPHEMERAL_ENCRYPTION_KEYS=false" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
+fi
+
 # Set standalone-image flag
 if [[ "${STANDALONE_IMAGE}" == "yes" ]]; then
   printf "%s\n" "STANDALONE_IMAGE=true" >>"${ROOT_MOUNT}/${SYS_ROOT}/usr/share/bottlerocket/image-features.env"
@@ -633,9 +643,13 @@ echo "${root_usage}" "${boot_usage}" | jq -s 'add | {disk_usage: .}' > "${OUTPUT
 
 # BOTTLEROCKET-PRIVATE
 if [[ "${STANDALONE_IMAGE}" == "no" ]]; then
-  # Generate bootconfig file for the image.
-  touch "${PRIVATE_MOUNT}/bootconfig.data"
-  bootconfig -a "${BOOTCONFIG_INPUT}" "${PRIVATE_MOUNT}/bootconfig.data"
+  # Generate bootconfig file for the image. When ephemeral encryption keys are
+  # enabled, bootconfig.data was baked onto the BOOT partition above (PRIVATE is
+  # LUKS-encrypted and grub-unreadable), so skip seeding it here.
+  if [[ "${EPHEMERAL_ENCRYPTION_KEYS}" != "yes" ]]; then
+    touch "${PRIVATE_MOUNT}/bootconfig.data"
+    bootconfig -a "${BOOTCONFIG_INPUT}" "${PRIVATE_MOUNT}/bootconfig.data"
+  fi
 
   # Targeted toward the current API server implementation.
   # Relative to the ext4 defaults, we:


### PR DESCRIPTION
**Description of changes:**
- Introduces a new, experimental image feature that works on top of encrypted-storage. If enabled, the keys used to encrypt the datastore and data partition are discarded after unlock. This forces the OS to recreate them everytime at boot.


**Testing done:**
- variant builds with this feature and feature testing.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
