### PR TITLE
feat(buildsys): mark StandaloneImage as experimental

### DIFF
--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -1129,7 +1129,10 @@ pub enum ImageFeature {
     StandaloneImage,
 }
 
-const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[&ImageFeature::EncryptedStorage];
+const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[
+    &ImageFeature::EncryptedStorage,
+    &ImageFeature::StandaloneImage,
+];
 
 const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
     &ImageFeature::GrubSetPrivateVar,


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

Add `ImageFeature::StandaloneImage` to `EXPERIMENTAL_IMAGE_FEATURES` so that variants using this feature emit the appropriate experimental warning at build time.

**Testing done:**

`make build`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
