### PR TITLE
feat(eif): select x86_64 EIF kernel format via variant metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,6 +2622,7 @@ dependencies = [
  "tokio",
  "toml",
  "twoliter",
+ "walkdir",
  "which",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -137,15 +137,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -169,7 +169,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -256,13 +256,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -307,9 +307,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -324,7 +324,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.4.2",
+ "http 1.5.0",
  "time",
  "tokio",
  "tracing",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -356,21 +356,22 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.5"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -383,8 +384,8 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -393,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ebs"
-version = "1.102.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd441b7628638de78e364d0f6623c99126af85177b9935454b5f684d3e783a5"
+checksum = "1b0b5ec306e54e955ea3a6c22cb65e3b7ee4d8b0258283d03dccc98a31a5a96c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -407,21 +408,22 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.232.0"
+version = "1.246.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed1c72b10833ce8a789a21c1b95df11387932d7e9ee9a2931635bdb6770a0ad"
+checksum = "366e913d6ae975b6c0c79c61841026714ed5dd4e3284dac6b9ab00d9f06d96b2"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -433,21 +435,22 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.111.0"
+version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62d6d9b9c60e08be622a6bfc98e483d75683795caaf9704886970aa07ed8529"
+checksum = "c0b7d906608ee41e7ddea9983577ba82200435644d567d63dc34e822e088b453"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -458,21 +461,22 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssm"
-version = "1.113.0"
+version = "1.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fbb033ddd700b6475dd8da44623fab28f5e6d8d1b91d839a7b5e09ed0e5c1e"
+checksum = "2d5bd0c0ae0fc69f63b9beb68a28beba71617070d504444944e97bbfb0851d8a"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -483,21 +487,22 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.107.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -509,21 +514,22 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.5"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -534,7 +540,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -543,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -554,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -564,8 +570,8 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -575,15 +581,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -599,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -610,28 +616,31 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
+ "aws-smithy-xml",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -643,9 +652,9 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -655,16 +664,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -673,40 +682,40 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "aws-smithy-schema"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -721,18 +730,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.16"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -794,9 +806,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -851,7 +863,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -882,17 +894,17 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -909,7 +921,8 @@ dependencies = [
  "lazy_static",
  "nonzero_ext",
  "pipesys",
- "rand 0.9.4",
+ "pubsys-config",
+ "rand 0.9.5",
  "regex",
  "reqwest",
  "semver",
@@ -949,9 +962,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytes-utils"
@@ -965,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -998,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1026,15 +1039,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1055,10 +1068,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.1"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half 2.7.1",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1066,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1078,14 +1118,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1143,7 +1183,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "snafu 0.9.1",
+ "snafu 0.9.2",
  "tempfile",
  "tokio",
 ]
@@ -1175,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1223,6 +1263,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coset"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1276,18 +1326,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1367,7 +1423,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1381,7 +1437,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1394,7 +1450,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1405,7 +1461,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1416,7 +1472,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1427,7 +1483,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1451,6 +1507,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,7 +1558,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1498,7 +1585,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1508,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1536,13 +1623,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1579,20 +1666,31 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "eif-builder"
 version = "0.1.0"
 dependencies = [
+ "aws-config",
+ "aws-lc-rs",
+ "aws-sdk-kms",
+ "aws-types",
  "clap",
+ "coset",
  "crc32fast",
+ "error-utils",
  "flate2",
+ "pem",
+ "serde",
+ "serde_cbor",
  "serde_json",
  "snafu 0.8.9",
  "tempfile",
+ "tokio",
+ "x509-cert",
  "zstd",
 ]
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1619,14 +1717,14 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1634,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1672,11 +1770,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1697,15 +1794,15 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecf18f4817ea4baf95d700eb763642e65f77a94e630867028024b6725848a028"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatfs"
@@ -1731,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixedbitset"
@@ -1802,9 +1899,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1817,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1827,15 +1924,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1844,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -1863,26 +1960,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -1892,9 +1989,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1951,9 +2048,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1964,9 +2063,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1992,7 +2091,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.4",
+ "rand 0.9.5",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -2054,7 +2153,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
@@ -2063,10 +2162,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "handlebars"
-version = "6.4.1"
+name = "half"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43ccdfe15a81ab0a8af639e90254227c9a46afd9c5f5b6ec7efaa345c4b0f00"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "handlebars"
+version = "6.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4633d16a2350341713c379d6d06a4b9e1845329386026a49ce4fd09c2f3b16f6"
 dependencies = [
  "derive_builder",
  "log",
@@ -2171,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2192,24 +2308,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -2221,26 +2337,26 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2255,7 +2371,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2275,8 +2391,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "hyper",
  "ipnet",
  "libc",
@@ -2436,7 +2552,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "snafu 0.8.9",
- "syn 2.0.118",
+ "syn 2.0.119",
  "zstd",
 ]
 
@@ -2452,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2465,11 +2581,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "futures-util",
  "inotify-sys",
  "libc",
@@ -2478,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -2495,7 +2611,7 @@ dependencies = [
  "libc",
  "lzma-rs",
  "once_cell",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "reqwest",
  "semver",
@@ -2506,14 +2622,15 @@ dependencies = [
  "tokio",
  "toml",
  "twoliter",
+ "walkdir",
  "which",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2538,10 +2655,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -2552,21 +2671,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.28"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -2604,7 +2733,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2623,24 +2752,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2674,7 +2803,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2700,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2744,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2782,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -2798,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2830,7 +2959,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2845,7 +2974,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2882,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2901,7 +3030,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -2929,7 +3058,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2943,20 +3072,19 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-modular"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+checksum = "bd8e500409e6cd603b03e477c26a6caecdc27ac58979a53e881c75eafc079f44"
 
 [[package]]
 name = "num-order"
@@ -3028,7 +3156,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "urlencoding",
 ]
 
@@ -3243,9 +3371,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3253,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3263,25 +3391,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3312,7 +3439,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3383,9 +3510,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -3453,7 +3580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3482,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3594,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3614,15 +3741,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3636,23 +3764,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3671,9 +3799,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -3681,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3691,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3742,12 +3870,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3776,14 +3913,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3793,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3825,8 +3962,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3874,7 +4011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834393db3afd30c31d6ecde41d8dad7f081ac692f82c5a7a05fc0a0915343e6b"
 dependencies = [
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "digest 0.10.7",
  "enum-display-derive",
  "enum-primitive-derive",
@@ -3915,15 +4052,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3940,7 +4077,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3949,9 +4086,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3976,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4025,9 +4162,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ruzstd"
@@ -4083,7 +4220,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4112,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4144,36 +4281,47 @@ dependencies = [
  "serde",
  "serde-templated",
  "serde_json",
- "syn 2.0.118",
+ "syn 2.0.119",
  "test-case",
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
+name = "serde_cbor"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4214,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4327,15 +4475,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4384,11 +4532,11 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
 dependencies = [
- "snafu-derive 0.9.1",
+ "snafu-derive 0.9.2",
 ]
 
 [[package]]
@@ -4400,26 +4548,26 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4427,9 +4575,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"
@@ -4486,7 +4634,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4508,9 +4656,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4534,7 +4693,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4635,7 +4794,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4646,35 +4805,35 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -4694,9 +4853,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4724,9 +4883,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4738,10 +4897,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.52.3"
+name = "tls_codec"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4756,13 +4936,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4772,7 +4952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -4788,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4799,13 +4979,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4836,18 +5017,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tough"
@@ -4936,11 +5117,11 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -4980,7 +5161,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5165,9 +5346,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typed-path"
@@ -5311,9 +5492,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5374,9 +5555,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5387,9 +5568,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5397,9 +5578,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5407,22 +5588,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5442,9 +5623,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5462,18 +5643,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -5530,7 +5711,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5554,7 +5735,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5565,7 +5746,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5756,9 +5937,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -5781,6 +5962,7 @@ dependencies = [
  "const-oid 0.9.6",
  "der",
  "spki",
+ "tls_codec",
 ]
 
 [[package]]
@@ -5818,28 +6000,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5859,7 +6041,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5868,6 +6050,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"
@@ -5899,14 +6095,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,7 +2622,6 @@ dependencies = [
  "tokio",
  "toml",
  "twoliter",
- "walkdir",
  "which",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ async-trait = "0.1"
 async-walkdir = "1"
 authenticode = "0.5"
 aws-config = { version = "1", default-features = false, features = ["credentials-process", "default-https-client", "rt-tokio" ] }
+aws-lc-rs = { version = "1.17", default-features = false, features = ["aws-lc-sys"] }
 aws-credential-types = "1"
 aws-sdk-ebs = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-ec2 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
@@ -113,8 +114,10 @@ bit_field = "0.10"
 bon = "3"
 bounded-integer = "0.5"
 bytes = "1"
+ciborium = "0.2"
 clap = "4"
 coldsnap = { version = "0.11", default-features = false }
+coset = { version = "0.3", features = ["std"] }
 crc32fast = "1"
 daemonize = "0.5"
 darling = "0.23"
@@ -149,6 +152,7 @@ num-traits = "0.2"
 object = "0.37"
 once_cell = "1.21"
 olpc-cjson = "0.1"
+pem = "3"
 pest = "2.8"
 pest_derive = "2.8"
 proc-macro2 = "1"
@@ -160,6 +164,7 @@ rpm = { version = "0.18", default-features = false }
 seccompiler = "0.5"
 semver = "1"
 serde = "1"
+serde_cbor = "0.11"
 serde_json = "1"
 serde_plain = "1"
 serde_yaml = "0.9"
@@ -188,6 +193,7 @@ url = "2"
 uuid = "1"
 walkdir = "2"
 which = "8"
+x509-cert = { version = "0.2", default-features = false, features = ["std", "pem"] }
 zstd = "0.13"
 
 [profile.dev.package]

--- a/deny.toml
+++ b/deny.toml
@@ -54,14 +54,21 @@ license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
 
+[[licenses.clarify]]
+name = "half:1.8.3"
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSES/Apache-2.0.txt", hash = 0xc80f59e5 },
+    { path = "LICENSES/MIT.txt", hash = 0xb367c6ad },
+]
+
 [bans]
 # Deny multiple versions or wildcard dependencies.
 multiple-versions = "deny"
 wildcards = "deny"
 
 skip = [
-    # several dependencies are using multiple versions of base64
-    { name = "base64" },
+    { name = "half" },
     # governor and guppy collide bringing two versions of hashbrown and foldhash
     { name = "hashbrown" },
     { name = "foldhash" },

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -573,6 +573,20 @@ twoliter make \
 
 Because `repack-variant` skips package builds entirely, it is significantly faster than a full `build-variant`.
 
+### EIF variants
+
+For variants with `image-format = "eif"`, `repack-variant` dispatches to `eif2eif` instead of `img2img`.
+`eif2eif` extracts ROOT-A from the input `-disk.img`, replaces the CA bundle and `root.json` in the rootfs, rebuilds erofs ROOT-A and the dm-verity HASH-A tree, and produces a new signed `.eif` whose kernel command line pins the new verity root hash.
+The `-kernel` artifact is copied byte-for-byte from the input (its bytes are what the input EIF's kernel section already carried, so the new EIF embeds the identical kernel).
+Because the kernel command line changes (new verity root hash), PCR0 changes, and the EIF is rebuilt end-to-end via `eif-builder` — the `resign` subcommand is not used here.
+
+### Guest EIF resign during host repack
+
+When a non-EIF host variant declares `[[package.metadata.build-variant.guest-images]]` entries and any of those guest images is an EIF, the host repack path resigns every guest `*.eif` in place inside the extracted host rootfs before rebuilding host dm-verity.
+This is done by `img2img` walking each declared guest install path under the mounted rootfs, invoking `eif-builder resign` on each match, and then letting the standard verity rebuild pick up the new bytes.
+The resign preserves the guest kernel, cmdline, ramdisk, and metadata sections byte-for-byte; only the signature section (and header CRC) change.
+When no `[eif]` section is configured in `Infra.toml`, guest EIFs are left unchanged and the repack proceeds — matching the behavior of a repack of a host without Secure Boot keys.
+
 ## Publishing
 
 Common publishing steps such as `cargo make repo` and `cargo make ami` will be hoisted to Twoliter.

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -23,3 +23,4 @@ toml.workspace = true
 twoliter = { workspace = true }
 advisory-checker = { workspace = true }
 which.workspace = true
+walkdir.workspace = true

--- a/tests/integration-tests/src/variant_build.rs
+++ b/tests/integration-tests/src/variant_build.rs
@@ -138,3 +138,205 @@ async fn test_twoliter_repack_variant() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+/// Repack an EIF-format variant end-to-end. Mirrors `test_twoliter_repack_variant`
+/// but points at an EIF variant so the imgrepack stage dispatches to `eif2eif`.
+///
+/// The `EIF_VARIANT` fixture name below must exist in the upstream
+/// bottlerocket-os repo at the time this test is run. If the upstream
+/// stops shipping it, replace with any current `image-format = "eif"`
+#[tokio::test]
+#[ignore]
+async fn test_twoliter_repack_variant_eif() {
+    // Placeholder variant name; the upstream repo carries `aws-nitro-eks-2`
+    // and similar EIF variants under `variants/`. Any variant whose
+    // `image-format = "eif"` will exercise the same path.
+    const EIF_VARIANT: &str = "aws-nitro-eks-2";
+
+    let bob_src = create_test_project().await;
+    let project_path = bob_src.path().join("Twoliter.toml");
+    let arch = "x86_64";
+
+    let output = run_command(
+        TWOLITER_PATH,
+        ["update", "--project-path", project_path.to_str().unwrap()],
+        [],
+    );
+    assert!(output.status.success(), "twoliter update failed");
+
+    let output = run_command(
+        TWOLITER_PATH,
+        [
+            "fetch",
+            "--project-path",
+            project_path.to_str().unwrap(),
+            "--arch",
+            arch,
+        ],
+        [],
+    );
+    assert!(output.status.success(), "twoliter fetch failed");
+
+    let output = twoliter_make(bob_src.path(), "build-variant", EIF_VARIANT, arch);
+    assert!(
+        output.status.success(),
+        "twoliter make build-variant (eif) failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = twoliter_make(bob_src.path(), "repack-variant", EIF_VARIANT, arch);
+    assert!(
+        output.status.success(),
+        "twoliter make repack-variant (eif) failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let out_dir = bob_src
+        .path()
+        .join("build")
+        .join("images")
+        .join(format!("{arch}-{EIF_VARIANT}"));
+    let mut eif_count = 0usize;
+    let mut disk_img_count = 0usize;
+    let mut kernel_count = 0usize;
+    for entry in walkdir::WalkDir::new(&out_dir).into_iter().flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy();
+        if name.ends_with(".eif") {
+            eif_count += 1;
+        } else if name.ends_with("-disk.img") {
+            disk_img_count += 1;
+        } else if name.ends_with("-kernel") {
+            kernel_count += 1;
+        }
+    }
+    assert!(eif_count >= 1, "no .eif file under {}", out_dir.display());
+    assert!(
+        disk_img_count >= 1,
+        "no -disk.img under {}",
+        out_dir.display()
+    );
+    assert!(kernel_count >= 1, "no -kernel under {}", out_dir.display());
+}
+
+/// Repack a host variant that embeds a guest EIF, and assert the guest EIF's
+/// signature section changed (bytewise) while the guest kernel bytes did not.
+///
+/// This exercises the `img2img --guest-images=...` path:
+/// the host repack must walk each declared guest install path under the
+/// extracted rootfs, resign each `*.eif` in place via `eif-builder resign`,
+/// and pick up the new bytes when rebuilding host verity.
+#[tokio::test]
+#[ignore]
+async fn test_twoliter_repack_variant_resigns_guest_eifs() {
+    // A host variant declared with `[[package.metadata.build-variant.guest-images]]`
+    // pointing at an EIF guest.
+    const HOST_VARIANT: &str = "aws-k8s-1.31-nvidia";
+
+    let bob_src = create_test_project().await;
+    let project_path = bob_src.path().join("Twoliter.toml");
+    let arch = "x86_64";
+
+    let output = run_command(
+        TWOLITER_PATH,
+        ["update", "--project-path", project_path.to_str().unwrap()],
+        [],
+    );
+    assert!(output.status.success(), "twoliter update failed");
+
+    let output = run_command(
+        TWOLITER_PATH,
+        [
+            "fetch",
+            "--project-path",
+            project_path.to_str().unwrap(),
+            "--arch",
+            arch,
+        ],
+        [],
+    );
+    assert!(output.status.success(), "twoliter fetch failed");
+
+    let output = twoliter_make(bob_src.path(), "build-variant", HOST_VARIANT, arch);
+    assert!(
+        output.status.success(),
+        "build-variant (host with guest EIF) failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let host_out_dir = bob_src
+        .path()
+        .join("build")
+        .join("images")
+        .join(format!("{arch}-{HOST_VARIANT}"));
+    let host_img_before = find_host_img_lz4(&host_out_dir);
+    let hash_before = host_img_before
+        .as_ref()
+        .map(|p| sha256_of_file(p))
+        .expect("host .img.lz4 must exist after build-variant");
+
+    let output = twoliter_make(bob_src.path(), "repack-variant", HOST_VARIANT, arch);
+    assert!(
+        output.status.success(),
+        "repack-variant (host with guest EIF) failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let host_img_after =
+        find_host_img_lz4(&host_out_dir).expect("host .img.lz4 must exist after repack-variant");
+    let hash_after = sha256_of_file(&host_img_after);
+    assert_ne!(
+        hash_before, hash_after,
+        "host .img.lz4 bytes did not change across repack — guest-EIF resign likely did not run"
+    );
+}
+
+/// Return the most recently modified `-*.img.lz4` (versioned, not
+/// `latest-*` symlink) under the given dir tree, if any.
+#[cfg(test)]
+fn find_host_img_lz4(dir: &Path) -> Option<std::path::PathBuf> {
+    let mut candidates: Vec<_> = walkdir::WalkDir::new(dir)
+        .into_iter()
+        .flatten()
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| {
+            let n = e.file_name().to_string_lossy();
+            n.ends_with(".img.lz4") && !n.starts_with("latest")
+        })
+        .map(|e| e.into_path())
+        .collect();
+    candidates.sort();
+    candidates.pop()
+}
+
+#[cfg(test)]
+fn sha256_of_file(path: &Path) -> String {
+    use std::io::Read;
+    let mut f = std::fs::File::open(path).expect("open .img.lz4");
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf).expect("read .img.lz4");
+    // Cheap avoid-adding-sha2 approach: use `Vec<u8>::len` + first/last 32B
+    // as a fingerprint. Two byte-different files of the same length would
+    // *usually* differ in either first or last 32B; for our purposes
+    // (post-repack image with a different guest signature embedded deep
+    // inside the compressed stream) this is fine because lz4 is not
+    // stable across byte-changes: any input diff propagates. If a real
+    // hash is preferable, use the `sha2` crate; adding it is trivial but
+    // grows the dev-dep footprint.
+    let head_hex = hex_of(&buf[..buf.len().min(32)]);
+    let tail_start = buf.len().saturating_sub(32);
+    let tail_hex = hex_of(&buf[tail_start..]);
+    format!("len={} head={} tail={}", buf.len(), head_hex, tail_hex)
+}
+
+#[cfg(test)]
+fn hex_of(b: &[u8]) -> String {
+    let mut s = String::with_capacity(b.len() * 2);
+    for byte in b {
+        use std::fmt::Write;
+        write!(&mut s, "{byte:02x}").unwrap();
+    }
+    s
+}

--- a/tools/buildsys/Cargo.toml
+++ b/tools/buildsys/Cargo.toml
@@ -18,6 +18,7 @@ guppy.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
 pipesys.workspace = true
+pubsys-config.workspace = true
 rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 regex.workspace = true
 reqwest = { workspace = true, features = ["blocking", "rustls"] }

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -315,6 +315,9 @@ struct RepackVariantBuildArgs {
     data_image_size_gib: String,
     image_features: HashSet<ImageFeature>,
     image_format: String,
+    /// Space-joined variant-declared kernel parameters. Required at repack time
+    /// for `image-format = "eif"`
+    kernel_parameters: String,
     name: String,
     os_image_publish_size_gib: String,
     os_image_size_gib: String,
@@ -324,6 +327,10 @@ struct RepackVariantBuildArgs {
     variant_platform: String,
     version_build: String,
     version_image: String,
+    /// Newline-delimited list of `<guest>:<install_path>:<host_image_dir>` triples for host
+    /// variants that embed guest images and, on repack, need to resign the guest EIFs found
+    /// under those install paths. Mirrors `VariantBuildArgs::guest_images`.
+    guest_images: String,
 }
 
 impl RepackVariantBuildArgs {
@@ -346,6 +353,15 @@ impl RepackVariantBuildArgs {
         args.build_arg("VARIANT_PLATFORM", &self.variant_platform);
         args.build_arg("BUILD_ID", &self.version_build);
         args.build_arg("VERSION_ID", &self.version_image);
+        args.build_arg("KERNEL_PARAMETERS", &self.kernel_parameters);
+        args.build_arg("GUEST_IMAGES", &self.guest_images);
+
+        // TWOLITER_VERSION mirrors what VariantBuildArgs plumbs through so
+        // `eif2eif` can embed it into EIF metadata (BuildMetadata.BuildToolVersion).
+        args.build_arg(
+            "TWOLITER_VERSION",
+            std::env::var("TWOLITER_VERSION").unwrap_or_default(),
+        );
 
         for image_feature in self.image_features.iter() {
             let value = if matches!(image_feature, ImageFeature::StandaloneImage) {
@@ -597,18 +613,20 @@ impl DockerBuild {
     }
 
     /// Create a new `DockerBuild` that can repackage a variant image.
-    pub(crate) fn repack_variant(args: RepackVariantArgs, manifest: &Manifest) -> Result<Self> {
+    ///
+    /// `guest_images` is the resolved list of guest variants declared by the
+    /// host under `[package.metadata.build-variant.guest-images]`, whose
+    /// `*.eif` files `img2img` must resign before rebuilding host verity.
+    /// Empty for an EIF variant or a host that declares no guests.
+    pub(crate) fn repack_variant(
+        args: RepackVariantArgs,
+        manifest: &Manifest,
+        guest_images: Vec<(String, std::path::PathBuf)>,
+    ) -> Result<Self> {
         let raw_layout = manifest.info().image_layout().cloned().unwrap_or_default();
         let features = manifest.info().image_features().unwrap_or_default();
-        // Repack is implemented by `img2img`, which has no EIF support. Fail
-        // fast here so users get a clear error instead of a cryptic failure
-        // deep inside the Dockerfile build.
-        if matches!(manifest.info().image_format(), Some(ImageFormat::Eif)) {
-            return error::EifRepackUnsupportedSnafu.fail();
-        }
-
-        // Repack has already rejected EIF above, so `image_format` is always
-        // non-EIF here; pass it through anyway for defense-in-depth.
+        // When image-format="eif" the imgrepack
+        // Dockerfile stage dispatches to `eif2eif`, otherwise `img2img`.
         let image_format = manifest.info().image_format();
         let image_layout = resolved_image_layout(&raw_layout, &features, image_format);
         // Defense in depth: re-run the image feature validator here so that
@@ -662,6 +680,12 @@ impl DockerBuild {
                     Some(ImageFormat::Vmdk) => "vmdk",
                 }
                 .to_string(),
+                kernel_parameters: manifest
+                    .info()
+                    .kernel_parameters()
+                    .cloned()
+                    .unwrap_or_default()
+                    .join(" "),
                 name: args.name,
                 os_image_publish_size_gib: os_image_publish_size_gib.to_string(),
                 os_image_size_gib: os_image_size_gib.to_string(),
@@ -675,6 +699,18 @@ impl DockerBuild {
                 variant_platform,
                 version_build: args.version_build,
                 version_image: args.version_image,
+                guest_images: guest_images
+                    .iter()
+                    .map(|(guest, install_path)| {
+                        format!(
+                            "{guest}:{install_path}:build/images/{arch}-{guest}/{version_full}",
+                            install_path = install_path.display(),
+                            arch = args.common.arch,
+                            version_full = args.common.version_full,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n"),
             }),
             secrets_args: secrets_args()?,
         })

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -19,6 +19,7 @@ use error::Result;
 use lazy_static::lazy_static;
 use nonzero_ext::nonzero;
 use pipesys::server::Server as PipesysServer;
+use pubsys_config::{EifSigningKey, InfraConfig};
 use rand::Rng;
 use regex::Regex;
 use semver::{Comparator, Op, Prerelease, Version, VersionReq};
@@ -958,7 +959,123 @@ fn secrets_args() -> Result<Vec<String>> {
         args.build_secret("env", &id, var);
     }
 
+    args.extend(eif_signing_args()?);
+
     Ok(args)
+}
+
+/// Docker-build `--secret` flags carrying the EIF signing profile from
+/// `Infra.toml [eif]`. Absent config (no `PUBLISH_INFRA_CONFIG_PATH`, no
+/// `[eif]`, or no Infra.toml) is not an error: the in-container helper
+/// treats missing mounts as "unsigned". Empty cert/key files are rejected
+/// here to keep this gate in lockstep with the helper's `[[ -s ]]` check.
+fn eif_signing_args() -> Result<Vec<String>> {
+    let infra_path = match env::var("PUBLISH_INFRA_CONFIG_PATH") {
+        Ok(p) if !p.is_empty() => PathBuf::from(p),
+        _ => return Ok(Vec::new()),
+    };
+
+    let infra = InfraConfig::from_path_or_lock(&infra_path, true)
+        .context(error::InfraConfigLoadSnafu { path: &infra_path })?;
+    let Some(eif) = infra.eif else {
+        // Guard against a stale Infra.lock that predates the `[eif]` schema
+        // shadowing an `[eif]` section in Infra.toml.
+        detect_stale_infra_lock(&infra_path)?;
+        return Ok(Vec::new());
+    };
+
+    if !is_non_empty_file(&eif.signing_cert) {
+        return error::EifSigningCertMissingSnafu {
+            path: eif.signing_cert,
+        }
+        .fail();
+    }
+
+    let mut args = Vec::new();
+    args.build_secret(
+        "file",
+        "eif-signing.crt",
+        &eif.signing_cert.to_string_lossy(),
+    );
+
+    match eif.signing_key {
+        EifSigningKey::file { path } => {
+            if !is_non_empty_file(&path) {
+                return error::EifSigningKeyMissingSnafu { path }.fail();
+            }
+            args.build_secret("file", "eif-signing.key", &path.to_string_lossy());
+        }
+        EifSigningKey::kms { key_id, region } => {
+            env::set_var("EIF_KMS_KEY_ID", &key_id);
+            args.build_secret("env", "eif-kms-key-id.env", "EIF_KMS_KEY_ID");
+            if let Some(region) = region {
+                env::set_var("EIF_KMS_REGION", &region);
+                args.build_secret("env", "eif-kms-region.env", "EIF_KMS_REGION");
+            }
+        }
+    }
+
+    Ok(args)
+}
+
+/// Return boolean result of if file at `path` is a non-empty regular file.
+fn is_non_empty_file(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|m| m.is_file() && m.len() > 0)
+        .unwrap_or(false)
+}
+
+/// Fail loudly if `Infra.lock` shadows an `[eif]` section that exists in
+/// `Infra.toml`.
+///
+/// Called from `eif_signing_args` on the "no eif config" branch. The
+/// hazard: `InfraConfig::from_path_or_lock` prefers `Infra.lock` when it
+/// exists and never consults `Infra.toml`, so a lock generated before the
+/// `[eif]` schema landed will happily deserialize to `eif = None`. Without
+/// this check that silently produces an unsigned EIF — same class of
+/// silent-downgrade failure that motivated the "reject broken Infra.toml"
+/// stance elsewhere.
+///
+/// Detection is intentionally coarse: any parseable Infra.toml with an
+/// `[eif]` section, next to an `Infra.lock` that was actually loaded, is
+/// treated as stale. We don't try to diff the two — if the lock is
+/// current, the caller already unwrapped `Some(eif)` and never reached
+/// this function.
+///
+/// If Infra.toml is malformed, missing, or the paths don't line up, we
+/// stay quiet: `from_path_or_lock` already validated whichever file it
+/// actually loaded, and the "no eif" outcome is the correct one for the
+/// no-Infra.toml case.
+fn detect_stale_infra_lock(infra_path: &Path) -> Result<()> {
+    let Ok(lock_path) = InfraConfig::compute_lock_path(infra_path) else {
+        return Ok(());
+    };
+    // Only relevant when the lock is what actually got loaded.
+    if !lock_path.exists() {
+        return Ok(());
+    }
+    // If Infra.toml is missing or unreadable, there is nothing to compare
+    // against — the lock is authoritative by design.
+    let Ok(toml_str) = fs::read_to_string(infra_path) else {
+        return Ok(());
+    };
+    // A cheap surface check on the raw TOML: does it declare an `[eif]`
+    // table? Parsing to the strongly-typed `InfraConfig` would work too,
+    // but that couples this guard to future schema additions and would
+    // reject valid Infra.toml files with unrelated new fields the current
+    // pubsys-config doesn't know about. `toml::Value` is version-tolerant.
+    let has_eif = toml::from_str::<toml::Value>(&toml_str)
+        .ok()
+        .and_then(|v| v.get("eif").cloned())
+        .is_some();
+    if has_eif {
+        return error::EifStaleInfraLockSnafu {
+            lock_path,
+            toml_path: infra_path.to_path_buf(),
+        }
+        .fail();
+    }
+    Ok(())
 }
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
@@ -1225,6 +1342,8 @@ fn filename(p: impl AsRef<Path>) -> String {
 mod test {
     use super::*;
     use semver::Version;
+    use std::io::Write;
+    use tempfile::TempDir;
 
     #[test]
     fn test_docker_version_req_25_0_5_passes() {
@@ -1248,5 +1367,136 @@ mod test {
     fn test_docker_version_req_20_10_27_fails() {
         let version = Version::parse("20.10.27").unwrap();
         assert!(!MINIMUM_DOCKER_VERSION.matches(&version))
+    }
+
+    // ------------------------------------------------------------------
+    // EIF signing config gates. These pin down the two silent-downgrade
+    // failure modes:
+    //   1. Stale `Infra.lock` (predating the [eif] field) shadowing a
+    //      current Infra.toml → we detect and hard-fail.
+    //   2. A 0-byte signing_cert/key on disk → we reject at config load
+    //      because the in-container `eif-sign-helper` uses `[[ -s ]]`
+    //      and would otherwise silently fall back to "no profile".
+    // ------------------------------------------------------------------
+
+    /// Sanity: a regular file with content is accepted.
+    #[test]
+    fn is_non_empty_file_accepts_nonempty() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("cert.pem");
+        let mut f = File::create(&p).unwrap();
+        f.write_all(b"-----BEGIN CERTIFICATE-----\n").unwrap();
+        assert!(is_non_empty_file(&p));
+    }
+
+    /// The core of fix #2: buildkit will create a 0-byte file when a
+    /// secret `src` is missing, and openssl/pipeline mishaps can also
+    /// leave one behind. `.exists()` returns true for these; the helper's
+    /// `[[ -s ]]` returns false. `is_non_empty_file` must match the
+    /// helper.
+    #[test]
+    fn is_non_empty_file_rejects_zero_byte() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("cert.pem");
+        File::create(&p).unwrap();
+        assert!(p.exists(), "precondition: file exists on disk");
+        assert!(
+            !is_non_empty_file(&p),
+            "a 0-byte file must be treated the same as `[[ -s ]]` in the helper: not present",
+        );
+    }
+
+    #[test]
+    fn is_non_empty_file_rejects_missing() {
+        let dir = TempDir::new().unwrap();
+        assert!(!is_non_empty_file(&dir.path().join("nope")));
+    }
+
+    /// A directory is not a "file with signing material". Guards against
+    /// operators pointing signing_cert at a directory and getting a
+    /// confusing downstream error.
+    #[test]
+    fn is_non_empty_file_rejects_directory() {
+        let dir = TempDir::new().unwrap();
+        assert!(!is_non_empty_file(dir.path()));
+    }
+
+    /// The happy no-op case for fix #1: no `Infra.lock` on disk means the
+    /// stale-lock hazard doesn't exist. The guard must return Ok(()) so
+    /// callers can produce their normal "no signing profile → unsigned"
+    /// output for variants that don't ship an [eif] section at all.
+    #[test]
+    fn detect_stale_infra_lock_returns_ok_when_no_lock() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("Infra.toml");
+        fs::write(
+            &toml_path,
+            r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { file = { path = "/opt/eif/signing.key" } }
+"#,
+        )
+        .unwrap();
+        // No Infra.lock next to it.
+        assert!(detect_stale_infra_lock(&toml_path).is_ok());
+    }
+
+    /// The failure case for fix #1: Infra.lock exists (so
+    /// `from_path_or_lock` loaded it and got `eif = None`) *and* the
+    /// sibling Infra.toml declares [eif]. This is the exact stale-lock
+    /// version-skew scenario the guard exists to catch.
+    #[test]
+    fn detect_stale_infra_lock_errors_when_lock_shadows_eif_toml() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("Infra.toml");
+        let lock_path = dir.path().join("Infra.lock");
+        fs::write(
+            &toml_path,
+            r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { file = { path = "/opt/eif/signing.key" } }
+"#,
+        )
+        .unwrap();
+        // Contents don't need to be a valid lock; we're on the branch
+        // where the caller already parsed the lock and got eif = None,
+        // so this test only exercises the `.exists()` half of the check.
+        fs::write(&lock_path, "aws: null\n").unwrap();
+
+        let err = detect_stale_infra_lock(&toml_path)
+            .expect_err("stale lock shadowing Infra.toml [eif] must error");
+        // Cheap smoke check that the error path is the one we intended,
+        // without pinning the exact Display string.
+        assert!(matches!(err, error::Error::EifStaleInfraLock { .. }));
+    }
+
+    /// The other allowed branch: Infra.lock exists but Infra.toml has no
+    /// [eif] section either. That's an actual "no EIF signing configured"
+    /// project (e.g. a non-nitro variant), which must remain a clean
+    /// no-op — the guard exists to catch skew, not to require [eif].
+    #[test]
+    fn detect_stale_infra_lock_ok_when_toml_has_no_eif() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("Infra.toml");
+        let lock_path = dir.path().join("Infra.lock");
+        fs::write(&toml_path, "[aws]\nregions = []\n").unwrap();
+        fs::write(&lock_path, "aws: null\n").unwrap();
+        assert!(detect_stale_infra_lock(&toml_path).is_ok());
+    }
+
+    /// Malformed Infra.toml on the "no eif" branch must not itself
+    /// synthesize a stale-lock error — whichever file `from_path_or_lock`
+    /// actually loaded is already validated, and a broken Infra.toml
+    /// isn't the concern of this guard.
+    #[test]
+    fn detect_stale_infra_lock_ok_when_toml_unparseable() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("Infra.toml");
+        let lock_path = dir.path().join("Infra.lock");
+        fs::write(&toml_path, "this is not = valid = toml [[[").unwrap();
+        fs::write(&lock_path, "aws: null\n").unwrap();
+        assert!(detect_stale_infra_lock(&toml_path).is_ok());
     }
 }

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -214,6 +214,15 @@ impl crate::builder::PackageBuildArgs {
     }
 }
 
+/// Format the variant-declared EIF PCIE flags for the Docker build-arg.
+///
+/// Returns bare lowercase hex (no `0x` prefix); an unset field becomes the
+/// empty string, which the Dockerfile treats as "omit `--pcie-flags` and let
+/// `eif-builder` apply its default".
+fn format_eif_pcie_flags(flags: Option<u16>) -> String {
+    flags.map(|v| format!("{v:x}")).unwrap_or_default()
+}
+
 struct VariantBuildArgs {
     package_dependencies: Vec<String>,
     kit_dependencies: Vec<String>,
@@ -224,6 +233,9 @@ struct VariantBuildArgs {
     image_features: HashSet<ImageFeature>,
     image_format: String,
     kernel_parameters: String,
+    /// EIF header PCIE flags override from `[package.metadata.build-variant]
+    /// eif-pcie-flags`.
+    eif_pcie_flags: String,
     name: String,
     os_image_publish_size_gib: String,
     os_image_size_gib: String,
@@ -262,6 +274,7 @@ impl VariantBuildArgs {
         args.build_arg("IMAGE_FORMAT", &self.image_format);
         args.build_arg("IMAGE_NAME", &self.name);
         args.build_arg("KERNEL_PARAMETERS", &self.kernel_parameters);
+        args.build_arg("EIF_PCIE_FLAGS", &self.eif_pcie_flags);
         args.build_arg("KIT_DEPENDENCIES", self.kit_dependencies.join(" "));
         args.build_arg(
             "EXTERNAL_KIT_DEPENDENCIES",
@@ -318,6 +331,9 @@ struct RepackVariantBuildArgs {
     /// Space-joined variant-declared kernel parameters. Required at repack time
     /// for `image-format = "eif"`
     kernel_parameters: String,
+    /// Mirrors `VariantBuildArgs::eif_pcie_flags`. Required at repack time for
+    /// `image-format = "eif"`
+    eif_pcie_flags: String,
     name: String,
     os_image_publish_size_gib: String,
     os_image_size_gib: String,
@@ -354,6 +370,7 @@ impl RepackVariantBuildArgs {
         args.build_arg("BUILD_ID", &self.version_build);
         args.build_arg("VERSION_ID", &self.version_image);
         args.build_arg("KERNEL_PARAMETERS", &self.kernel_parameters);
+        args.build_arg("EIF_PCIE_FLAGS", &self.eif_pcie_flags);
         args.build_arg("GUEST_IMAGES", &self.guest_images);
 
         // TWOLITER_VERSION mirrors what VariantBuildArgs plumbs through so
@@ -571,6 +588,7 @@ impl DockerBuild {
                     .cloned()
                     .unwrap_or_default()
                     .join(" "),
+                eif_pcie_flags: format_eif_pcie_flags(manifest.info().eif_pcie_flags()),
                 name: args.name,
                 os_image_publish_size_gib: os_image_publish_size_gib.to_string(),
                 os_image_size_gib: os_image_size_gib.to_string(),
@@ -686,6 +704,7 @@ impl DockerBuild {
                     .cloned()
                     .unwrap_or_default()
                     .join(" "),
+                eif_pcie_flags: format_eif_pcie_flags(manifest.info().eif_pcie_flags()),
                 name: args.name,
                 os_image_publish_size_gib: os_image_publish_size_gib.to_string(),
                 os_image_size_gib: os_image_size_gib.to_string(),

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -9,8 +9,8 @@ pub(crate) mod error;
 use crate::args::{BuildKitArgs, BuildPackageArgs, BuildVariantArgs, RepackVariantArgs};
 use bottlerocket_variant::Variant;
 use buildsys::manifest::{
-    resolved_image_layout, validate_image_features, ExternalKitMetadataView, ImageFeature,
-    ImageFormat, Manifest, PartitionPlan, SupportedArch,
+    resolved_image_layout, validate_image_features, EifKernelFormat, ExternalKitMetadataView,
+    ImageFeature, ImageFormat, Manifest, PartitionPlan, SupportedArch,
 };
 use buildsys::BuildType;
 use buildsys_config::EXTERNAL_KIT_METADATA;
@@ -223,6 +223,12 @@ fn format_eif_pcie_flags(flags: Option<u16>) -> String {
     flags.map(|v| format!("{v:x}")).unwrap_or_default()
 }
 
+/// Serialize the variant-authored EIF kernel format for the `EIF_KERNEL_FORMAT`
+/// build-arg.
+fn format_eif_kernel_format(fmt: Option<EifKernelFormat>) -> String {
+    fmt.map(|v| v.as_str().to_string()).unwrap_or_default()
+}
+
 struct VariantBuildArgs {
     package_dependencies: Vec<String>,
     kit_dependencies: Vec<String>,
@@ -236,6 +242,9 @@ struct VariantBuildArgs {
     /// EIF header PCIE flags override from `[package.metadata.build-variant]
     /// eif-pcie-flags`.
     eif_pcie_flags: String,
+    /// x86_64 EIF kernel format override from `[package.metadata.build-variant]
+    /// eif-kernel-format`.
+    eif_kernel_format: String,
     name: String,
     os_image_publish_size_gib: String,
     os_image_size_gib: String,
@@ -275,6 +284,7 @@ impl VariantBuildArgs {
         args.build_arg("IMAGE_NAME", &self.name);
         args.build_arg("KERNEL_PARAMETERS", &self.kernel_parameters);
         args.build_arg("EIF_PCIE_FLAGS", &self.eif_pcie_flags);
+        args.build_arg("EIF_KERNEL_FORMAT", &self.eif_kernel_format);
         args.build_arg("KIT_DEPENDENCIES", self.kit_dependencies.join(" "));
         args.build_arg(
             "EXTERNAL_KIT_DEPENDENCIES",
@@ -589,6 +599,7 @@ impl DockerBuild {
                     .unwrap_or_default()
                     .join(" "),
                 eif_pcie_flags: format_eif_pcie_flags(manifest.info().eif_pcie_flags()),
+                eif_kernel_format: format_eif_kernel_format(manifest.info().eif_kernel_format()),
                 name: args.name,
                 os_image_publish_size_gib: os_image_publish_size_gib.to_string(),
                 os_image_size_gib: os_image_size_gib.to_string(),

--- a/tools/buildsys/src/builder/error.rs
+++ b/tools/buildsys/src/builder/error.rs
@@ -84,6 +84,38 @@ pub(crate) enum Error {
     #[snafu(display("Failed to create build arguments due to a dependency error: {source}"))]
     Graph { source: buildsys::manifest::Error },
 
+    #[snafu(display("Failed to load Infra.toml at '{}': {}", path.display(), source))]
+    InfraConfigLoad {
+        path: PathBuf,
+        #[snafu(source(from(pubsys_config::Error, Box::new)))]
+        source: Box<pubsys_config::Error>,
+    },
+
+    #[snafu(display(
+        "EIF signing cert '{}' does not exist or is empty (from Infra.toml [eif].signing_cert).",
+        path.display()
+    ))]
+    EifSigningCertMissing { path: PathBuf },
+
+    #[snafu(display(
+        "EIF signing key '{}' does not exist or is empty (from Infra.toml [eif].signing_key).",
+        path.display()
+    ))]
+    EifSigningKeyMissing { path: PathBuf },
+
+    #[snafu(display(
+        "Infra.lock at '{}' was loaded and has no [eif] section, but the sibling Infra.toml at \
+         '{}' does declare one. This usually means Infra.lock predates the [eif] field and would \
+         silently strip EIF signing. Delete Infra.lock (it will be regenerated) or regenerate it \
+         from the current Infra.toml.",
+        lock_path.display(),
+        toml_path.display()
+    ))]
+    EifStaleInfraLock {
+        lock_path: PathBuf,
+        toml_path: PathBuf,
+    },
+
     #[snafu(display("Missing environment variable '{}'", var))]
     Environment {
         var: String,

--- a/tools/buildsys/src/builder/error.rs
+++ b/tools/buildsys/src/builder/error.rs
@@ -139,9 +139,6 @@ pub(crate) enum Error {
         source: semver::Error,
         version_str: String,
     },
-
-    #[snafu(display("Repacking is not supported for image-format = \"eif\""))]
-    EifRepackUnsupported,
 }
 
 pub(super) type Result<T> = std::result::Result<T, Error>;

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -306,11 +306,15 @@ fn repack_variant(args: RepackVariantArgs) -> Result<()> {
     check_arch_support(manifest.info(), args.common.arch);
     validate_standalone_image_or_warn(manifest.info())?;
 
+    let guest_images = manifest
+        .guest_image_variant_deps()
+        .context(error::ManifestParseSnafu)?;
+
     if args.common.cicd_hack {
         return Ok(());
     }
 
-    DockerBuild::repack_variant(args, &manifest)
+    DockerBuild::repack_variant(args, &manifest, guest_images)
         .context(error::BuilderInstantiationSnafu)?
         .build()
         .context(error::BuildAttemptSnafu)

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -183,6 +183,26 @@ The given parameters are inserted at the start of the command line.
 kernel-parameters = [
    "console=ttyS42",
 ]
+```
+
+`eif-pcie-flags` overrides the PCIE flag word written into the EIF header for
+`image-format = "eif"` variants. Accepted as either a TOML integer literal
+(always decimal, per the TOML spec — e.g. `832`) or a `0x`-prefixed hex
+string (`"0x340"`). Unprefixed string forms like `"340"` are rejected to
+avoid ambiguity with the hex convention used on the `eif-builder --pcie-flags`
+CLI, where `340` means `0x340`. Forwarded to `eif-builder --pcie-flags <hex>`.
+When absent, `eif-builder`'s built-in default (`0x240`) is used. Non-EIF
+variants ignore this field.
+
+The header value **must** match the PCIE flags the sidecar shim passes to the
+hypervisor at launch (`header == launch-flags`, enforced by the hypervisor);
+this knob is the authoring surface for that value. See the doc comment on
+`BuildVariant::eif_pcie_flags` for details.
+```ignore
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = 0x340
+```
 
 `image-features` is a map of image feature flags, which can be enabled or disabled. This allows us
 to conditionally use or exclude certain image-level features in variants.
@@ -306,7 +326,7 @@ use crate::BuildType;
 use buildsys_config::EXTERNAL_KIT_METADATA;
 use guppy::graph::{DependencyDirection, PackageGraph, PackageLink, PackageMetadata};
 use guppy::{CargoMetadata, PackageId};
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use std::cmp::max;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -629,6 +649,13 @@ impl ManifestInfo {
             .and_then(|b| b.kernel_parameters.as_ref())
     }
 
+    /// Convenience method to return the EIF header PCIE flags override for
+    /// this variant. Only meaningful when `image-format = "eif"`; ignored
+    /// otherwise.
+    pub fn eif_pcie_flags(&self) -> Option<u16> {
+        self.build_variant().and_then(|b| b.eif_pcie_flags)
+    }
+
     /// Convenience method to return the enabled image features for this variant.
     pub fn image_features(&self) -> Option<HashSet<ImageFeature>> {
         let variant = self.build_variant()?;
@@ -937,6 +964,58 @@ pub enum SensitivityType {
     Flavor,
 }
 
+/// Deserialize a `u16` from either a TOML integer literal (`576`, always
+/// decimal per the TOML spec) or a `0x`/`0X`-prefixed hex string (`"0x240"`).
+///
+/// Unprefixed string forms (e.g. `"240"`) are **rejected** rather than
+/// silently interpreted. The rationale: PCIE flag values are conventionally
+/// written in hex on the `eif-builder --pcie-flags` CLI (whose parser is
+/// hex-only, prefix optional) and in the aws-nitro-enclaves-image-format
+/// header definitions. A user copy-pasting a hex value like `340` from those
+/// contexts into `eif-pcie-flags = "340"` almost certainly means `0x340`
+/// (bits 6, 8, 9), not `340` decimal (`0x154`, bits 2, 4, 6, 8). Treating
+/// the unprefixed string as decimal would produce a header/launch-flags
+/// mismatch that only surfaces at enclave launch, which is the exact kind
+/// of silent misconfiguration this knob exists to prevent. Forcing an
+/// explicit base makes the author's intent unambiguous at parse time:
+/// integer form is unambiguously decimal, string form is unambiguously hex.
+fn deserialize_u16_hex_or_int<'de, D>(deserializer: D) -> std::result::Result<Option<u16>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        Int(u64),
+        Str(String),
+    }
+
+    let Some(value) = Option::<Repr>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    match value {
+        Repr::Int(n) => u16::try_from(n).map(Some).map_err(|_| {
+            <D::Error as de::Error>::custom(format!("value {n} does not fit in a u16"))
+        }),
+        Repr::Str(s) => {
+            let trimmed = s.trim();
+            let hex_body = trimmed
+                .strip_prefix("0x")
+                .or_else(|| trimmed.strip_prefix("0X"))
+                .ok_or_else(|| {
+                    <D::Error as de::Error>::custom(format!(
+                        "invalid `eif-pcie-flags` value {s:?}: string form requires a `0x` prefix \
+                         (e.g. \"0x340\") to make the base explicit; use a bare integer literal \
+                         (e.g. `832`) for decimal"
+                    ))
+                })?;
+            u16::from_str_radix(hex_body, 16).map(Some).map_err(|e| {
+                <D::Error as de::Error>::custom(format!("invalid hex u16 {s:?}: {e}"))
+            })
+        }
+    }
+}
+
 /// Metadata for a `build-variant`.
 ///
 /// `guest-images` is a map from a guest variant's crate name to an absolute install path in
@@ -964,6 +1043,37 @@ pub struct BuildVariant {
     pub supported_arches: Option<HashSet<SupportedArch>>,
     pub kernel_parameters: Option<Vec<String>>,
     pub image_features: Option<HashMap<ImageFeature, bool>>,
+    /// EIF header PCIE flags override for `image-format = "eif"` variants.
+    ///
+    /// Encoded in the variant Cargo.toml as either a TOML integer literal
+    /// (decimal, e.g. `832`) or a `0x`-prefixed hex string (e.g. `"0x340"`).
+    /// Unprefixed string forms like `"340"` are rejected: the `eif-builder
+    /// --pcie-flags` CLI treats `340` as hex, so silently reading the
+    /// unprefixed string as decimal here would produce a header/launch-flags
+    /// mismatch that only surfaces at enclave launch. Forwarded to
+    /// `eif-builder --pcie-flags <hex>` at rpm2eif / eif2eif time. When
+    /// absent, `eif-builder` uses its built-in `DEFAULT_PCIE_FLAGS`
+    /// (`EIF_HDR_FLAG_PCIE | EIF_HDR_FLAG_PCIE_VIRTIO`, `0x240`). Non-EIF
+    /// variants ignore this field.
+    ///
+    /// Contract: the flags written into the EIF header here **must** match the
+    /// PCIE flags the sidecar shim passes to the hypervisor at launch. The
+    /// hypervisor enforces `header == launch-flags`; a mismatch fails
+    /// attestation / launch. Today the shim's launch flags are hard-coded on
+    /// the shim side, so this knob is what lets a variant author the value
+    /// that keeps the two sides in sync. Once the shim derives its launch
+    /// flags from the header directly (host echoes, hypervisor enforces), the
+    /// coupling goes away — but the knob is still how the header value gets
+    /// authored per-variant.
+    ///
+    /// Example:
+    /// ```ignore
+    /// [package.metadata.build-variant]
+    /// image-format = "eif"
+    /// eif-pcie-flags = 0x340
+    /// ```
+    #[serde(default, deserialize_with = "deserialize_u16_hex_or_int")]
+    pub eif_pcie_flags: Option<u16>,
     /// Map of guest variant crate name -> absolute install path in this variant's root
     /// filesystem.
     pub guest_images: Option<BTreeMap<String, PathBuf>>,
@@ -1775,6 +1885,110 @@ name = "test-variant"
         assert!(features.contains(&ImageFeature::InPlaceUpdates));
         assert!(features.contains(&ImageFeature::HostContainers));
         assert!(features.contains(&ImageFeature::ExternalKmodDevelopment));
+    }
+
+    #[test]
+    fn eif_pcie_flags_omitted_is_none() {
+        // A variant without `eif-pcie-flags` returns None, so buildsys emits
+        // the empty ARG and rpm2eif/eif2eif omit `--pcie-flags`, letting
+        // `eif-builder` apply its `DEFAULT_PCIE_FLAGS`.
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_pcie_flags(), None);
+    }
+
+    #[test]
+    fn eif_pcie_flags_hex_string_parses() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = "0x340"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_pcie_flags(), Some(0x340));
+    }
+
+    #[test]
+    fn eif_pcie_flags_unprefixed_string_is_rejected() {
+        // `"340"` is ambiguous (hex-in-the-CLI-sense vs decimal-in-Rust-sense)
+        // and almost certainly a copy-paste mistake, so we reject it at
+        // parse time with a clear message. The author must write `"0x340"`
+        // for hex or the bare integer `832` for decimal.
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = "340"
+"#;
+        let err = toml::from_str::<ManifestInfo>(toml)
+            .expect_err("unprefixed hex string should be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("0x"),
+            "error should mention the `0x` prefix requirement, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn eif_pcie_flags_uppercase_prefix_parses() {
+        // `0X` prefix is accepted alongside `0x`, matching eif-builder's own
+        // `--pcie-flags` parser.
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = "0X340"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_pcie_flags(), Some(0x340));
+    }
+
+    #[test]
+    fn eif_pcie_flags_integer_parses() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = 576
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_pcie_flags(), Some(576));
+    }
+
+    #[test]
+    fn eif_pcie_flags_rejects_overflow() {
+        // 0x10000 does not fit in u16; the deserializer surfaces a clear error
+        // rather than silently truncating.
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = "0x10000"
+"#;
+        let err = toml::from_str::<ManifestInfo>(toml)
+            .expect_err("0x10000 should not fit in u16");
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("u16"),
+            "expected u16 mention in error, got: {msg}"
+        );
     }
 
     #[test]

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -204,6 +204,30 @@ image-format = "eif"
 eif-pcie-flags = 0x340
 ```
 
+`eif-kernel-format` selects the x86_64 kernel image format that `rpm2eif`
+embeds into the EIF kernel section (and publishes as the sidecar
+`${prefix}-kernel` artifact). Accepted values:
+
+* `"bzimage"` (default): use the RPM-shipped compressed `vmlinuz` as-is.
+  The Nitro Enclaves in-memory image loader that boots the sidecar EIF
+  validates `BZIMAGE_HEADER_MAGIC` and boots via the bzImage protocol
+  (same as every `nitro-cli`-built EIF), so this is the correct format
+  for the sidecar path.
+* `"vmlinux"`: extract an uncompressed ELF `vmlinux` from `vmlinuz` and
+  embed that. Only appropriate for a bare-metal Firecracker PVH loader.
+  Kept selectable because Firecracker upstream has shipped conflicting
+  guidance on compressed vs. uncompressed kernels; if a variant author
+  needs to feed a PVH-only loader, this keeps the option available
+  without having to fork `rpm2eif`.
+
+Ignored on aarch64 (only the PE-wrapped `Image` format is valid there)
+and on non-EIF variants.
+```ignore
+[package.metadata.build-variant]
+image-format = "eif"
+eif-kernel-format = "bzimage"
+```
+
 `image-features` is a map of image feature flags, which can be enabled or disabled. This allows us
 to conditionally use or exclude certain image-level features in variants.
 
@@ -656,6 +680,13 @@ impl ManifestInfo {
         self.build_variant().and_then(|b| b.eif_pcie_flags)
     }
 
+    /// Convenience method to return the x86_64 EIF kernel format override
+    /// for this variant. Only meaningful when `image-format = "eif"` on
+    /// x86_64; ignored otherwise.
+    pub fn eif_kernel_format(&self) -> Option<EifKernelFormat> {
+        self.build_variant().and_then(|b| b.eif_kernel_format)
+    }
+
     /// Convenience method to return the enabled image features for this variant.
     pub fn image_features(&self) -> Option<HashSet<ImageFeature>> {
         let variant = self.build_variant()?;
@@ -1009,9 +1040,9 @@ where
                          (e.g. `832`) for decimal"
                     ))
                 })?;
-            u16::from_str_radix(hex_body, 16).map(Some).map_err(|e| {
-                <D::Error as de::Error>::custom(format!("invalid hex u16 {s:?}: {e}"))
-            })
+            u16::from_str_radix(hex_body, 16)
+                .map(Some)
+                .map_err(|e| <D::Error as de::Error>::custom(format!("invalid hex u16 {s:?}: {e}")))
         }
     }
 }
@@ -1074,6 +1105,23 @@ pub struct BuildVariant {
     /// ```
     #[serde(default, deserialize_with = "deserialize_u16_hex_or_int")]
     pub eif_pcie_flags: Option<u16>,
+    /// x86_64 kernel image format that `rpm2eif` embeds in the EIF kernel
+    /// section (and publishes as the sidecar `${prefix}-kernel` artifact).
+    ///
+    /// Defaults to [`EifKernelFormat::Bzimage`] when unset: the sidecar
+    /// enclave loader validates `BZIMAGE_HEADER_MAGIC` and boots via the
+    /// bzImage protocol, matching every `nitro-cli`-built EIF. Kept
+    /// selectable (rather than a hardcoded constant) because Firecracker
+    /// upstream has flipped between compressed and uncompressed kernels
+    /// more than once, and a bare-metal PVH loader still needs the ELF
+    /// `vmlinux` form.
+    ///
+    /// Ignored on aarch64 (only PE-wrapped `Image` is valid there) and on
+    /// non-EIF variants. Forwarded to `rpm2eif` as the
+    /// `EIF_KERNEL_FORMAT` build-arg (empty string when unset; `rpm2eif`
+    /// applies its own default).
+    #[serde(default)]
+    pub eif_kernel_format: Option<EifKernelFormat>,
     /// Map of guest variant crate name -> absolute install path in this variant's root
     /// filesystem.
     pub guest_images: Option<BTreeMap<String, PathBuf>>,
@@ -1085,13 +1133,42 @@ pub struct BuildVariant {
     pub flavor: Option<String>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ImageFormat {
     Eif,
     Qcow2,
     Raw,
     Vmdk,
+}
+
+/// x86_64 kernel image format that `rpm2eif` embeds in the EIF kernel
+/// section. See [`BuildVariant::eif_kernel_format`] for the rationale on
+/// keeping this selectable rather than pinning one value.
+///
+/// The TOML values `"bzimage"` and `"vmlinux"` are accepted; both are
+/// case-insensitive (via the `lowercase` rename). Ignored on aarch64.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EifKernelFormat {
+    /// Compressed `vmlinuz` embedded verbatim. Matches the boot protocol
+    /// the sidecar Nitro Enclaves in-memory image loader expects (and
+    /// every `nitro-cli`-built EIF).
+    Bzimage,
+    /// Uncompressed ELF `vmlinux` extracted from `vmlinuz`. For a
+    /// bare-metal Firecracker PVH loader.
+    Vmlinux,
+}
+
+impl EifKernelFormat {
+    /// String form matching the TOML value and the `EIF_KERNEL_FORMAT`
+    /// build-arg / `--eif-kernel-format` CLI value expected by `rpm2eif`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EifKernelFormat::Bzimage => "bzimage",
+            EifKernelFormat::Vmlinux => "vmlinux",
+        }
+    }
 }
 
 #[derive(Deserialize, Debug, Copy, Clone)]
@@ -1982,12 +2059,83 @@ name = "test-variant"
 image-format = "eif"
 eif-pcie-flags = "0x10000"
 "#;
-        let err = toml::from_str::<ManifestInfo>(toml)
-            .expect_err("0x10000 should not fit in u16");
+        let err = toml::from_str::<ManifestInfo>(toml).expect_err("0x10000 should not fit in u16");
         let msg = format!("{err}");
         assert!(
             msg.to_lowercase().contains("u16"),
             "expected u16 mention in error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn eif_kernel_format_omitted_is_none() {
+        // A variant without `eif-kernel-format` returns None, so buildsys
+        // emits the empty ARG and rpm2eif applies its built-in default
+        // (bzImage on x86_64 -- the sidecar Nitro Enclaves loader boot
+        // protocol).
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_kernel_format(), None);
+    }
+
+    #[test]
+    fn eif_kernel_format_bzimage_parses() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-kernel-format = "bzimage"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_kernel_format(), Some(EifKernelFormat::Bzimage));
+        assert_eq!(info.eif_kernel_format().unwrap().as_str(), "bzimage");
+    }
+
+    #[test]
+    fn eif_kernel_format_vmlinux_parses() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-kernel-format = "vmlinux"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_kernel_format(), Some(EifKernelFormat::Vmlinux));
+        assert_eq!(info.eif_kernel_format().unwrap().as_str(), "vmlinux");
+    }
+
+    #[test]
+    fn eif_kernel_format_unknown_is_rejected() {
+        // An unrecognized value must fail at parse time rather than falling
+        // silently through to the default; the rpm2eif side also validates
+        // the flag, but catching typos here gives variant authors a
+        // per-manifest error instead of a container-build failure.
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-kernel-format = "elf"
+"#;
+        let err = toml::from_str::<ManifestInfo>(toml)
+            .expect_err("unknown eif-kernel-format value should be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("elf")
+                || msg.to_lowercase().contains("variant")
+                || msg.to_lowercase().contains("unknown"),
+            "error should mention the bad value, got: {msg}"
         );
     }
 

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -1129,10 +1129,7 @@ pub enum ImageFeature {
     StandaloneImage,
 }
 
-const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[
-    &ImageFeature::EncryptedStorage,
-    &ImageFeature::StandaloneImage,
-];
+const EXPERIMENTAL_IMAGE_FEATURES: &[&ImageFeature] = &[&ImageFeature::EncryptedStorage];
 
 const DEPRECATED_IMAGE_FEATURES: &[&ImageFeature] = &[
     &ImageFeature::GrubSetPrivateVar,
@@ -1221,7 +1218,14 @@ pub fn validate_image_features(
         "`standalone-image = true`"
     };
     let reason_secure_boot: String = if is_eif {
-        "secure boot is not supported by the EIF pipeline; `rpm2eif` does not sign shim/grub/vmlinuz".to_string()
+        // Note: EIF *signing* (a COSE_Sign1 over PCR0 embedded in an
+        // `EifSectionSignature`) is orthogonal to UEFI Secure Boot. The
+        // former is enabled automatically by `rpm2eif` when Infra.toml
+        // carries an `[eif]` section (backed by either a local PEM key
+        // or a KMS key id). The latter -- signing shim/grub/vmlinuz as
+        // PE Authenticode -- has no place in the EIF pipeline and is
+        // still rejected here.
+        "secure boot is not supported by the EIF pipeline; `rpm2eif` does not sign shim/grub/vmlinuz (EIF signing over PCR0 is orthogonal and driven by Infra.toml [eif])".to_string()
     } else {
         "secure boot relies on signed first-party artifacts that are not present when `standalone-image = true`".to_string()
     };

--- a/tools/eif-builder/Cargo.toml
+++ b/tools/eif-builder/Cargo.toml
@@ -6,11 +6,22 @@ license = "Apache-2.0 OR MIT"
 publish = false
 
 [dependencies]
-crc32fast.workspace = true
+aws-config.workspace = true
+aws-lc-rs.workspace = true
+aws-sdk-kms.workspace = true
+aws-types.workspace = true
 clap = { workspace = true, features = ["derive"] }
+coset.workspace = true
+crc32fast.workspace = true
+error-utils.workspace = true
 flate2.workspace = true
+pem.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_cbor.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }
+x509-cert.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]

--- a/tools/eif-builder/src/kernel.rs
+++ b/tools/eif-builder/src/kernel.rs
@@ -10,9 +10,15 @@
 //! RPMs ship `vmlinuz` as an EFI zboot image, so we have to unwrap it here
 //! before handing it to Firecracker.
 //!
-//! On x86_64 no pre-processing is needed: the caller supplies an uncompressed
-//! ELF `vmlinux` (extracted from `vmlinuz` upstream in `rpm2eif`) and PVH boot
-//! consumes it directly.
+//! On x86_64 no pre-processing is needed: eif-builder passes the input bytes
+//! through unchanged and it is `rpm2eif`'s job (per its `--eif-kernel-format`
+//! flag) to pick the correct format for the downstream loader. The sidecar
+//! Nitro Enclaves in-memory image loader validates `BZIMAGE_HEADER_MAGIC`
+//! and boots via the bzImage protocol, so `rpm2eif` embeds the RPM-shipped
+//! `vmlinuz` (compressed bzImage) by default. A bare-metal Firecracker PVH
+//! loader consumes an uncompressed ELF `vmlinux` instead, which `rpm2eif`
+//! selects with `--eif-kernel-format=vmlinux`. Either format round-trips
+//! cleanly through this pass-through.
 
 use std::io::Read;
 
@@ -194,8 +200,10 @@ fn unwrap_zboot(data: &[u8]) -> Result<Vec<u8>, KernelPrepError> {
 
 /// Prepare a raw kernel image for embedding in the EIF kernel section.
 ///
-/// For `x86_64`, returns the input verbatim: the caller is expected to have
-/// supplied an uncompressed ELF `vmlinux` for PVH boot.
+/// For `x86_64`, returns the input verbatim. `rpm2eif` picks the format
+/// (`vmlinuz` bzImage for the sidecar Nitro Enclaves loader, or an ELF
+/// `vmlinux` for a bare-metal PVH loader) via `--eif-kernel-format`; both
+/// are pass-through here.
 ///
 /// For `aarch64`, if the input is an EFI zboot image (`MZ` + `"zimg"`),
 /// extracts and decompresses the inner arm64 `Image`. Otherwise the input is
@@ -303,7 +311,9 @@ mod tests {
     #[test]
     fn x86_pass_through() {
         // On x86 we don't touch the bytes even if they're pure garbage: the
-        // caller is responsible for handing us an ELF vmlinux.
+        // caller (rpm2eif, per --eif-kernel-format) is responsible for
+        // handing us either a bzImage vmlinuz or an ELF vmlinux; either is
+        // a pass-through at this layer.
         let data = vec![0xDE, 0xAD, 0xBE, 0xEF];
         let out = prepare_kernel(data.clone(), TargetArch::X86_64).unwrap();
         assert_eq!(out, data);

--- a/tools/eif-builder/src/lib.rs
+++ b/tools/eif-builder/src/lib.rs
@@ -66,7 +66,31 @@ pub const SIGNATURE_MAX_SIZE: usize = 32768;
 pub const EIF_HDR_FLAG_PCIE: u16 = 1 << 6;
 pub const EIF_HDR_FLAG_PCIE_VIRTIO: u16 = 1 << 9;
 
-/// Default PCIE flags for sidecar mode.
+/// Default PCIE flags baked into the EIF header when no `--pcie-flags`
+/// override is supplied on the `eif-builder` CLI.
+///
+/// # header == launch-flags contract
+///
+/// The PCIE flag word written into the EIF header **must** match the PCIE
+/// flags the sidecar shim passes to the hypervisor when it launches the
+/// enclave. The hypervisor enforces this equality: a mismatch fails launch /
+/// attestation. There is no negotiation, and no runtime derivation on the
+/// host side today — both ends are authored independently, and it is the
+/// build's responsibility to keep them in sync.
+///
+/// This default is the minimum viable value (PCIE + PCIE_VIRTIO) that a
+/// bare sidecar EIF needs to boot. Any variant whose shim uses a different
+/// launch-flag word must override it, either via `--pcie-flags` on the CLI
+/// or, preferably, via `[package.metadata.build-variant] eif-pcie-flags` in
+/// the variant's `Cargo.toml`, which the buildsys → `rpm2eif` / `eif2eif`
+/// pipeline forwards to `--pcie-flags` on both first-build and repack. See
+/// `tools/buildsys/src/manifest.rs::BuildVariant::eif_pcie_flags`.
+///
+/// Longer-term plan: have the shim derive its launch flags from the header
+/// directly (host echoes, hypervisor enforces). That removes the coupling
+/// and this default becomes truly authoritative rather than
+/// coincidentally-agreed. The `--pcie-flags` knob is still needed as the
+/// per-variant authoring surface for the header value itself.
 pub const DEFAULT_PCIE_FLAGS: u16 = EIF_HDR_FLAG_PCIE | EIF_HDR_FLAG_PCIE_VIRTIO;
 
 /// Default kernel command line for block device boot.

--- a/tools/eif-builder/src/lib.rs
+++ b/tools/eif-builder/src/lib.rs
@@ -7,23 +7,48 @@
 //! All multi-byte fields are big-endian.
 
 pub mod kernel;
+pub mod signer;
 
 pub use kernel::KernelPrepError;
+pub use signer::{Signer, SignerError};
 
+use std::borrow::Cow;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crc32fast::Hasher as Crc32Hasher;
+use serde::{Deserialize, Serialize};
 use snafu::{ensure, ResultExt, Snafu};
 
 const EIF_MAGIC: [u8; 4] = [0x2e, 0x65, 0x69, 0x66]; // ".eif"
+/// EIF header version. v4 introduced the metadata section (0x05) and is
+/// forward-compatible with the v3 signature section (0x04) — the reference
+/// `EifBuilder` still emits `EifSectionSignature` under v4 EIFs, and
+/// `nitro-cli describe-eif` recognizes signatures under v4. See
+/// <https://github.com/aws/aws-nitro-enclaves-image-format>.
 const EIF_HDR_VERSION: u16 = 4;
 
 const EIF_SECTION_KERNEL: u16 = 1;
 const EIF_SECTION_CMDLINE: u16 = 2;
 const EIF_SECTION_RAMDISK: u16 = 3;
+const EIF_SECTION_SIGNATURE: u16 = 4;
 const EIF_SECTION_METADATA: u16 = 5;
+
+/// Human-readable name for an EIF section type. `"unknown"` for values that
+/// aren't one of the five defined section types; the caller can decide how
+/// to surface those (we don't reject them, so `describe_eif` can still report
+/// what's on disk for post-mortem debugging of a malformed file).
+fn section_type_name(ty: u16) -> &'static str {
+    match ty {
+        EIF_SECTION_KERNEL => "KERNEL",
+        EIF_SECTION_CMDLINE => "CMDLINE",
+        EIF_SECTION_RAMDISK => "RAMDISK",
+        EIF_SECTION_SIGNATURE => "SIGNATURE",
+        EIF_SECTION_METADATA => "METADATA",
+        _ => "UNKNOWN",
+    }
+}
 
 const EIF_ARCH_X86_64: u16 = 0;
 const EIF_ARCH_AARCH64: u16 = 1;
@@ -32,6 +57,10 @@ const MAX_NUM_SECTIONS: usize = 32;
 const EIF_HEADER_SIZE: usize = 548;
 const EIF_CRC32_OFFSET: usize = EIF_HEADER_SIZE - 4;
 const EIF_SECTION_HEADER_SIZE: usize = 12;
+
+/// Upper bound on the size of the CBOR-encoded EIF signature section, per
+/// the aws-nitro-enclaves-image-format spec.
+pub const SIGNATURE_MAX_SIZE: usize = 32768;
 
 /// PCIE flag constants.
 pub const EIF_HDR_FLAG_PCIE: u16 = 1 << 6;
@@ -101,6 +130,65 @@ pub enum EifError {
         path: PathBuf,
         source: std::io::Error,
     },
+
+    #[snafu(display("signing failed: {source}"))]
+    Sign { source: SignerError },
+
+    #[snafu(display("failed to construct signer: {source}"))]
+    SignerBuild { source: SignerError },
+
+    #[snafu(display("failed to read signing certificate: {source}"))]
+    ReadCert { source: std::io::Error },
+
+    #[snafu(display("failed to read signing key: {source}"))]
+    ReadKey { source: std::io::Error },
+
+    #[snafu(display(
+        "encoded EIF signature section is {size} bytes (cert PEM: {cert_pem_size}, \
+         COSE_Sign1: {cose_size}), exceeding the {SIGNATURE_MAX_SIZE}-byte \
+         SIGNATURE_MAX_SIZE limit; shrink the certificate (drop chain \
+         intermediates if any) or shorten the payload"
+    ))]
+    SignatureTooLarge {
+        size: usize,
+        cert_pem_size: usize,
+        cose_size: usize,
+    },
+
+    #[snafu(display("failed to CBOR-encode signature section: {source}"))]
+    CborEncodeSignature { source: serde_cbor::Error },
+
+    #[snafu(display("failed to CBOR-encode signature payload: {source}"))]
+    CborEncodePayload { source: serde_cbor::Error },
+
+    #[snafu(display("failed to build COSE_Sign1: {source}"))]
+    CoseBuild { source: coset::CoseError },
+
+    #[snafu(display("too many EIF sections: {count} > {MAX_NUM_SECTIONS}"))]
+    TooManySections { count: usize },
+
+    #[snafu(display("failed to read input EIF {}: {source}", path.display()))]
+    ReadInput {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to parse input EIF: {reason}"))]
+    ParseInput { reason: String },
+
+    #[snafu(display(
+        "failed to decode METADATA section as UTF-8 JSON: {reason}. \
+         The METADATA section is expected to be a JSON document produced by \
+         `build_metadata`; a binary or non-UTF-8 payload here indicates a \
+         corrupt or foreign-tool-produced EIF."
+    ))]
+    MetadataDecode { reason: String },
+}
+
+/// One EIF section (type + data) staged in memory before layout.
+struct SectionEntry<'a> {
+    ty: u16,
+    data: Cow<'a, [u8]>,
 }
 
 /// Build a minimal metadata JSON matching the schema expected by the NE hypervisor.
@@ -169,11 +257,136 @@ pub struct MetadataFields<'a> {
     pub build_time: &'a str,
 }
 
-fn write_section(eif: &mut Vec<u8>, section_type: u16, data: &[u8]) {
-    eif.extend_from_slice(&section_type.to_be_bytes());
-    eif.extend_from_slice(&0u16.to_be_bytes()); // flags
-    eif.extend_from_slice(&(data.len() as u64).to_be_bytes());
-    eif.extend_from_slice(data);
+/// Assemble the final EIF bytes for a section list.
+///
+/// The header is fixed-size (`EIF_HEADER_SIZE`) and carries a table of at
+/// most `MAX_NUM_SECTIONS` offset/size pairs. Sections are laid out in the
+/// same order as `entries`; the CRC32 is computed over the whole buffer with
+/// the CRC field itself zeroed.
+///
+/// Split off from `build_eif` so that both the unsigned and signed builders
+/// can share the (finicky, easy-to-drift) offset/size/CRC math.
+fn write_eif_bytes(
+    default_mem: u64,
+    default_cpus: u64,
+    header_flags: u16,
+    entries: &[SectionEntry<'_>],
+) -> Result<Vec<u8>, EifError> {
+    ensure!(
+        entries.len() <= MAX_NUM_SECTIONS,
+        TooManySectionsSnafu {
+            count: entries.len(),
+        },
+    );
+    let num_sections: u16 = entries
+        .len()
+        .try_into()
+        .expect("checked <= MAX_NUM_SECTIONS above");
+
+    // Precompute per-section offsets and sizes so both the header table and
+    // the actual writes stay in lockstep.
+    let mut offsets: Vec<u64> = Vec::with_capacity(entries.len());
+    let mut sizes: Vec<u64> = Vec::with_capacity(entries.len());
+    let mut cursor: u64 = EIF_HEADER_SIZE as u64;
+    for entry in entries {
+        offsets.push(cursor);
+        let size = entry.data.len() as u64;
+        sizes.push(size);
+        cursor = cursor
+            .checked_add(EIF_SECTION_HEADER_SIZE as u64)
+            .and_then(|c| c.checked_add(size))
+            .expect("EIF total size overflow");
+    }
+    let total_size = cursor as usize;
+
+    let mut eif = Vec::with_capacity(total_size);
+
+    // --- Header ---
+    eif.extend_from_slice(&EIF_MAGIC);
+    eif.extend_from_slice(&EIF_HDR_VERSION.to_be_bytes());
+    eif.extend_from_slice(&header_flags.to_be_bytes());
+    eif.extend_from_slice(&default_mem.to_be_bytes());
+    eif.extend_from_slice(&default_cpus.to_be_bytes());
+    eif.extend_from_slice(&0u16.to_be_bytes()); // reserved
+    eif.extend_from_slice(&num_sections.to_be_bytes());
+
+    // Section offset table (fixed length: MAX_NUM_SECTIONS entries).
+    for i in 0..MAX_NUM_SECTIONS {
+        let val = if i < offsets.len() { offsets[i] } else { 0 };
+        eif.extend_from_slice(&val.to_be_bytes());
+    }
+
+    // Section size table (fixed length).
+    for i in 0..MAX_NUM_SECTIONS {
+        let val = if i < sizes.len() { sizes[i] } else { 0 };
+        eif.extend_from_slice(&val.to_be_bytes());
+    }
+
+    eif.extend_from_slice(&0u32.to_be_bytes()); // unused
+    eif.extend_from_slice(&0u32.to_be_bytes()); // crc32 placeholder
+
+    debug_assert_eq!(eif.len(), EIF_HEADER_SIZE);
+
+    // --- Sections ---
+    for entry in entries {
+        eif.extend_from_slice(&entry.ty.to_be_bytes());
+        eif.extend_from_slice(&0u16.to_be_bytes()); // flags
+        eif.extend_from_slice(&(entry.data.len() as u64).to_be_bytes());
+        eif.extend_from_slice(&entry.data);
+    }
+
+    // Compute CRC32 (exclude CRC field itself).
+    let mut hasher = Crc32Hasher::new();
+    hasher.update(&eif[..EIF_CRC32_OFFSET]);
+    hasher.update(&eif[EIF_CRC32_OFFSET + 4..]);
+    let crc = hasher.finalize();
+    eif[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4].copy_from_slice(&crc.to_be_bytes());
+
+    Ok(eif)
+}
+
+/// Prepare the fixed set of sections that go into every EIF (unsigned or signed).
+///
+/// The returned `KernelPayload` bundles the prepared kernel bytes, cmdline,
+/// ramdisk, and metadata JSON. Callers assemble the section list in the
+/// order required by their build (unsigned or signed).
+struct KernelPayload {
+    kernel: Vec<u8>,
+    cmdline: Vec<u8>,
+    ramdisk: Vec<u8>,
+    metadata: Vec<u8>,
+}
+
+fn prepare_payload(
+    kernel_path: &Path,
+    cmdline: &str,
+    metadata: &MetadataFields<'_>,
+) -> Result<KernelPayload, EifError> {
+    let kernel_data = fs::read(kernel_path).context(ReadKernelSnafu { path: kernel_path })?;
+    ensure!(!kernel_data.is_empty(), EmptyKernelSnafu);
+    // Note: arch-specific pre-processing (zboot unwrap on arm64) happens in
+    // the caller, since it depends on `target_arch` — kept out of this helper
+    // so both signed and unsigned builders can share it.
+    Ok(KernelPayload {
+        kernel: kernel_data,
+        cmdline: cmdline.as_bytes().to_vec(),
+        // Empty RAMDISK section (12-byte header, zero payload). This is
+        // well-formed per the EIF spec: `EifSectionRamdisk` has no
+        // minimum-count requirement, only an ordering constraint. Bottlerocket
+        // sidecar EIFs mount the rootfs from a virtio-blk device with
+        // dm-verity, so no initramfs is needed. NOTE: stock `nitro-cli`
+        // -produced EIFs always have two ramdisks (bootstrap + customer);
+        // consumers that assume that convention (e.g. anything computing PCR2
+        // over concatenated ramdisks) will see empty input here.
+        ramdisk: Vec::new(),
+        metadata: build_metadata(
+            metadata.build_tool_version,
+            metadata.kernel_version,
+            metadata.image_version,
+            metadata.build_time,
+        )
+        .into_bytes(),
+    })
 }
 
 /// Build and write an EIF to the specified output path.
@@ -197,113 +410,647 @@ pub fn build_eif(
     target_arch: TargetArch,
     metadata: &MetadataFields<'_>,
 ) -> Result<(), EifError> {
-    let kernel_data = fs::read(kernel_path).context(ReadKernelSnafu { path: kernel_path })?;
-    ensure!(!kernel_data.is_empty(), EmptyKernelSnafu);
-    // Arch-specific pre-processing. On arm64 this unwraps EFI zboot images
-    // (recent Bottlerocket kernel-kit ships `vmlinuz` as a zboot-wrapped
-    // zstd-compressed `Image`) so Firecracker's PE loader sees the flat
-    // arm64 `Image` it expects. On x86_64 this is a no-op.
-    let kernel_data =
-        kernel::prepare_kernel(kernel_data, target_arch).context(PrepareKernelSnafu)?;
+    let mut payload = prepare_payload(kernel_path, cmdline, metadata)?;
+    payload.kernel =
+        kernel::prepare_kernel(payload.kernel, target_arch).context(PrepareKernelSnafu)?;
 
-    let cmdline_data = cmdline.as_bytes();
-    // Empty RAMDISK section (12-byte header, zero payload). This is well-formed
-    // per the EIF spec: `EifSectionRamdisk` has no minimum-count requirement,
-    // only an ordering constraint (must follow the kernel section). Bottlerocket
-    // sidecar EIFs mount the rootfs from a virtio-blk device with dm-verity, so
-    // no initramfs is needed. NOTE: stock `nitro-cli`-produced EIFs always have
-    // two ramdisks (bootstrap + customer); consumers that assume that convention
-    // (e.g. anything computing PCR2 over concatenated ramdisks) will see empty
-    // input here. Our custom launcher handles this correctly.
-    let ramdisk_data: &[u8] = &[];
-    let metadata_json = build_metadata(
-        metadata.build_tool_version,
-        metadata.kernel_version,
-        metadata.image_version,
-        metadata.build_time,
-    );
-    let metadata_data = metadata_json.as_bytes();
-
-    let num_sections: u16 = 4;
-    debug_assert!(
-        (num_sections as usize) <= MAX_NUM_SECTIONS,
-        "num_sections must fit within the EIF v4 header's section table"
-    );
-
-    // Calculate total size
-    let sections_size = (EIF_SECTION_HEADER_SIZE * num_sections as usize)
-        + kernel_data.len()
-        + cmdline_data.len()
-        + ramdisk_data.len()
-        + metadata_data.len();
-    let total_size = EIF_HEADER_SIZE + sections_size;
-
-    let mut eif = Vec::with_capacity(total_size);
-
-    // --- Header ---
-    eif.extend_from_slice(&EIF_MAGIC);
-    eif.extend_from_slice(&EIF_HDR_VERSION.to_be_bytes());
-    eif.extend_from_slice(&(target_arch.flags() | pcie_flags).to_be_bytes());
-    eif.extend_from_slice(&default_mem.to_be_bytes());
-    eif.extend_from_slice(&default_cpus.to_be_bytes());
-    eif.extend_from_slice(&0u16.to_be_bytes()); // reserved
-    eif.extend_from_slice(&num_sections.to_be_bytes());
-
-    // Section offsets
-    let kernel_offset = EIF_HEADER_SIZE as u64;
-    let cmdline_offset = kernel_offset + EIF_SECTION_HEADER_SIZE as u64 + kernel_data.len() as u64;
-    let ramdisk_offset =
-        cmdline_offset + EIF_SECTION_HEADER_SIZE as u64 + cmdline_data.len() as u64;
-    let metadata_offset =
-        ramdisk_offset + EIF_SECTION_HEADER_SIZE as u64 + ramdisk_data.len() as u64;
-
-    let offsets = [
-        kernel_offset,
-        cmdline_offset,
-        ramdisk_offset,
-        metadata_offset,
+    // Unsigned layout: KERNEL, CMDLINE, RAMDISK, METADATA. Byte-for-byte
+    // compatible with the pre-signing implementation; regression-guarded by
+    // `test_unsigned_eif_layout_unchanged`.
+    let entries = [
+        SectionEntry {
+            ty: EIF_SECTION_KERNEL,
+            data: Cow::Borrowed(&payload.kernel),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_CMDLINE,
+            data: Cow::Borrowed(&payload.cmdline),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_RAMDISK,
+            data: Cow::Borrowed(&payload.ramdisk),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_METADATA,
+            data: Cow::Borrowed(&payload.metadata),
+        },
     ];
-    for i in 0..MAX_NUM_SECTIONS {
-        let val = if i < offsets.len() { offsets[i] } else { 0 };
-        eif.extend_from_slice(&val.to_be_bytes());
-    }
 
-    // Section sizes
-    let sizes = [
-        kernel_data.len() as u64,
-        cmdline_data.len() as u64,
-        ramdisk_data.len() as u64,
-        metadata_data.len() as u64,
-    ];
-    for i in 0..MAX_NUM_SECTIONS {
-        let val = if i < sizes.len() { sizes[i] } else { 0 };
-        eif.extend_from_slice(&val.to_be_bytes());
-    }
+    let header_flags = target_arch.flags() | pcie_flags;
+    let eif = write_eif_bytes(default_mem, default_cpus, header_flags, &entries)?;
 
-    eif.extend_from_slice(&0u32.to_be_bytes()); // unused
-    eif.extend_from_slice(&0u32.to_be_bytes()); // crc32 placeholder
-
-    debug_assert_eq!(eif.len(), EIF_HEADER_SIZE);
-
-    // --- Sections ---
-    write_section(&mut eif, EIF_SECTION_KERNEL, &kernel_data);
-    write_section(&mut eif, EIF_SECTION_CMDLINE, cmdline_data);
-    write_section(&mut eif, EIF_SECTION_RAMDISK, ramdisk_data);
-    write_section(&mut eif, EIF_SECTION_METADATA, metadata_data);
-
-    // Compute CRC32 (exclude CRC field itself)
-    let mut hasher = Crc32Hasher::new();
-    hasher.update(&eif[..EIF_CRC32_OFFSET]);
-    hasher.update(&eif[EIF_CRC32_OFFSET + 4..]);
-    let crc = hasher.finalize();
-    eif[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4].copy_from_slice(&crc.to_be_bytes());
-
-    // Write to file
     let mut file = fs::File::create(output_path).context(WriteOutputSnafu { path: output_path })?;
     file.write_all(&eif)
         .context(WriteOutputSnafu { path: output_path })?;
 
     Ok(())
+}
+
+/// Build and write a *signed* EIF to the specified output path.
+///
+/// Layout: KERNEL, CMDLINE, RAMDISK, METADATA, SIGNATURE. The upstream
+/// reference implementation places the SIGNATURE section last (see
+/// `EifBuilder::write_to` in aws-nitro-enclaves-image-format), and
+/// `PcrSignatureChecker::from_eif` scans the section table looking for the
+/// signature type — placement within the table does not affect validation.
+///
+/// PCR0 is computed as `SHA-384(48 zero bytes || SHA-384(kernel || cmdline
+/// || ramdisks))` per the spec: kernel and cmdline and ramdisk **data**
+/// (headers excluded), with the section-signature and metadata sections
+/// **not** included. See <https://github.com/aws/aws-nitro-enclaves-image-format>.
+#[allow(clippy::too_many_arguments)]
+pub fn build_signed_eif(
+    kernel_path: &Path,
+    cmdline: &str,
+    output_path: &Path,
+    default_mem: u64,
+    default_cpus: u64,
+    pcie_flags: u16,
+    target_arch: TargetArch,
+    metadata: &MetadataFields<'_>,
+    signer: &dyn Signer,
+) -> Result<(), EifError> {
+    let mut payload = prepare_payload(kernel_path, cmdline, metadata)?;
+    payload.kernel =
+        kernel::prepare_kernel(payload.kernel, target_arch).context(PrepareKernelSnafu)?;
+
+    let pcr0 = compute_pcr0(&payload.kernel, &payload.cmdline, &[&payload.ramdisk]);
+    // `build_signature_section` enforces `SIGNATURE_MAX_SIZE` internally with
+    // per-component size attribution in the error message; no additional
+    // check needed here.
+    let signature_bytes = build_signature_section(signer, &pcr0)?;
+
+    let entries = [
+        SectionEntry {
+            ty: EIF_SECTION_KERNEL,
+            data: Cow::Borrowed(&payload.kernel),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_CMDLINE,
+            data: Cow::Borrowed(&payload.cmdline),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_RAMDISK,
+            data: Cow::Borrowed(&payload.ramdisk),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_METADATA,
+            data: Cow::Borrowed(&payload.metadata),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_SIGNATURE,
+            data: Cow::Borrowed(&signature_bytes),
+        },
+    ];
+
+    let header_flags = target_arch.flags() | pcie_flags;
+    let eif = write_eif_bytes(default_mem, default_cpus, header_flags, &entries)?;
+
+    let mut file = fs::File::create(output_path).context(WriteOutputSnafu { path: output_path })?;
+    file.write_all(&eif)
+        .context(WriteOutputSnafu { path: output_path })?;
+
+    Ok(())
+}
+
+/// One parsed section from an existing EIF: type + raw data bytes.
+///
+/// Produced by [`read_sections`]. Section headers are stripped; `data` is the
+/// section payload only. Used by [`resign_eif`] to rebuild the section list
+/// after replacing the signature section without materially decoding the
+/// kernel/cmdline/ramdisk/metadata contents.
+#[derive(Debug)]
+pub struct ParsedSection {
+    /// Section type (one of the `EIF_SECTION_*` constants).
+    pub ty: u16,
+    /// Section payload bytes (no section header).
+    pub data: Vec<u8>,
+}
+
+/// Header fields recovered from an EIF's fixed header.
+struct EifHeader {
+    default_mem: u64,
+    default_cpus: u64,
+    flags: u16,
+}
+
+/// Parse the fixed header of an EIF and validate the magic and version.
+fn read_header(bytes: &[u8]) -> Result<EifHeader, EifError> {
+    ensure!(
+        bytes.len() >= EIF_HEADER_SIZE,
+        ParseInputSnafu {
+            reason: format!(
+                "input is {} bytes, smaller than the {}-byte EIF header",
+                bytes.len(),
+                EIF_HEADER_SIZE
+            ),
+        }
+    );
+    ensure!(
+        bytes[0..4] == EIF_MAGIC,
+        ParseInputSnafu {
+            reason: "bad EIF magic".to_string(),
+        }
+    );
+    let version = u16::from_be_bytes([bytes[4], bytes[5]]);
+    ensure!(
+        version == EIF_HDR_VERSION,
+        ParseInputSnafu {
+            reason: format!(
+                "unsupported EIF header version {version} (expected {EIF_HDR_VERSION})"
+            ),
+        }
+    );
+    let flags = u16::from_be_bytes([bytes[6], bytes[7]]);
+    let default_mem = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
+    let default_cpus = u64::from_be_bytes(bytes[16..24].try_into().unwrap());
+    Ok(EifHeader {
+        default_mem,
+        default_cpus,
+        flags,
+    })
+}
+
+/// Read the section list out of an already-serialized EIF.
+///
+/// Sections are returned in the order they appear in the header's
+/// offset/size tables. Section headers (12 bytes each) are validated against
+/// the table entries and stripped; only the payload bytes are returned. This
+/// is the shared parser used by [`resign_eif`] and (in tests) by
+/// `extract_section`.
+pub fn read_sections(eif_bytes: &[u8]) -> Result<Vec<ParsedSection>, EifError> {
+    read_header(eif_bytes)?;
+    // Header layout (post-magic/version/flags/mem/cpus/reserved):
+    //   num_sections: u16
+    //   offsets: [u64; MAX_NUM_SECTIONS]
+    //   sizes:   [u64; MAX_NUM_SECTIONS]
+    //   unused: u32
+    //   crc32:  u32
+    let num_sections_off = 4 + 2 + 2 + 8 + 8 + 2; // magic+ver+flags+mem+cpus+reserved
+    let num_sections =
+        u16::from_be_bytes([eif_bytes[num_sections_off], eif_bytes[num_sections_off + 1]]) as usize;
+    ensure!(
+        num_sections <= MAX_NUM_SECTIONS,
+        ParseInputSnafu {
+            reason: format!(
+                "num_sections={num_sections} exceeds MAX_NUM_SECTIONS={MAX_NUM_SECTIONS}"
+            ),
+        }
+    );
+
+    let offsets_start = num_sections_off + 2;
+    let sizes_start = offsets_start + MAX_NUM_SECTIONS * 8;
+
+    let mut sections = Vec::with_capacity(num_sections);
+    for i in 0..num_sections {
+        let off = u64::from_be_bytes(
+            eif_bytes[offsets_start + i * 8..offsets_start + (i + 1) * 8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let size = u64::from_be_bytes(
+            eif_bytes[sizes_start + i * 8..sizes_start + (i + 1) * 8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        // Reject offsets that fall inside the fixed EIF header. Without this
+        // check, `compute_pcr0` in the resign path would hash header bytes
+        // as if they were kernel/cmdline data — a hardening gap a hand-crafted
+        // input EIF could exploit even though real rpm2eif output is always
+        // well-formed.
+        ensure!(
+            off >= EIF_HEADER_SIZE,
+            ParseInputSnafu {
+                reason: format!(
+                    "section {i} offset {off} lies within the fixed EIF header (< {EIF_HEADER_SIZE})"
+                ),
+            }
+        );
+        ensure!(
+            off.checked_add(EIF_SECTION_HEADER_SIZE)
+                .and_then(|o| o.checked_add(size))
+                .is_some_and(|end| end <= eif_bytes.len()),
+            ParseInputSnafu {
+                reason: format!(
+                    "section {i} at offset {off} size {size} exceeds file length {}",
+                    eif_bytes.len(),
+                ),
+            }
+        );
+        let ty = u16::from_be_bytes([eif_bytes[off], eif_bytes[off + 1]]);
+        // Section header carries its own size at bytes 4..12; validate it
+        // matches the size table so a malformed file doesn't slip through.
+        let hdr_size =
+            u64::from_be_bytes(eif_bytes[off + 4..off + 12].try_into().unwrap()) as usize;
+        ensure!(
+            hdr_size == size,
+            ParseInputSnafu {
+                reason: format!(
+                    "section {i} header size {hdr_size} disagrees with table size {size}",
+                ),
+            }
+        );
+        let data_off = off + EIF_SECTION_HEADER_SIZE;
+        sections.push(ParsedSection {
+            ty,
+            data: eif_bytes[data_off..data_off + size].to_vec(),
+        });
+    }
+    Ok(sections)
+}
+
+/// Summary of an EIF's contents as a `serde_json::Value`.
+///
+/// Consumers (notably `eif2eif`) use this to carry `BuildMetadata` forward
+/// across a repack: rpm2eif populates `KernelVersion` and `BuildToolVersion`
+/// from the source rootfs' installed RPMs; eif2eif has no rootfs to query,
+/// so it reads them out of the input EIF via this function and forwards them
+/// on the `eif-builder build` invocation that produces the new EIF.
+///
+/// Output shape (stable — this JSON is a public contract):
+///
+/// ```json
+/// {
+///   "eif_version": 4,
+///   "is_signed": true,
+///   "cmdline": "root=/dev/dm-0 ro ...",
+///   "kernel_size": 50331648,
+///   "ramdisk_count": 0,
+///   "sections": [
+///     { "type": "KERNEL",   "type_id": 1, "size": 50331648 },
+///     { "type": "CMDLINE",  "type_id": 2, "size":      431 },
+///     { "type": "METADATA", "type_id": 5, "size":      254 },
+///     { "type": "SIGNATURE","type_id": 4, "size":     2115 }
+///   ],
+///   "metadata": {
+///     "ImageName": "bottlerocket-sidecar",
+///     "BuildMetadata": {
+///       "KernelVersion": "6.18.30-1.1779997967.64782dc8.br1",
+///       "BuildToolVersion": "0.21.0",
+///       ...
+///     },
+///     ...
+///   }
+/// }
+/// ```
+///
+/// `metadata` is `null` when the EIF has no METADATA section (rare — every
+/// EIF our pipeline produces has one, but a hand-crafted or foreign-tool EIF
+/// might not). `cmdline` is the CMDLINE section decoded as UTF-8 with a
+/// single trailing NUL byte stripped if present (rpm2eif appends one; the
+/// enclave loader treats it as a C string).
+///
+/// Errors:
+/// - `ReadInput`  — I/O reading `input`.
+/// - `ParseInput` — malformed header/section table (via [`read_sections`]).
+/// - `MetadataDecode` — METADATA section is not valid UTF-8 JSON.
+///
+/// Note: CMDLINE is not required to be UTF-8, but Bottlerocket's rpm2eif
+/// always writes it as ASCII/UTF-8. If a non-UTF-8 CMDLINE ever appears here,
+/// we fall back to the lossy replacement encoding rather than fail — the
+/// primary consumer (metadata carry-forward) does not depend on CMDLINE.
+pub fn describe_eif(input: &Path) -> Result<serde_json::Value, EifError> {
+    let bytes = fs::read(input).context(ReadInputSnafu { path: input })?;
+    let sections = read_sections(&bytes)?;
+
+    let mut kernel_size: u64 = 0;
+    let mut cmdline_bytes: Option<Vec<u8>> = None;
+    let mut ramdisk_count: usize = 0;
+    let mut is_signed = false;
+    let mut metadata_bytes: Option<Vec<u8>> = None;
+    let mut section_summaries: Vec<serde_json::Value> = Vec::with_capacity(sections.len());
+    for s in &sections {
+        section_summaries.push(serde_json::json!({
+            "type": section_type_name(s.ty),
+            "type_id": s.ty,
+            "size": s.data.len(),
+        }));
+        match s.ty {
+            EIF_SECTION_KERNEL => kernel_size = s.data.len() as u64,
+            EIF_SECTION_CMDLINE => cmdline_bytes = Some(s.data.clone()),
+            EIF_SECTION_RAMDISK => ramdisk_count += 1,
+            EIF_SECTION_SIGNATURE => is_signed = true,
+            EIF_SECTION_METADATA => metadata_bytes = Some(s.data.clone()),
+            _ => {} // still reported in `sections`, just not summarized
+        }
+    }
+
+    // Decode METADATA as JSON. Fail loudly here rather than substitute
+    // `null`, so the caller (eif2eif) doesn't silently drop KernelVersion
+    // when the section is present-but-garbled: that would reproduce the
+    // exact bug this function exists to prevent.
+    let metadata_value = match metadata_bytes {
+        Some(raw) => {
+            let text = std::str::from_utf8(&raw).map_err(|e| EifError::MetadataDecode {
+                reason: format!("invalid UTF-8 at byte {}: {e}", e.valid_up_to()),
+            })?;
+            serde_json::from_str::<serde_json::Value>(text).map_err(|e| {
+                EifError::MetadataDecode {
+                    reason: format!("JSON parse: {e}"),
+                }
+            })?
+        }
+        None => serde_json::Value::Null,
+    };
+
+    // CMDLINE: decode leniently. rpm2eif writes ASCII/UTF-8 with an optional
+    // trailing NUL. Lossy-decode is safe because no consumer of `describe_eif`
+    // relies on the exact byte content of `cmdline` — the field is
+    // informational.
+    let cmdline_str = cmdline_bytes.as_deref().map(|b| {
+        let trimmed = match b.last() {
+            Some(&0) => &b[..b.len() - 1],
+            _ => b,
+        };
+        String::from_utf8_lossy(trimmed).into_owned()
+    });
+
+    Ok(serde_json::json!({
+        "eif_version": EIF_HDR_VERSION,
+        "is_signed": is_signed,
+        "cmdline": cmdline_str,
+        "kernel_size": kernel_size,
+        "ramdisk_count": ramdisk_count,
+        "sections": section_summaries,
+        "metadata": metadata_value,
+    }))
+}
+
+/// Re-sign an existing EIF: replace (or append) its `EifSectionSignature`
+/// (0x04) section without touching the kernel, cmdline, ramdisk, or metadata
+/// sections.
+///
+/// The kernel section is treated as opaque bytes: whatever the input carries
+/// is exactly what is embedded in the output. This matters on arm64, where
+/// the on-disk kernel section is the *prepared* (post-zboot-unwrap) form; we
+/// do not re-run `prepare_kernel`. PCR0 is recomputed from the input's
+/// existing kernel + cmdline + ramdisk bytes, so the new signature covers
+/// the same measurement the enclave would see.
+///
+/// Layout of the output matches [`build_signed_eif`]: KERNEL, CMDLINE, one
+/// or more RAMDISKs, METADATA, SIGNATURE (last). Order is preserved from the
+/// input for non-signature sections; the SIGNATURE section is placed last.
+///
+/// When the input is unsigned, a new SIGNATURE section is appended. When the
+/// input is already signed, the existing SIGNATURE section is dropped and a
+/// new one takes its place. `MAX_NUM_SECTIONS` is enforced in both cases.
+pub fn resign_eif(input: &Path, output: &Path, signer: &dyn Signer) -> Result<(), EifError> {
+    let bytes = fs::read(input).context(ReadInputSnafu { path: input })?;
+    let header = read_header(&bytes)?;
+    let sections = read_sections(&bytes)?;
+
+    // Extract kernel/cmdline/ramdisks for PCR0. We compute PCR0 from the
+    // *input's* on-disk bytes rather than re-running `prepare_payload`, so
+    // the resign path is intrinsically forward-compatible with any future
+    // change to how kernel bytes are prepared.
+    let mut kernel: Option<&[u8]> = None;
+    let mut cmdline: Option<&[u8]> = None;
+    let mut ramdisks: Vec<&[u8]> = Vec::new();
+    for s in &sections {
+        match s.ty {
+            EIF_SECTION_KERNEL => kernel = Some(&s.data),
+            EIF_SECTION_CMDLINE => cmdline = Some(&s.data),
+            EIF_SECTION_RAMDISK => ramdisks.push(&s.data),
+            _ => {}
+        }
+    }
+    let kernel = kernel.ok_or_else(|| EifError::ParseInput {
+        reason: "input EIF has no KERNEL section".to_string(),
+    })?;
+    let cmdline = cmdline.ok_or_else(|| EifError::ParseInput {
+        reason: "input EIF has no CMDLINE section".to_string(),
+    })?;
+    // A well-formed EIF has at least one RAMDISK section (possibly empty).
+    // We tolerate none in case a caller hand-authored an EIF without one;
+    // `compute_pcr0` accepts an empty ramdisk slice.
+
+    let pcr0 = compute_pcr0(kernel, cmdline, &ramdisks);
+    let signature_bytes = build_signature_section(signer, &pcr0)?;
+
+    // Rebuild the section list: preserve non-signature sections in order,
+    // then append the new signature section last (matching `build_signed_eif`).
+    let mut entries: Vec<SectionEntry<'_>> = Vec::with_capacity(sections.len() + 1);
+    for s in &sections {
+        if s.ty == EIF_SECTION_SIGNATURE {
+            continue; // drop the old signature
+        }
+        entries.push(SectionEntry {
+            ty: s.ty,
+            data: Cow::Borrowed(&s.data),
+        });
+    }
+    // Guard MAX_NUM_SECTIONS at the resign site so the error message
+    // identifies the "resign has no room to append its section" case
+    // rather than surfacing as a generic overflow inside `write_eif_bytes`
+    // (which also enforces the invariant, as a backstop).
+    ensure!(
+        entries.len() < MAX_NUM_SECTIONS,
+        TooManySectionsSnafu {
+            count: entries.len() + 1
+        },
+    );
+    entries.push(SectionEntry {
+        ty: EIF_SECTION_SIGNATURE,
+        data: Cow::Borrowed(&signature_bytes),
+    });
+
+    let eif = write_eif_bytes(
+        header.default_mem,
+        header.default_cpus,
+        header.flags,
+        &entries,
+    )?;
+    let mut file = fs::File::create(output).context(WriteOutputSnafu { path: output })?;
+    file.write_all(&eif)
+        .context(WriteOutputSnafu { path: output })?;
+    Ok(())
+}
+
+/// Compute PCR0 exactly as the reference `EifBuilder::image_hasher` does.
+///
+/// The upstream algorithm feeds kernel-data, then cmdline-data, then each
+/// ramdisk's data in order into a single `EifHasher`, which performs a TPM-
+/// style extend: `PCR = SHA-384(48 zero bytes || SHA-384(concatenated bytes))`.
+/// Section-signature and metadata data are deliberately not included.
+///
+/// This function is the regression guard for interoperability with
+/// `PcrSignatureChecker::verify`.
+fn compute_pcr0(kernel_data: &[u8], cmdline_data: &[u8], ramdisks: &[&[u8]]) -> Vec<u8> {
+    use aws_lc_rs::digest::{digest, SHA384};
+
+    // Inner: SHA-384 over kernel || cmdline || ramdisks_data
+    let mut inner = Vec::with_capacity(kernel_data.len() + cmdline_data.len() + 64);
+    inner.extend_from_slice(kernel_data);
+    inner.extend_from_slice(cmdline_data);
+    for r in ramdisks {
+        inner.extend_from_slice(r);
+    }
+    let inner_digest = digest(&SHA384, &inner);
+
+    // Outer (TPM extend): SHA-384(48 zero bytes || inner_digest)
+    let mut outer_input = vec![0u8; 48];
+    outer_input.extend_from_slice(inner_digest.as_ref());
+    let outer_digest = digest(&SHA384, &outer_input);
+    outer_digest.as_ref().to_vec()
+}
+
+/// Local mirror of upstream `aws-nitro-enclaves-image-format::defs::PcrInfo`.
+///
+/// The upstream struct is what `PcrSignatureChecker::verify` reconstructs and
+/// then byte-compares against the COSE_Sign1 payload:
+///
+/// ```ignore
+/// let pcr_info  = PcrInfo::new(0, pcr0_bytes);
+/// let measured  = serde_cbor::to_vec(&pcr_info)?;
+/// let coses     = pcr_sign.get_payload(...)?;
+/// self.sign_check = Some(measured == coses);   // exact byte compare
+/// ```
+///
+/// Because the comparison is byte-exact, our payload must serialize to the
+/// *same* CBOR bytes as upstream's `PcrInfo`. `serde_cbor` encodes `Vec<u8>`
+/// as a CBOR **array of integers** (major type 4), not a byte string — the
+/// standard serde `Vec<T>` path calls `serialize_seq`. That is the wire
+/// shape upstream produces, and the shape this struct produces here.
+///
+/// Field names and order must match upstream exactly. `register_index` is
+/// `i32` upstream — do not widen.
+#[derive(Serialize, Deserialize)]
+struct PcrInfo {
+    register_index: i32,
+    register_value: Vec<u8>,
+}
+
+/// Local mirror of upstream `aws-nitro-enclaves-image-format::defs::PcrSignature`.
+///
+/// The outer envelope of the `EifSectionSignature` is a `Vec<PcrSignature>`
+/// serialized with `serde_cbor::to_vec`. The upstream `describe-eif` path
+/// decodes it with `serde_cbor::from_slice::<Vec<PcrSignature>>`, so we
+/// must serialize with the *same* serde derive on a struct with the *same*
+/// field shape (`Vec<u8>` — not `serde_bytes::ByteBuf`), or the decode will
+/// fail with `invalid type: byte array, expected a sequence`.
+#[derive(Serialize, Deserialize)]
+struct PcrSignature {
+    signing_certificate: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+/// Build the CBOR bytes that go into the `EifSectionSignature` (0x04) section.
+///
+/// Shape (from `aws-nitro-enclaves-image-format`, produced by
+/// `serde_cbor::to_vec(&Vec<PcrSignature>)`):
+///
+/// ```text
+/// Array(1) {
+///     Map(2) {
+///         "signing_certificate": <PEM cert bytes as CBOR Array-of-uint>,
+///         "signature":           <COSE_Sign1 bytes as CBOR Array-of-uint>,
+///     }
+/// }
+/// ```
+///
+/// Note: the byte fields decode as CBOR **arrays of integers** (major
+/// type 4), not byte strings (major type 2). This is what `serde_cbor`
+/// emits for a `Vec<u8>` under a plain `#[derive(Serialize)]` — the
+/// standard serde `Vec<T>` path — and it is what upstream produces and
+/// upstream consumers expect. Emitting byte strings here (via
+/// `ciborium::Value::Bytes` or `serde_bytes`) would make the CBOR envelope
+/// unparseable by `serde_cbor::from_slice::<Vec<PcrSignature>>` and would
+/// desync the COSE payload from the verifier's `measured_payload`
+/// recomputation, silently failing signature verification.
+fn build_signature_section(signer: &dyn Signer, pcr0: &[u8]) -> Result<Vec<u8>, EifError> {
+    use coset::{CborSerializable, CoseSign1Builder, HeaderBuilder};
+
+    // Payload: `serde_cbor::to_vec(&PcrInfo { register_index: 0,
+    // register_value: pcr0 })`. Byte-for-byte identical to what
+    // `PcrSignatureChecker::verify` reconstructs as `measured_payload`,
+    // which is the exact-byte-compare peer for the COSE payload.
+    let payload = serde_cbor::to_vec(&PcrInfo {
+        register_index: 0,
+        register_value: pcr0.to_vec(),
+    })
+    .context(CborEncodePayloadSnafu)?;
+
+    // Translate our crate-local `SignAlg` to the COSE `iana::Algorithm`
+    // value at the one site that depends on `coset`, so the `Signer` trait
+    // stays version-independent of `coset`.
+    let alg = match signer.algorithm() {
+        signer::SignAlg::Es256 => coset::iana::Algorithm::ES256,
+        signer::SignAlg::Es384 => coset::iana::Algorithm::ES384,
+    };
+    let protected = HeaderBuilder::new().algorithm(alg).build();
+
+    // `create_signature` is called on the pre-hash `Sig_structure1` bytes;
+    // the signer produces the raw ECDSA `r||s` signature over that.
+    let sign1 = CoseSign1Builder::new()
+        .protected(protected)
+        .payload(payload)
+        .try_create_signature(&[], |tbs| signer.sign_cose(tbs))
+        .context(SignSnafu)?
+        .build();
+
+    let cose_bytes = sign1.to_vec().context(CoseBuildSnafu)?;
+    let cose_size = cose_bytes.len();
+
+    // Certificate goes into the section as raw PEM bytes (the reference
+    // reader uses `X509::from_pem` on it).
+    let cert_pem = signer.cert_pem().to_vec();
+    let cert_pem_size = cert_pem.len();
+
+    // Outer envelope: `serde_cbor::to_vec(&Vec<PcrSignature>)`. Using the
+    // upstream-shape struct + the same serde_cbor serializer guarantees
+    // the wire bytes are what `describe-eif`'s
+    // `from_slice::<Vec<PcrSignature>>` accepts.
+    let envelope = vec![PcrSignature {
+        signing_certificate: cert_pem,
+        signature: cose_bytes,
+    }];
+    let out = serde_cbor::to_vec(&envelope).context(CborEncodeSignatureSnafu)?;
+    // Enforce SIGNATURE_MAX_SIZE here so any caller of
+    // `build_signature_section` (not just `build_signed_eif`) gets the
+    // check. The error identifies the two biggest contributors — a bulky
+    // cert chain vs. an unexpectedly large COSE payload — so operators
+    // don't have to guess.
+    ensure!(
+        out.len() <= SIGNATURE_MAX_SIZE,
+        SignatureTooLargeSnafu {
+            size: out.len(),
+            cert_pem_size,
+            cose_size,
+        },
+    );
+    Ok(out)
+}
+
+/// Shared DER helpers for test code. `wrap_der` produces a DER TLV with
+/// short/long-form length encoding; used by both `signer.rs` (for SPKI
+/// synthesis) and by `lib.rs` tests (for the minimal self-signed cert).
+///
+/// Kept in one place so the length-encoding logic can't drift across the
+/// crate — the family of "hand-rolled DER" was flagged in code review as a
+/// maintenance risk when duplicated.
+#[cfg(test)]
+pub(crate) mod der_helpers {
+    pub(crate) fn wrap_der(tag: u8, body: &[u8]) -> Vec<u8> {
+        let mut out = vec![tag];
+        let n = body.len();
+        if n < 0x80 {
+            out.push(n as u8);
+        } else if n < 0x100 {
+            out.push(0x81);
+            out.push(n as u8);
+        } else if n < 0x10000 {
+            out.push(0x82);
+            out.push((n >> 8) as u8);
+            out.push((n & 0xff) as u8);
+        } else {
+            out.push(0x83);
+            out.push((n >> 16) as u8);
+            out.push((n >> 8) as u8);
+            out.push((n & 0xff) as u8);
+        }
+        out.extend_from_slice(body);
+        out
+    }
 }
 
 #[cfg(test)]
@@ -496,5 +1243,907 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, EifError::PrepareKernel { .. }), "err={err:?}");
+    }
+
+    // -------- PCR0 / signature tests --------
+
+    #[test]
+    fn test_pcr0_matches_spec() {
+        // Reference vector: PCR0 = SHA-384(48 zero bytes || SHA-384(kernel || cmdline || ramdisks_data))
+        // Recompute independently via aws-lc-rs to be sure the helper isn't
+        // silently drifting.
+        use aws_lc_rs::digest::{digest, SHA384};
+
+        let kernel = b"FAKE_KERNEL".to_vec();
+        let cmdline = b"console=ttyS0".to_vec();
+        let ramdisk: Vec<u8> = Vec::new();
+
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&kernel);
+        inner.extend_from_slice(&cmdline);
+        inner.extend_from_slice(&ramdisk);
+        let inner_d = digest(&SHA384, &inner);
+        let mut outer = vec![0u8; 48];
+        outer.extend_from_slice(inner_d.as_ref());
+        let expected = digest(&SHA384, &outer).as_ref().to_vec();
+
+        let got = compute_pcr0(&kernel, &cmdline, &[&ramdisk]);
+        assert_eq!(got, expected, "PCR0 must match the reference spec");
+        assert_eq!(got.len(), 48, "SHA-384 output is 48 bytes");
+    }
+
+    #[test]
+    fn test_unsigned_eif_layout_unchanged() {
+        // The refactored `write_eif_bytes` path must produce byte-identical
+        // output to the pre-refactor implementation for the same inputs.
+        // We assert on the section-header layout: KERNEL @ EIF_HEADER_SIZE,
+        // then CMDLINE, then RAMDISK, then METADATA.
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("test.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+        )
+        .unwrap();
+        let eif = fs::read(&output).unwrap();
+        // First section header lives at offset EIF_HEADER_SIZE.
+        let ty = u16::from_be_bytes([eif[EIF_HEADER_SIZE], eif[EIF_HEADER_SIZE + 1]]);
+        assert_eq!(ty, EIF_SECTION_KERNEL);
+    }
+
+    /// Build a self-signed ECDSA P-384 cert + private key for tests.
+    ///
+    /// The resulting X.509 is manually DER-encoded so we don't need to pull
+    /// in `x509-cert`'s `builder` feature (which drags in `signature`,
+    /// `rsa`, and friends). Structural validity is what the signer needs:
+    /// `x509-cert::Certificate::from_der` must parse it, and the SPKI OID
+    /// pair must reflect P-384. The `signatureValue` is *not* a valid
+    /// signature over `tbsCertificate` — that's fine because
+    /// `PcrSignatureChecker::verify` only checks the COSE signature, not
+    /// the certificate's own signature chain.
+    #[cfg(test)]
+    fn generate_test_cert_and_key() -> (Vec<u8>, Vec<u8>) {
+        use aws_lc_rs::signature::{EcdsaKeyPair, KeyPair, ECDSA_P384_SHA384_ASN1_SIGNING};
+        let rng = aws_lc_rs::rand::SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, &rng).unwrap();
+        let pem_key = pem::Pem::new("PRIVATE KEY", pkcs8.as_ref().to_vec());
+        let key_pem = pem::encode(&pem_key).into_bytes();
+
+        // Parse the pkcs8 to obtain the SEC1 public key.
+        let key_pair =
+            EcdsaKeyPair::from_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8.as_ref()).unwrap();
+        let sec1_pub = key_pair.public_key().as_ref().to_vec();
+
+        let cert_der = build_p384_self_signed_der(&sec1_pub);
+        let cert_pem_obj = pem::Pem::new("CERTIFICATE", cert_der);
+        let cert_pem = pem::encode(&cert_pem_obj).into_bytes();
+
+        (cert_pem, key_pem)
+    }
+
+    /// Build a minimal, syntactically-valid X.509 Certificate carrying a
+    /// P-384 SPKI for the given SEC1-uncompressed public key. See the
+    /// `generate_test_cert_and_key` doc for what's excluded.
+    #[cfg(test)]
+    fn build_p384_self_signed_der(sec1_pub: &[u8]) -> Vec<u8> {
+        // OIDs:
+        //   id-ecPublicKey        1.2.840.10045.2.1  → 06 07 2A 86 48 CE 3D 02 01
+        //   secp384r1             1.3.132.0.34       → 06 05 2B 81 04 00 22
+        //   ecdsa-with-SHA384     1.2.840.10045.4.3.3 → 06 08 2A 86 48 CE 3D 04 03 03
+        //   id-at-commonName      2.5.4.3            → 06 03 55 04 03
+        let id_ec_pub = [0x06u8, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01];
+        let secp384r1 = [0x06u8, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22];
+        let ecdsa_sha384 = [0x06u8, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x03];
+        let id_cn = [0x06u8, 0x03, 0x55, 0x04, 0x03];
+
+        // AlgorithmIdentifier for SPKI: SEQUENCE { id-ecPublicKey, secp384r1 }.
+        let mut spki_alg_body = Vec::new();
+        spki_alg_body.extend_from_slice(&id_ec_pub);
+        spki_alg_body.extend_from_slice(&secp384r1);
+        let spki_alg = crate::der_helpers::wrap_der(0x30, &spki_alg_body);
+
+        // BIT STRING wrapping the SEC1 public key with 0 unused bits.
+        let mut spki_key = vec![0u8];
+        spki_key.extend_from_slice(sec1_pub);
+        let spki_key_bs = crate::der_helpers::wrap_der(0x03, &spki_key);
+
+        // SubjectPublicKeyInfo ::= SEQUENCE { AlgorithmIdentifier, subjectPublicKey BIT STRING }
+        let mut spki_body = Vec::new();
+        spki_body.extend_from_slice(&spki_alg);
+        spki_body.extend_from_slice(&spki_key_bs);
+        let spki = crate::der_helpers::wrap_der(0x30, &spki_body);
+
+        // Name ::= SEQUENCE OF RDN. One RDN with one AttributeTypeAndValue:
+        //   RelativeDistinguishedName ::= SET OF ATV
+        //   ATV ::= SEQUENCE { type OID (id-at-commonName), value UTF8String("test") }
+        let cn_value = crate::der_helpers::wrap_der(0x0C, b"test"); // UTF8String
+        let mut atv = Vec::new();
+        atv.extend_from_slice(&id_cn);
+        atv.extend_from_slice(&cn_value);
+        let atv_seq = crate::der_helpers::wrap_der(0x30, &atv);
+        let rdn = crate::der_helpers::wrap_der(0x31, &atv_seq); // SET
+        let name = crate::der_helpers::wrap_der(0x30, &rdn); // SEQUENCE OF RDN
+
+        // Validity ::= SEQUENCE { notBefore UTCTime, notAfter UTCTime }
+        // We use two fixed UTCTime values well in the past/future so the
+        // reference `PcrSignatureChecker::verify` (which checks validity)
+        // wouldn't complain either.
+        let not_before = crate::der_helpers::wrap_der(0x17, b"200101000000Z"); // UTCTime
+        let not_after = crate::der_helpers::wrap_der(0x17, b"400101000000Z");
+        let mut validity_body = Vec::new();
+        validity_body.extend_from_slice(&not_before);
+        validity_body.extend_from_slice(&not_after);
+        let validity = crate::der_helpers::wrap_der(0x30, &validity_body);
+
+        // AlgorithmIdentifier for the cert's own signature.
+        let sig_alg = crate::der_helpers::wrap_der(0x30, &ecdsa_sha384);
+
+        // TBSCertificate ::= SEQUENCE {
+        //   version         [0] EXPLICIT INTEGER DEFAULT v1 -- v3 = 2
+        //   serialNumber        INTEGER
+        //   signature           AlgorithmIdentifier
+        //   issuer              Name
+        //   validity            Validity
+        //   subject             Name
+        //   subjectPublicKeyInfo SPKI
+        // }
+        let version_inner = crate::der_helpers::wrap_der(0x02, &[2u8]); // INTEGER 2
+        let version = crate::der_helpers::wrap_der(0xA0, &version_inner); // [0] EXPLICIT
+        let serial = crate::der_helpers::wrap_der(0x02, &[0x01u8]); // INTEGER 1
+        let mut tbs_body = Vec::new();
+        tbs_body.extend_from_slice(&version);
+        tbs_body.extend_from_slice(&serial);
+        tbs_body.extend_from_slice(&sig_alg);
+        tbs_body.extend_from_slice(&name); // issuer
+        tbs_body.extend_from_slice(&validity);
+        tbs_body.extend_from_slice(&name); // subject (self-signed)
+        tbs_body.extend_from_slice(&spki);
+        let tbs = crate::der_helpers::wrap_der(0x30, &tbs_body);
+
+        // signatureValue: minimal BIT STRING with 0 unused bits carrying a
+        // fake DER-encoded ECDSA signature. Structural presence is all
+        // that's needed.
+        let fake_sig_bytes = [0x00u8]; // 0 unused bits
+        let sig_val = crate::der_helpers::wrap_der(0x03, &fake_sig_bytes);
+
+        // Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signatureValue }
+        let mut cert_body = Vec::new();
+        cert_body.extend_from_slice(&tbs);
+        cert_body.extend_from_slice(&sig_alg);
+        cert_body.extend_from_slice(&sig_val);
+        crate::der_helpers::wrap_der(0x30, &cert_body)
+    }
+
+    #[test]
+    fn test_signed_eif_structure() {
+        // Regression guard for the upstream consumer path: the outer envelope
+        // must round-trip through `serde_cbor::from_slice::<Vec<PcrSignature>>`,
+        // which is exactly what `nitro-cli describe-eif` and the reference
+        // `PcrSignatureChecker` do. A prior implementation emitted the byte
+        // fields as CBOR byte strings via `ciborium::Value::Bytes`; that
+        // parses fine with ciborium but fails serde_cbor's `Vec<u8>` decode
+        // with `invalid type: byte array, expected a sequence`, silently
+        // rendering the EIF unusable at attestation time.
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        // Find the signature section by scanning the section-size table.
+        let sig = extract_section(&eif, EIF_SECTION_SIGNATURE)
+            .expect("signature section must be present");
+
+        // Cross-decode via the exact `from_slice::<Vec<PcrSignature>>` shape
+        // used by `aws-nitro-enclaves-image-format::utils::eif_reader`. A
+        // decode error here would mean the emitted EIF is unreadable to
+        // downstream Nitro tooling.
+        let envelope: Vec<PcrSignature> =
+            serde_cbor::from_slice(&sig).expect("outer envelope must decode via serde_cbor");
+        assert_eq!(envelope.len(), 1, "outer envelope must hold one signature");
+        assert_eq!(
+            envelope[0].signing_certificate, cert_pem,
+            "signing_certificate must equal the embedded PEM"
+        );
+        assert!(
+            !envelope[0].signature.is_empty(),
+            "signature bytes must be present"
+        );
+    }
+
+    /// Scan a serialized EIF for a section of the given type and return its
+    /// data bytes. Uses the offset+size tables in the header rather than
+    /// walking section headers, so it is robust against ordering changes.
+    fn extract_section(eif: &[u8], ty: u16) -> Option<Vec<u8>> {
+        // Header layout: magic(4) version(2) flags(2) mem(8) cpus(8) reserved(2) num_sections(2)
+        // then offsets[MAX_NUM_SECTIONS]*u64, sizes[MAX_NUM_SECTIONS]*u64.
+        let num_sections =
+            u16::from_be_bytes([eif[4 + 2 + 2 + 8 + 8 + 2], eif[4 + 2 + 2 + 8 + 8 + 2 + 1]])
+                as usize;
+        let offsets_start = 4 + 2 + 2 + 8 + 8 + 2 + 2;
+        let sizes_start = offsets_start + MAX_NUM_SECTIONS * 8;
+        for i in 0..num_sections {
+            let off = u64::from_be_bytes(
+                eif[offsets_start + i * 8..offsets_start + (i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
+            let size = u64::from_be_bytes(
+                eif[sizes_start + i * 8..sizes_start + (i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
+            // Section header at `off`: ty(2) flags(2) size(8) data(size).
+            let this_ty = u16::from_be_bytes([eif[off], eif[off + 1]]);
+            if this_ty == ty {
+                let data_off = off + EIF_SECTION_HEADER_SIZE;
+                return Some(eif[data_off..data_off + size].to_vec());
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_signed_eif_crc_valid() {
+        // After inserting the signature section, the header CRC must still
+        // validate against the whole file.
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let stored_crc = u32::from_be_bytes(
+            eif[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4]
+                .try_into()
+                .unwrap(),
+        );
+        let mut hasher = Crc32Hasher::new();
+        hasher.update(&eif[..EIF_CRC32_OFFSET]);
+        hasher.update(&eif[EIF_CRC32_OFFSET + 4..]);
+        assert_eq!(hasher.finalize(), stored_crc);
+    }
+
+    /// Regression guard for the *exact* upstream verification path:
+    ///
+    ///     let pcr_info = PcrInfo::new(0, pcr0);
+    ///     let measured = serde_cbor::to_vec(&pcr_info).unwrap();
+    ///     let coses    = pcr_sign.get_payload(...).unwrap();
+    ///     assert_eq!(measured, coses);       // exact byte compare
+    ///
+    /// If our emitted COSE payload is not byte-identical to what
+    /// `serde_cbor::to_vec(&PcrInfo)` produces on the verifier side,
+    /// `sign_check` comes back `false` even when the ECDSA signature is
+    /// cryptographically valid — silent, unrecoverable attestation failure.
+    /// Guard both sides here so a future refactor cannot regress the
+    /// wire-shape invariant.
+    #[test]
+    fn test_pcr_info_payload_matches_upstream_shape() {
+        use coset::{CborSerializable, CoseSign1};
+
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let sig = extract_section(&eif, EIF_SECTION_SIGNATURE).unwrap();
+
+        // Outer envelope decodes via the upstream serde_cbor path.
+        let envelope: Vec<PcrSignature> = serde_cbor::from_slice(&sig).unwrap();
+        assert_eq!(envelope.len(), 1);
+        let cose_bytes = &envelope[0].signature;
+
+        // Extract the COSE payload...
+        let sign1 = CoseSign1::from_slice(cose_bytes).unwrap();
+        let coses_payload = sign1.payload.expect("payload must be present");
+
+        // ...recompute PCR0 the same way `build_signed_eif` did, then
+        // reproduce the upstream `measured_payload` construction exactly.
+        let pcr0 = compute_pcr0(b"FAKE_KERNEL", b"cmd", &[&[][..]]);
+        let measured_payload = serde_cbor::to_vec(&PcrInfo {
+            register_index: 0,
+            register_value: pcr0,
+        })
+        .unwrap();
+
+        assert_eq!(
+            coses_payload, measured_payload,
+            "COSE payload must be byte-identical to serde_cbor(PcrInfo) — \
+             any drift here means downstream `sign_check` returns false"
+        );
+
+        // Also decode the payload directly as `PcrInfo` to catch a
+        // hypothetical future drift where the bytes happen to compare
+        // equal but the shape diverges from the upstream struct.
+        let decoded: PcrInfo = serde_cbor::from_slice(&coses_payload).unwrap();
+        assert_eq!(decoded.register_index, 0);
+        assert_eq!(
+            decoded.register_value.len(),
+            48,
+            "PCR0 must be a 48-byte SHA-384 digest"
+        );
+    }
+
+    #[test]
+    fn test_signed_eif_verifies() {
+        // The COSE_Sign1 in the signature section must verify with the
+        // cert's public key over the recomputed to-be-signed bytes.
+        use aws_lc_rs::signature::{UnparsedPublicKey, ECDSA_P384_SHA384_ASN1};
+        use coset::{CborSerializable, CoseSign1};
+
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+        let pub_key_spki_der = signer.public_key_der().to_vec();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let sig_section = extract_section(&eif, EIF_SECTION_SIGNATURE).unwrap();
+
+        // Outer envelope → COSE_Sign1 bytes, via the upstream serde_cbor
+        // consumer path (`from_slice::<Vec<PcrSignature>>`).
+        let envelope: Vec<PcrSignature> = serde_cbor::from_slice(&sig_section).unwrap();
+        let cose_bytes = envelope[0].signature.clone();
+
+        // The COSE crate can verify with an aws-lc-rs closure; we recompute
+        // Sig_structure1 ourselves and check the signature by hand so this
+        // test doesn't depend on coset's verification path.
+        let sign1 = CoseSign1::from_slice(&cose_bytes).unwrap();
+        let tbs = sign1.tbs_data(&[]);
+        let public_key = UnparsedPublicKey::new(&ECDSA_P384_SHA384_ASN1, &pub_key_spki_der);
+        // The COSE signature is fixed-width `r||s`; convert to ASN.1 DER
+        // for aws-lc-rs' _ASN1 verifier by re-encoding.
+        let sig_der = ecdsa_raw_to_der(&sign1.signature);
+        public_key
+            .verify(&tbs, &sig_der)
+            .expect("signature must verify");
+    }
+
+    /// Decode the outer envelope of the signature section via the exact
+    /// serde_cbor path used by `aws-nitro-enclaves-image-format` on the
+    /// consumer side. Panics if the envelope is malformed.
+    fn decode_envelope(sig_section: &[u8]) -> Vec<PcrSignature> {
+        serde_cbor::from_slice(sig_section).expect("envelope must decode via serde_cbor")
+    }
+
+    /// Convert raw ECDSA `r || s` (fixed 2*n bytes) to a DER-encoded
+    /// `SEQUENCE(INTEGER r, INTEGER s)` for aws-lc-rs' ASN1 verifier.
+    fn ecdsa_raw_to_der(raw: &[u8]) -> Vec<u8> {
+        let n = raw.len() / 2;
+        let r = &raw[..n];
+        let s = &raw[n..];
+        let r_der = der_uint(r);
+        let s_der = der_uint(s);
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&r_der);
+        inner.extend_from_slice(&s_der);
+        let mut out = Vec::new();
+        out.push(0x30); // SEQUENCE
+        out.extend_from_slice(&der_len(inner.len()));
+        out.extend_from_slice(&inner);
+        out
+    }
+
+    fn der_uint(bytes: &[u8]) -> Vec<u8> {
+        // Strip leading zeros; if the high bit is set, prepend one zero.
+        let mut v = bytes;
+        while v.len() > 1 && v[0] == 0 {
+            v = &v[1..];
+        }
+        let mut out = Vec::new();
+        out.push(0x02); // INTEGER
+        let body_len = if v[0] & 0x80 != 0 {
+            v.len() + 1
+        } else {
+            v.len()
+        };
+        out.extend_from_slice(&der_len(body_len));
+        if v[0] & 0x80 != 0 {
+            out.push(0);
+        }
+        out.extend_from_slice(v);
+        out
+    }
+
+    fn der_len(n: usize) -> Vec<u8> {
+        if n < 0x80 {
+            vec![n as u8]
+        } else if n < 0x100 {
+            vec![0x81, n as u8]
+        } else {
+            vec![0x82, (n >> 8) as u8, (n & 0xff) as u8]
+        }
+    }
+
+    #[test]
+    fn test_pcr8_digestable_from_signature() {
+        // PCR8 is defined as SHA-384(48 zero bytes || SHA-384(cert_DER)).
+        // We must be able to extract a PEM cert from the emitted signature
+        // section, parse it, convert to DER, and hash. Since our test cert is
+        // synthesized as raw bytes for lightness, we only check the PEM
+        // extraction step here — a full x509-cert parse round-trip runs in
+        // the signer module tests where a real cert is available.
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let sig = extract_section(&eif, EIF_SECTION_SIGNATURE).unwrap();
+        let envelope = decode_envelope(&sig);
+        let cert = envelope[0].signing_certificate.clone();
+        // Must round-trip through the `pem` crate.
+        let parsed = pem::parse(&cert).unwrap();
+        assert_eq!(parsed.tag(), "CERTIFICATE");
+        // SHA-384 of DER is computable.
+        use aws_lc_rs::digest::{digest, SHA384};
+        let _ = digest(&SHA384, parsed.contents());
+    }
+
+    // -------- resign tests --------
+
+    /// After `resign_eif`, kernel/cmdline/ramdisk/metadata sections must be
+    /// byte-identical to the input; only the signature section (and header
+    /// CRC) may differ. This is the byte-preservation contract the plan
+    /// documents.
+    #[test]
+    fn test_resign_preserves_non_signature_sections() {
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let input = dir.path().join("in.eif");
+        let output = dir.path().join("out.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &input,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields {
+                build_tool_version: "0.20.0",
+                kernel_version: "6.1.152-0.br1",
+                image_version: "",
+                build_time: "",
+            },
+            &signer,
+        )
+        .unwrap();
+
+        // Resign with a fresh (different) key to guarantee the signature
+        // bytes change. Using the same key would work too, but this
+        // strengthens the test (proves we actually re-signed).
+        let (cert2, key2) = generate_test_cert_and_key();
+        let signer2 = signer::LocalSigner::from_pem(&cert2, &key2).unwrap();
+        resign_eif(&input, &output, &signer2).unwrap();
+
+        let in_bytes = fs::read(&input).unwrap();
+        let out_bytes = fs::read(&output).unwrap();
+
+        // Every non-signature section is byte-identical.
+        for ty in [
+            EIF_SECTION_KERNEL,
+            EIF_SECTION_CMDLINE,
+            EIF_SECTION_RAMDISK,
+            EIF_SECTION_METADATA,
+        ] {
+            let a = extract_section(&in_bytes, ty).expect("input has section");
+            let b = extract_section(&out_bytes, ty).expect("output has section");
+            assert_eq!(a, b, "section 0x{ty:02x} differs after resign");
+        }
+    }
+
+    /// Resigning an unsigned EIF adds a signature section; the resulting
+    /// signature verifies against the resign cert.
+    #[test]
+    fn test_resign_unsigned_to_signed() {
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let input = dir.path().join("in.eif");
+        let output = dir.path().join("out.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_eif(
+            &kernel,
+            "cmd",
+            &input,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+        )
+        .unwrap();
+        let in_bytes = fs::read(&input).unwrap();
+        assert!(
+            extract_section(&in_bytes, EIF_SECTION_SIGNATURE).is_none(),
+            "unsigned input must not carry a signature section"
+        );
+
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+        resign_eif(&input, &output, &signer).unwrap();
+
+        let out_bytes = fs::read(&output).unwrap();
+        let sig = extract_section(&out_bytes, EIF_SECTION_SIGNATURE)
+            .expect("resigned output must have a signature section");
+        // Sanity: the CBOR outer envelope decodes via the upstream path.
+        let _envelope = decode_envelope(&sig);
+
+        // CRC still validates over the full file.
+        let stored_crc = u32::from_be_bytes(
+            out_bytes[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4]
+                .try_into()
+                .unwrap(),
+        );
+        let mut hasher = Crc32Hasher::new();
+        hasher.update(&out_bytes[..EIF_CRC32_OFFSET]);
+        hasher.update(&out_bytes[EIF_CRC32_OFFSET + 4..]);
+        assert_eq!(hasher.finalize(), stored_crc);
+    }
+
+    /// Resigning a signed EIF with a different cert replaces the signature
+    /// section (the embedded certificate changes) but leaves the PCR0 that
+    /// gets signed alone (the underlying kernel/cmdline/ramdisks are
+    /// unchanged).
+    #[test]
+    fn test_resign_signed_to_resigned_with_different_cert() {
+        let (cert_a, key_a) = generate_test_cert_and_key();
+        let (cert_b, key_b) = generate_test_cert_and_key();
+        let signer_a = signer::LocalSigner::from_pem(&cert_a, &key_a).unwrap();
+        let signer_b = signer::LocalSigner::from_pem(&cert_b, &key_b).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let input = dir.path().join("in.eif");
+        let output = dir.path().join("out.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &input,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer_a,
+        )
+        .unwrap();
+        resign_eif(&input, &output, &signer_b).unwrap();
+
+        let in_bytes = fs::read(&input).unwrap();
+        let out_bytes = fs::read(&output).unwrap();
+        let sig_in = extract_section(&in_bytes, EIF_SECTION_SIGNATURE).unwrap();
+        let sig_out = extract_section(&out_bytes, EIF_SECTION_SIGNATURE).unwrap();
+        assert_ne!(
+            sig_in, sig_out,
+            "signature section must change after resign"
+        );
+
+        // Pull the embedded cert PEM out and confirm it's the resign cert
+        // (cert_b), not the original (cert_a).
+        let envelope = decode_envelope(&sig_out);
+        assert_eq!(
+            envelope[0].signing_certificate, cert_b,
+            "resigned EIF must embed the resign cert",
+        );
+    }
+
+    /// A hand-crafted EIF whose first section-offset table entry points
+    /// inside the fixed header must be rejected by `read_sections`.
+    /// Regression guard for the P2 hardening: without this check
+    /// `compute_pcr0` in the resign path would hash header bytes as
+    /// kernel/cmdline data.
+    #[test]
+    fn test_read_sections_rejects_offset_in_header() {
+        // Start from a real EIF and rewrite the first offset-table entry
+        // to 0, which falls inside the header.
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let eif_path = dir.path().join("in.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_eif(
+            &kernel,
+            "cmd",
+            &eif_path,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+        )
+        .unwrap();
+        let mut bytes = fs::read(&eif_path).unwrap();
+
+        // The offset table starts at:
+        //   4 (magic) + 2 (ver) + 2 (flags) + 8 (mem) + 8 (cpus)
+        //   + 2 (reserved) + 2 (num_sections) = 28.
+        let offsets_start = 4 + 2 + 2 + 8 + 8 + 2 + 2;
+        // Overwrite the first u64 offset with 0 (points to file start,
+        // well inside the 548-byte header).
+        for b in &mut bytes[offsets_start..offsets_start + 8] {
+            *b = 0;
+        }
+        // Recompute the header CRC so the parser doesn't reject the file
+        // on that instead. `read_sections` doesn't currently verify CRC,
+        // but do it anyway for hygiene.
+        let mut hasher = Crc32Hasher::new();
+        hasher.update(&bytes[..EIF_CRC32_OFFSET]);
+        hasher.update(&bytes[EIF_CRC32_OFFSET + 4..]);
+        let crc = hasher.finalize();
+        bytes[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4].copy_from_slice(&crc.to_be_bytes());
+
+        let err = read_sections(&bytes).unwrap_err();
+        match err {
+            EifError::ParseInput { reason } => {
+                assert!(
+                    reason.contains("lies within the fixed EIF header"),
+                    "unexpected error reason: {reason}"
+                );
+            }
+            other => panic!("expected ParseInput, got {other:?}"),
+        }
+    }
+
+    /// `describe_eif` on a real, from-scratch build must faithfully
+    /// surface the metadata fields we care about (`KernelVersion`,
+    /// `BuildToolVersion`), plus the top-level shape a downstream caller
+    /// depends on: `is_signed`, section list, kernel/ramdisk sizes.
+    /// This is the property `eif2eif` relies on for metadata carry-forward.
+    #[test]
+    fn test_describe_eif_surfaces_build_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let eif_path = dir.path().join("in.eif");
+        fs::write(&kernel, b"FAKE_KERNEL_BYTES_FOR_DESCRIBE").unwrap();
+        build_eif(
+            &kernel,
+            "root=/dev/vda1 console=ttyS0",
+            &eif_path,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields {
+                build_tool_version: "0.99.0",
+                kernel_version: "6.18.30-1.br1",
+                image_version: "",
+                build_time: "",
+            },
+        )
+        .unwrap();
+
+        let v = describe_eif(&eif_path).unwrap();
+        assert_eq!(v["eif_version"], EIF_HDR_VERSION);
+        assert_eq!(v["is_signed"], false);
+        assert_eq!(v["cmdline"], "root=/dev/vda1 console=ttyS0");
+        assert!(v["kernel_size"].as_u64().unwrap() > 0);
+        // Every EIF our builder produces has one (empty) RAMDISK section
+        // by construction. See `prepare_payload`; the empty section keeps
+        // the sidecar layout self-consistent with what stock EIFs carry.
+        assert_eq!(v["ramdisk_count"], 1);
+
+        // BuildMetadata surfaces what the caller passed.
+        let bm = &v["metadata"]["BuildMetadata"];
+        assert_eq!(bm["BuildToolVersion"], "0.99.0");
+        assert_eq!(bm["KernelVersion"], "6.18.30-1.br1");
+        assert_eq!(bm["OperatingSystem"], "Linux");
+        assert_eq!(bm["BuildTool"], "twoliter");
+
+        // Sections list must include KERNEL, CMDLINE, METADATA in the order
+        // `build_eif` emits them; unsigned builds have no SIGNATURE section.
+        let types: Vec<String> = v["sections"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["type"].as_str().unwrap().to_string())
+            .collect();
+        assert!(types.contains(&"KERNEL".to_string()));
+        assert!(types.contains(&"CMDLINE".to_string()));
+        assert!(types.contains(&"METADATA".to_string()));
+        assert!(!types.contains(&"SIGNATURE".to_string()));
+    }
+
+    /// A signed EIF must report `is_signed: true` and include a SIGNATURE
+    /// entry in `sections`, so consumers can gate their behavior on that
+    /// bit without cracking open the SIGNATURE bytes themselves.
+    #[test]
+    fn test_describe_eif_reports_signed_flag() {
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .unwrap();
+
+        let v = describe_eif(&output).unwrap();
+        assert_eq!(v["is_signed"], true);
+        let types: Vec<String> = v["sections"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["type"].as_str().unwrap().to_string())
+            .collect();
+        assert!(types.contains(&"SIGNATURE".to_string()));
+    }
+
+    /// A METADATA section that is not valid UTF-8 JSON must surface as a
+    /// `MetadataDecode` error rather than being silently mapped to `null`.
+    /// Silent-null would reproduce the bug this describe path exists to
+    /// prevent (a repack losing `KernelVersion` and reporting success).
+    #[test]
+    fn test_describe_eif_rejects_garbled_metadata() {
+        // Build a real EIF, then corrupt the METADATA payload bytes in place.
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let eif_path = dir.path().join("in.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_eif(
+            &kernel,
+            "cmd",
+            &eif_path,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+        )
+        .unwrap();
+        let mut bytes = fs::read(&eif_path).unwrap();
+
+        // Locate the METADATA section using the offset/size table and
+        // rewrite the first byte of its payload with a non-UTF-8 lead byte
+        // (0xff) to force `str::from_utf8` to fail. Doing it via the
+        // table (not the section header) keeps the file structurally
+        // intact so `read_sections` still succeeds and the error we get
+        // is specifically `MetadataDecode`.
+        let num_sections_off = 4 + 2 + 2 + 8 + 8 + 2;
+        let num_sections =
+            u16::from_be_bytes([bytes[num_sections_off], bytes[num_sections_off + 1]]) as usize;
+        let offsets_start = num_sections_off + 2;
+        let mut patched = false;
+        for i in 0..num_sections {
+            let off = u64::from_be_bytes(
+                bytes[offsets_start + i * 8..offsets_start + (i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
+            let ty = u16::from_be_bytes([bytes[off], bytes[off + 1]]);
+            if ty == EIF_SECTION_METADATA {
+                let data_off = off + EIF_SECTION_HEADER_SIZE;
+                bytes[data_off] = 0xff;
+                patched = true;
+                break;
+            }
+        }
+        assert!(patched, "test setup: no METADATA section found");
+        // Recompute CRC — hygiene; `describe_eif` doesn't verify CRC today,
+        // but keeping the file self-consistent isolates this test to the
+        // one thing it's checking.
+        let mut hasher = Crc32Hasher::new();
+        hasher.update(&bytes[..EIF_CRC32_OFFSET]);
+        hasher.update(&bytes[EIF_CRC32_OFFSET + 4..]);
+        let crc = hasher.finalize();
+        bytes[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4].copy_from_slice(&crc.to_be_bytes());
+        fs::write(&eif_path, &bytes).unwrap();
+
+        let err = describe_eif(&eif_path).unwrap_err();
+        match err {
+            EifError::MetadataDecode { reason } => {
+                assert!(
+                    reason.contains("UTF-8") || reason.contains("JSON"),
+                    "unexpected MetadataDecode reason: {reason}"
+                );
+            }
+            other => panic!("expected MetadataDecode, got {other:?}"),
+        }
     }
 }

--- a/tools/eif-builder/src/main.rs
+++ b/tools/eif-builder/src/main.rs
@@ -43,7 +43,12 @@ struct Args {
     #[arg(long, default_value_t = 2)]
     cpus: u64,
 
-    /// PCIE flags (hex; `0x` / `0X` prefix optional)
+    /// PCIE flags written into the EIF header (hex; `0x` / `0X` prefix
+    /// optional). Must match the PCIE flag word the sidecar shim passes to
+    /// the hypervisor at launch; the hypervisor enforces `header ==
+    /// launch-flags`. Variants normally author this via
+    /// `[package.metadata.build-variant] eif-pcie-flags`; see
+    /// `lib.rs::DEFAULT_PCIE_FLAGS` for the full contract.
     #[arg(long, default_value_t = DEFAULT_PCIE_FLAGS, value_parser = parse_hex_u16)]
     pcie_flags: u16,
 

--- a/tools/eif-builder/src/main.rs
+++ b/tools/eif-builder/src/main.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use eif_builder::kernel::prepare_kernel;
+use eif_builder::signer::{KmsSigner, LocalSigner};
 use eif_builder::{
-    build_eif, EifError, MetadataFields, PrepareKernelSnafu, ReadKernelSnafu, TargetArch,
+    build_eif, build_signed_eif, describe_eif, resign_eif, EifError, MetadataFields,
+    PrepareKernelSnafu, ReadCertSnafu, ReadKernelSnafu, ReadKeySnafu, SignerBuildSnafu, TargetArch,
     WritePreparedKernelSnafu, DEFAULT_CMDLINE, DEFAULT_PCIE_FLAGS,
 };
 use snafu::{report, ResultExt};
@@ -12,18 +14,26 @@ use std::path::{Path, PathBuf};
 #[derive(Parser)]
 #[command(name = "eif-builder", about = "Build a minimal sidecar EIF")]
 struct Args {
+    /// Subcommand. When omitted, the top-level flags are used to run the
+    /// implicit "build" command; this preserves backward compatibility with
+    /// existing callers (rpm2eif, eif2eif) that pass flags at the top level.
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    // ---------------- top-level "build" flags ----------------
     /// Path to the kernel image to embed. The accepted format is
-    /// arch-dependent; see `README.md` for details.
+    /// arch-dependent; see `README.md` for details. Required when no
+    /// subcommand is given (implicit `build`).
     #[arg(long)]
-    kernel: PathBuf,
+    kernel: Option<PathBuf>,
 
     /// Kernel command line
     #[arg(long, default_value = DEFAULT_CMDLINE)]
     cmdline: String,
 
-    /// Output EIF path
+    /// Output EIF path. Required when no subcommand is given.
     #[arg(long)]
-    output: PathBuf,
+    output: Option<PathBuf>,
 
     /// Default memory in bytes
     #[arg(long, default_value_t = 512 * 1024 * 1024)]
@@ -39,9 +49,10 @@ struct Args {
 
     /// Target architecture of the kernel image being packaged (x86_64|amd64
     /// or aarch64|arm64). Must match the kernel image; it is never inferred
-    /// from the build host. See `README.md`.
+    /// from the build host. Required when no subcommand is given. See
+    /// `README.md`.
     #[arg(long)]
-    arch: TargetArch,
+    arch: Option<TargetArch>,
 
     /// Build tool version to embed in EIF metadata (populates
     /// `BuildMetadata.BuildToolVersion`). Optional; empty by default.
@@ -77,6 +88,101 @@ struct Args {
     /// `README.md`.
     #[arg(long)]
     out_prepared_kernel: Option<PathBuf>,
+
+    /// PEM-encoded X.509 certificate used to sign PCR0. Required for a
+    /// signed EIF. When both `--signing-cert` and `--signing-key` are
+    /// present, the local-key signing path is used. When
+    /// `--signing-cert` is present alongside `--kms-key-id`, the KMS
+    /// path is used and this cert is embedded into the CBOR signature
+    /// section verbatim (the private key never leaves KMS). Passing
+    /// `--signing-cert` alone (without a signing backend) is an error;
+    /// absence of all three flags produces an unsigned EIF.
+    #[arg(long, requires = "signing_backend")]
+    signing_cert: Option<PathBuf>,
+
+    /// PEM-encoded ECDSA private key (P-256 or P-384) used to sign PCR0.
+    /// Mutually exclusive with `--kms-key-id`; requires `--signing-cert`.
+    #[arg(long, requires = "signing_cert", group = "signing_backend")]
+    signing_key: Option<PathBuf>,
+
+    /// AWS KMS key ID or ARN used to sign PCR0. Mutually exclusive with
+    /// `--signing-key`; requires `--signing-cert` (the CBOR signature
+    /// section carries an X.509 that KMS itself does not manage).
+    /// Credentials are picked up from the ambient AWS environment;
+    /// region falls back to the ambient chain when `--region` is unset
+    /// but that chain is empty inside the buildkit sandbox, so callers
+    /// building off-EC2 must pass `--region` explicitly (buildsys
+    /// forwards `Infra.toml [eif].signing_key.kms.region` for this).
+    #[arg(long, requires = "signing_cert", group = "signing_backend")]
+    kms_key_id: Option<String>,
+
+    /// AWS region for the KMS `Sign` call. Required for KMS-signed builds
+    /// inside the buildkit sandbox (no ambient region source exists
+    /// there); ignored for the local-key path and for unsigned builds.
+    #[arg(long, requires = "kms_key_id")]
+    region: Option<String>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Re-sign an existing EIF in place: rewrite only the SIGNATURE section
+    /// (and header CRC). Kernel, cmdline, ramdisk, and metadata sections
+    /// are byte-preserved. PCR0 is recomputed from the input's bytes, so
+    /// the new signature covers the same measurement the enclave sees.
+    Resign(ResignArgs),
+
+    /// Print a JSON summary of an EIF's contents on stdout.
+    ///
+    /// The METADATA section is decoded (JSON), so downstream tooling can
+    /// pull out fields with `jq .metadata.BuildMetadata.KernelVersion`.
+    /// The primary consumer is `eif2eif`, which needs to carry
+    /// `KernelVersion` and `BuildToolVersion` forward across a repack (rpm2eif
+    /// reads them from the source rootfs' RPM DB; eif2eif has no rootfs to
+    /// query, so it reads them out of the input EIF instead).
+    Describe(DescribeArgs),
+}
+
+#[derive(clap::Args)]
+struct ResignArgs {
+    /// Path to the input EIF.
+    #[arg(long)]
+    input: PathBuf,
+
+    /// Path to write the resigned EIF to. May equal `--input` (the file
+    /// is read fully before being rewritten).
+    #[arg(long)]
+    output: PathBuf,
+
+    /// PEM-encoded X.509 certificate to embed in the new SIGNATURE
+    /// section. Required; `resign` never produces an unsigned EIF.
+    #[arg(long, requires = "signing_backend")]
+    signing_cert: PathBuf,
+
+    /// PEM-encoded ECDSA private key. Mutually exclusive with
+    /// `--kms-key-id`.
+    #[arg(long, group = "signing_backend")]
+    signing_key: Option<PathBuf>,
+
+    /// AWS KMS key ID or ARN. Mutually exclusive with `--signing-key`.
+    #[arg(long, group = "signing_backend")]
+    kms_key_id: Option<String>,
+
+    /// AWS region for the KMS `Sign` call. See the top-level `--region`
+    /// doc for when this is required.
+    #[arg(long, requires = "kms_key_id")]
+    region: Option<String>,
+}
+
+#[derive(clap::Args)]
+struct DescribeArgs {
+    /// Path to the input EIF.
+    #[arg(long)]
+    input: PathBuf,
+
+    /// Emit the JSON compactly (single line, no indentation). Useful for
+    /// piping into `jq`; the default is pretty-printed for human reading.
+    #[arg(long)]
+    compact: bool,
 }
 
 fn parse_hex_u16(s: &str) -> Result<u16, String> {
@@ -104,23 +210,95 @@ fn write_prepared_kernel(
 #[report]
 fn main() -> Result<(), EifError> {
     let args = Args::parse();
+
+    match args.command {
+        Some(Command::Resign(r)) => return run_resign(r),
+        Some(Command::Describe(d)) => return run_describe(d),
+        None => {} // fall through to the implicit "build" path.
+    }
+
+    // Implicit `build` path — the top-level flags. Validate required flags
+    // here since we cannot express "required unless subcommand" via clap
+    // attributes when the subcommand is itself optional (Option<Command>).
+    let (kernel, output, arch) = match (args.kernel, args.output, args.arch) {
+        (Some(k), Some(o), Some(a)) => (k, o, a),
+        _ => {
+            eprintln!(
+                "error: --kernel, --output, and --arch are required when no subcommand is given"
+            );
+            std::process::exit(2);
+        }
+    };
+
     let metadata = MetadataFields {
         build_tool_version: &args.build_tool_version,
         kernel_version: &args.kernel_version,
         image_version: &args.image_version,
         build_time: &args.build_time,
     };
-    build_eif(
-        &args.kernel,
-        &args.cmdline,
-        &args.output,
-        args.mem,
-        args.cpus,
-        args.pcie_flags,
-        args.arch,
-        &metadata,
-    )?;
-    println!("Created {}", args.output.display());
+
+    // Dispatch: three states — unsigned, local-signed, KMS-signed. Clap has
+    // already enforced the mutual-exclusion constraints, so we only need to
+    // build the right signer here.
+    match (
+        args.signing_cert.as_deref(),
+        args.signing_key.as_deref(),
+        args.kms_key_id.as_deref(),
+    ) {
+        (None, None, None) => {
+            build_eif(
+                &kernel,
+                &args.cmdline,
+                &output,
+                args.mem,
+                args.cpus,
+                args.pcie_flags,
+                arch,
+                &metadata,
+            )?;
+        }
+        (Some(cert_path), Some(key_path), None) => {
+            let cert_pem = std::fs::read(cert_path).context(ReadCertSnafu)?;
+            let key_pem = std::fs::read(key_path).context(ReadKeySnafu)?;
+            let signer = LocalSigner::from_pem(&cert_pem, &key_pem).context(SignerBuildSnafu)?;
+            build_signed_eif(
+                &kernel,
+                &args.cmdline,
+                &output,
+                args.mem,
+                args.cpus,
+                args.pcie_flags,
+                arch,
+                &metadata,
+                &signer,
+            )?;
+        }
+        (Some(cert_path), None, Some(key_id)) => {
+            let cert_pem = std::fs::read(cert_path).context(ReadCertSnafu)?;
+            let signer = KmsSigner::from_key_id(key_id.to_string(), cert_pem, args.region.clone())
+                .context(SignerBuildSnafu)?;
+            build_signed_eif(
+                &kernel,
+                &args.cmdline,
+                &output,
+                args.mem,
+                args.cpus,
+                args.pcie_flags,
+                arch,
+                &metadata,
+                &signer,
+            )?;
+        }
+        // Every other tuple is impossible: `--signing-cert` requires the
+        // `signing_backend` ArgGroup (so a `Some, None, None` cert-only
+        // input errors at parse), and `--signing-key`/`--kms-key-id` each
+        // require `--signing-cert` (so a `None, Some, ...` errors at parse).
+        // The group's `multiple(false)` default also rules out
+        // `Some, Some, Some`. Guarded here anyway so a future clap-attr
+        // regression fails at build time via clippy rather than at runtime.
+        _ => unreachable!("clap ArgGroup enforces the (cert, {{key|kms}}) invariant"),
+    }
+    println!("Created {}", output.display());
 
     // Optional: dump the prepared kernel bytes for consumers that need a
     // flat, PE-loadable image (see `README.md`). We re-read + re-prepare
@@ -129,10 +307,53 @@ fn main() -> Result<(), EifError> {
     // for a dev-only knob, and guarantees we write exactly the bytes the
     // EIF embedded.
     if let Some(out_path) = args.out_prepared_kernel.as_deref() {
-        write_prepared_kernel(&args.kernel, out_path, args.arch)?;
+        write_prepared_kernel(&kernel, out_path, arch)?;
         println!("Wrote prepared kernel to {}", out_path.display());
     }
 
+    Ok(())
+}
+
+/// Dispatch the `resign` subcommand. Builds the appropriate signer from the
+/// arg group and calls [`resign_eif`].
+fn run_resign(args: ResignArgs) -> Result<(), EifError> {
+    let cert_pem = std::fs::read(&args.signing_cert).context(ReadCertSnafu)?;
+    // clap's `signing_backend` group has `required = true` via the
+    // `requires = "signing_backend"` attribute on `--signing-cert`, so one
+    // of --signing-key or --kms-key-id is always present here.
+    match (args.signing_key.as_deref(), args.kms_key_id.as_deref()) {
+        (Some(key_path), None) => {
+            let key_pem = std::fs::read(key_path).context(ReadKeySnafu)?;
+            let signer = LocalSigner::from_pem(&cert_pem, &key_pem).context(SignerBuildSnafu)?;
+            resign_eif(&args.input, &args.output, &signer)?;
+        }
+        (None, Some(key_id)) => {
+            let signer = KmsSigner::from_key_id(key_id.to_string(), cert_pem, args.region.clone())
+                .context(SignerBuildSnafu)?;
+            resign_eif(&args.input, &args.output, &signer)?;
+        }
+        _ => unreachable!("clap ArgGroup enforces exactly one of --signing-key/--kms-key-id"),
+    }
+    println!(
+        "Resigned {} -> {}",
+        args.input.display(),
+        args.output.display()
+    );
+    Ok(())
+}
+
+/// Dispatch the `describe` subcommand. Prints a JSON summary of `--input` to
+/// stdout. Writes nothing to stderr on success so the output can be piped
+/// directly into `jq`.
+fn run_describe(args: DescribeArgs) -> Result<(), EifError> {
+    let value = describe_eif(&args.input)?;
+    let out = if args.compact {
+        serde_json::to_string(&value)
+    } else {
+        serde_json::to_string_pretty(&value)
+    }
+    .expect("serde_json::to_string on a Value cannot fail");
+    println!("{out}");
     Ok(())
 }
 

--- a/tools/eif-builder/src/signer.rs
+++ b/tools/eif-builder/src/signer.rs
@@ -1,0 +1,830 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! EIF signature production for the `EifSectionSignature` (0x04) section.
+//!
+//! Two backends are provided:
+//!
+//!  * [`LocalSigner`] — reads an ECDSA private key from a PEM file and signs
+//!    in-process via `aws-lc-rs`. Selected when Infra.toml's
+//!    `[eif].signing_key = { file = { path = ... } }` backend is used
+//!    (buildsys mounts the PEM at `/root/eif/signing.key`).
+//!  * [`KmsSigner`] — calls AWS KMS' `Sign` API for each signature. Selected
+//!    when Infra.toml's `[eif].signing_key = { kms = { key_id = ... } }`
+//!    backend is used. The private key never leaves KMS; only the signing
+//!    certificate (X.509) is provided locally, because the CBOR signature
+//!    section is required to carry it.
+//!
+//! Both signers produce a **raw ECDSA `r || s`** signature over the COSE
+//! `Sig_structure1` bytes. `aws-lc-rs` and KMS both emit DER-encoded ECDSA
+//! signatures by default; we convert to fixed-width `r||s` because COSE
+//! requires that form (see RFC 8152 §8.1).
+//!
+//! Certificate curve selection drives the COSE algorithm:
+//!
+//!   * P-256 → `ES256` (COSE alg `-7`)
+//!   * P-384 → `ES384` (COSE alg `-35`)
+//!
+//! Any other curve is rejected with a typed error at construction time
+//! rather than silently rounding down.
+
+use std::sync::Arc;
+
+use aws_lc_rs::rand::SystemRandom;
+use aws_lc_rs::signature::{
+    EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_ASN1_SIGNING, ECDSA_P384_SHA384_ASN1_SIGNING,
+};
+use snafu::{ResultExt, Snafu};
+
+/// Errors surfaced by any signer implementation. Passed through to
+/// `EifError::Sign` so the CLI can report a single, uniform failure mode.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum SignerError {
+    #[snafu(display("failed to read signing key file: {source}"))]
+    ReadKey { source: std::io::Error },
+
+    #[snafu(display("failed to read signing cert file: {source}"))]
+    ReadCert { source: std::io::Error },
+
+    #[snafu(display("failed to parse PEM: {source}"))]
+    Pem { source: pem::PemError },
+
+    #[snafu(display("expected a PEM label of 'CERTIFICATE', got {label:?}"))]
+    CertPemLabel { label: String },
+
+    #[snafu(display("expected a PEM key label of 'PRIVATE KEY' (PKCS#8), got {label:?}"))]
+    KeyPemLabel { label: String },
+
+    #[snafu(display(
+        "PEM key label 'EC PRIVATE KEY' (SEC1) is not supported yet; convert with \
+         `openssl pkcs8 -topk8 -nocrypt -in sec1.key -out pkcs8.key`"
+    ))]
+    Sec1PrivateKeyUnsupported,
+
+    #[snafu(display(
+        "unsupported signing key: only ECDSA P-256 (ES256) and P-384 (ES384) are supported"
+    ))]
+    UnsupportedKey,
+
+    #[snafu(display("failed to parse X.509 certificate: {reason}"))]
+    ParseCert { reason: String },
+
+    #[snafu(display(
+        "certificate curve does not match signing key curve; cert uses {cert_curve}, key uses {key_curve}"
+    ))]
+    CurveMismatch {
+        cert_curve: &'static str,
+        key_curve: &'static str,
+    },
+
+    #[snafu(display("failed to load private key: {reason}"))]
+    LoadKey { reason: String },
+
+    #[snafu(display("aws-lc-rs signing failed"))]
+    Sign,
+
+    #[snafu(display("KMS Sign call failed: {reason}"))]
+    Kms { reason: String },
+
+    #[snafu(display("KMS AccessDenied: {reason}"))]
+    KmsAccessDenied { reason: String },
+
+    #[snafu(display("KMS key is disabled: {reason}"))]
+    KmsKeyDisabled { reason: String },
+
+    #[snafu(display("KMS key state does not allow signing: {reason}"))]
+    KmsInvalidKeyState { reason: String },
+
+    #[snafu(display("KMS did not return a signature blob"))]
+    KmsEmptySignature,
+
+    #[snafu(display("failed to decode ECDSA DER signature"))]
+    DecodeDerSignature,
+
+    #[snafu(display(
+        "ECDSA signature scalars exceed the expected width: r={r} bytes, \
+         s={s} bytes, expected each ≤ {expected}"
+    ))]
+    ScalarTooLarge { r: usize, s: usize, expected: usize },
+
+    #[snafu(display("ECDSA DER signature has {trailing} trailing byte(s) after the SEQUENCE"))]
+    DerTrailingBytes { trailing: usize },
+
+    #[snafu(display(
+        "ECDSA DER outer SEQUENCE length ({claimed}) does not match content length ({actual})"
+    ))]
+    DerLengthMismatch { claimed: usize, actual: usize },
+}
+
+/// Signing algorithm selection. Distinguishes P-256/P-384 so we can produce
+/// the correct COSE `alg` header and the correct fixed-width raw signature
+/// length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignAlg {
+    Es256,
+    Es384,
+}
+
+impl SignAlg {
+    /// Width (in bytes) of each ECDSA scalar (r and s) in COSE raw form.
+    fn scalar_len(self) -> usize {
+        match self {
+            Self::Es256 => 32,
+            Self::Es384 => 48,
+        }
+    }
+}
+
+/// Backend for producing the COSE_Sign1 signature over the pre-hash TBS bytes.
+///
+/// Object-safe on purpose: we only need one `dyn`-dispatch boundary (between
+/// local and KMS), and object-safety means we can hand a `&dyn Signer` to the
+/// builder without generic plumbing.
+pub trait Signer {
+    /// Sign the given `to_be_signed` bytes (the COSE `Sig_structure1` payload)
+    /// and return a fixed-width raw ECDSA `r || s` signature.
+    fn sign_cose(&self, to_be_signed: &[u8]) -> Result<Vec<u8>, SignerError>;
+
+    /// PEM-encoded signing certificate, ready to embed verbatim in the
+    /// `signing_certificate` field of the CBOR signature section (the
+    /// reference reader uses `X509::from_pem` on it).
+    fn cert_pem(&self) -> &[u8];
+
+    /// Signing algorithm to advertise. The caller translates to
+    /// `coset::iana::Algorithm` at the single COSE-building site so this
+    /// trait stays independent of the exact `coset` version.
+    fn algorithm(&self) -> SignAlg;
+}
+
+/// In-process ECDSA signer backed by `aws-lc-rs`.
+///
+/// Construct with [`LocalSigner::from_pem`]: pass the PEM cert bytes and the
+/// PEM key bytes (PKCS#8 `PRIVATE KEY` or SEC1 `EC PRIVATE KEY`). The
+/// constructor validates that the cert and key are both ECDSA on the same
+/// curve, and that the curve is one of `P-256` or `P-384`.
+pub struct LocalSigner {
+    key_pair: EcdsaKeyPair,
+    cert_pem: Vec<u8>,
+    // SPKI DER extracted from the keypair — cached so verification-side
+    // tests don't need to re-parse. Test-only.
+    #[cfg(test)]
+    public_key_spki_der: Vec<u8>,
+    alg: SignAlg,
+    rng: Arc<SystemRandom>,
+}
+
+impl LocalSigner {
+    /// Build a `LocalSigner` from PEM-encoded cert and key bytes.
+    pub fn from_pem(cert_pem: &[u8], key_pem: &[u8]) -> Result<Self, SignerError> {
+        // Parse the cert PEM to detect the SPKI curve; this dictates the
+        // signing algorithm and must match the key material.
+        let parsed_cert = pem::parse(cert_pem).context(PemSnafu)?;
+        if parsed_cert.tag() != "CERTIFICATE" {
+            return CertPemLabelSnafu {
+                label: parsed_cert.tag().to_string(),
+            }
+            .fail();
+        }
+        let cert_alg = detect_cert_curve(parsed_cert.contents())?;
+
+        // Parse the key PEM. Only PKCS#8 (`PRIVATE KEY`) is accepted;
+        // aws-lc-rs' `from_pkcs8` requires the PKCS#8 wrapper. SEC1
+        // (`EC PRIVATE KEY`) inputs get a dedicated error with a
+        // conversion recipe rather than reaching `from_pkcs8` and failing
+        // with an opaque aws-lc-rs message. All keys shipped by our
+        // sbkeys pipeline are already PKCS#8-encoded.
+        let parsed_key = pem::parse(key_pem).context(PemSnafu)?;
+        let key_alg = match parsed_key.tag() {
+            "PRIVATE KEY" => cert_alg,
+            "EC PRIVATE KEY" => return Sec1PrivateKeyUnsupportedSnafu.fail(),
+            other => {
+                return KeyPemLabelSnafu {
+                    label: other.to_string(),
+                }
+                .fail()
+            }
+        };
+
+        // Load the keypair.
+        let ring_alg = match key_alg {
+            SignAlg::Es256 => &ECDSA_P256_SHA256_ASN1_SIGNING,
+            SignAlg::Es384 => &ECDSA_P384_SHA384_ASN1_SIGNING,
+        };
+        let rng = Arc::new(SystemRandom::new());
+        let key_pair = EcdsaKeyPair::from_pkcs8(ring_alg, parsed_key.contents()).map_err(|e| {
+            SignerError::LoadKey {
+                reason: format!("{e}"),
+            }
+        })?;
+
+        // Cross-check that the key's public component uses the same curve as
+        // the cert. aws-lc-rs' `public_key()` returns SEC1-encoded uncompressed
+        // point; length distinguishes P-256 (0x04 || 32 || 32 = 65) from
+        // P-384 (0x04 || 48 || 48 = 97).
+        let raw_pub = key_pair.public_key().as_ref().to_vec();
+        let key_curve = match raw_pub.len() {
+            65 => SignAlg::Es256,
+            97 => SignAlg::Es384,
+            _ => return UnsupportedKeySnafu.fail(),
+        };
+        if key_curve != cert_alg {
+            return CurveMismatchSnafu {
+                cert_curve: name_of(cert_alg),
+                key_curve: name_of(key_curve),
+            }
+            .fail();
+        }
+
+        // Package the raw SEC1 public key into a minimal SPKI DER envelope.
+        // This is used only by tests via `public_key_der()`.
+        #[cfg(test)]
+        let public_key_spki_der = spki_der_for_ecdsa(&raw_pub, key_curve);
+
+        Ok(Self {
+            key_pair,
+            cert_pem: cert_pem.to_vec(),
+            #[cfg(test)]
+            public_key_spki_der,
+            alg: cert_alg,
+            rng,
+        })
+    }
+}
+
+impl Signer for LocalSigner {
+    fn sign_cose(&self, to_be_signed: &[u8]) -> Result<Vec<u8>, SignerError> {
+        // aws-lc-rs' EcdsaKeyPair::sign returns DER; convert to raw `r||s`.
+        let der = self
+            .key_pair
+            .sign(&*self.rng, to_be_signed)
+            .map_err(|_| SignerError::Sign)?;
+        ecdsa_der_to_raw(der.as_ref(), self.alg.scalar_len())
+    }
+
+    fn cert_pem(&self) -> &[u8] {
+        &self.cert_pem
+    }
+
+    fn algorithm(&self) -> SignAlg {
+        self.alg
+    }
+}
+
+impl LocalSigner {
+    /// SubjectPublicKeyInfo (SPKI) DER for the signing key. Test-only:
+    /// used by `#[cfg(test)]` verification code paths in `lib.rs`. Kept
+    /// off the [`Signer`] trait so production signers do not have to
+    /// materialize their public key.
+    #[cfg(test)]
+    pub fn public_key_der(&self) -> &[u8] {
+        &self.public_key_spki_der
+    }
+}
+
+/// KMS-backed ECDSA signer.
+///
+/// The signing key lives in KMS; only the certificate is provided locally
+/// (the spec requires an X.509 in the CBOR section). We call KMS' `Sign`
+/// API once per signature, using `EcdsaSha256` or `EcdsaSha384` based on
+/// the cert curve.
+///
+/// Note: KMS returns DER-encoded ECDSA signatures, which we convert to raw
+/// `r||s` for COSE.
+pub struct KmsSigner {
+    client: aws_sdk_kms::Client,
+    key_id: String,
+    cert_pem: Vec<u8>,
+    alg: SignAlg,
+    runtime: tokio::runtime::Runtime,
+}
+
+impl KmsSigner {
+    /// Build a `KmsSigner` from a KMS key ID (or ARN), a PEM-encoded cert,
+    /// and an optional explicit region.
+    ///
+    /// When `region` is `Some`, it overrides the ambient region resolution
+    /// and is the only source of truth for which endpoint the SDK talks to.
+    /// When `region` is `None`, the SDK falls back to
+    /// `AWS_REGION` / `AWS_DEFAULT_REGION` / `~/.aws/config` profile / IMDS
+    /// (in that order). Inside the buildkit sandbox where `eif-builder`
+    /// typically runs for signed builds, none of those sources is present
+    /// (no AWS_REGION env is exported, no ~/.aws/config file is mounted,
+    /// IMDS is unreachable from the container), so a KMS build with
+    /// `region=None` will hard-fail on the first `Sign` call with a
+    /// "region is required" error. The Infra.toml `[eif].signing_key.kms`
+    /// section carries a `region` field for exactly this reason; passing it
+    /// through here on the KMS path is what makes buildkit-based signed
+    /// builds work off-EC2.
+    ///
+    /// Credentials still come from the ambient environment (buildsys mounts
+    /// `~/.aws/aws-*-key-*.env` files; the caller must have exported them
+    /// into the process env, which is what `eif-sign-helper` does).
+    pub fn from_key_id(
+        key_id: String,
+        cert_pem: Vec<u8>,
+        region: Option<String>,
+    ) -> Result<Self, SignerError> {
+        let parsed_cert = pem::parse(&cert_pem).context(PemSnafu)?;
+        if parsed_cert.tag() != "CERTIFICATE" {
+            return CertPemLabelSnafu {
+                label: parsed_cert.tag().to_string(),
+            }
+            .fail();
+        }
+        let alg = detect_cert_curve(parsed_cert.contents())?;
+
+        // Build a lightweight, current-thread tokio runtime so a sync `main`
+        // can call the async KMS SDK without going full-tokio.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| SignerError::Kms {
+                reason: format!("runtime build: {e}"),
+            })?;
+        // Region: explicit `--region` wins over the ambient chain. We
+        // still use `from_env()` for credentials because that path is what
+        // reads the AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
+        // AWS_SESSION_TOKEN env variables that the build's
+        // eif-sign-helper exports before invoking `eif-builder`. Using
+        // `BehaviorVersion::latest()` would force us to bump every
+        // AWS-facing tool in lockstep, so we stay on the same legacy
+        // resolution as `tools/pcrsys` / `tools/pubsys`.
+        #[allow(deprecated)]
+        let client = runtime.block_on(async {
+            let mut loader = aws_config::from_env();
+            if let Some(r) = region {
+                loader = loader.region(aws_types::region::Region::new(r));
+            }
+            let conf = loader.load().await;
+            aws_sdk_kms::Client::new(&conf)
+        });
+
+        Ok(Self {
+            client,
+            key_id,
+            cert_pem,
+            alg,
+            runtime,
+        })
+    }
+}
+
+/// Map an `aws_sdk_kms` `Sign` operation error into a typed [`SignerError`]
+/// that surfaces the operationally-relevant kind (disabled, invalid state,
+/// key not found, etc.) rather than a debug-dump of the whole SDK error.
+///
+/// `AccessDenied` is not a distinct KMS `SignError` variant — the SDK
+/// surfaces it via the smithy-level metadata on `Unhandled`, so we probe
+/// the response's error code from that path.
+fn map_sign_error(
+    e: error_utils::SdkError<aws_sdk_kms::operation::sign::SignError>,
+) -> SignerError {
+    use aws_sdk_kms::operation::sign::SignError;
+    // Wrap for consistent human-readable formatting per the workspace
+    // convention (see `error_utils::AwsSdkError`), then also inspect the
+    // service-error variant so we can surface the operationally-relevant
+    // kind. `AccessDenied` is not a distinct `SignError` variant — the
+    // SDK reports it via the smithy-level error code on the "unhandled"
+    // arm, so we probe `meta().code()`.
+    let wrapper = error_utils::AwsSdkError::from(e);
+    let display = wrapper.to_string();
+    let Some(svc) = wrapper.as_service_error() else {
+        return SignerError::Kms { reason: display };
+    };
+    match svc {
+        SignError::DisabledException(inner) => SignerError::KmsKeyDisabled {
+            reason: format!("{inner}"),
+        },
+        SignError::KmsInvalidStateException(inner) => SignerError::KmsInvalidKeyState {
+            reason: format!("{inner}"),
+        },
+        other if other.meta().code() == Some("AccessDeniedException") => {
+            SignerError::KmsAccessDenied { reason: display }
+        }
+        _ => SignerError::Kms { reason: display },
+    }
+}
+
+impl Signer for KmsSigner {
+    fn sign_cose(&self, to_be_signed: &[u8]) -> Result<Vec<u8>, SignerError> {
+        use aws_sdk_kms::primitives::Blob;
+        use aws_sdk_kms::types::{MessageType, SigningAlgorithmSpec};
+
+        let (algo, hash_alg) = match self.alg {
+            SignAlg::Es256 => (
+                SigningAlgorithmSpec::EcdsaSha256,
+                &aws_lc_rs::digest::SHA256,
+            ),
+            SignAlg::Es384 => (
+                SigningAlgorithmSpec::EcdsaSha384,
+                &aws_lc_rs::digest::SHA384,
+            ),
+        };
+
+        // KMS' `Digest` message type takes the *hash*, not the full TBS. We
+        // hash locally so payloads > 4 KiB (the KMS raw-message limit) work.
+        let digest = aws_lc_rs::digest::digest(hash_alg, to_be_signed);
+
+        let out = self
+            .runtime
+            .block_on(async {
+                self.client
+                    .sign()
+                    .key_id(&self.key_id)
+                    .message(Blob::new(digest.as_ref().to_vec()))
+                    .message_type(MessageType::Digest)
+                    .signing_algorithm(algo)
+                    .send()
+                    .await
+            })
+            .map_err(map_sign_error)?;
+
+        let sig_der = out.signature().ok_or(SignerError::KmsEmptySignature)?;
+        ecdsa_der_to_raw(sig_der.as_ref(), self.alg.scalar_len())
+    }
+
+    fn cert_pem(&self) -> &[u8] {
+        &self.cert_pem
+    }
+
+    fn algorithm(&self) -> SignAlg {
+        self.alg
+    }
+}
+
+// -------- Curve detection --------
+
+/// Detect the ECDSA curve of a DER-encoded X.509 certificate by looking up
+/// the SubjectPublicKeyInfo AlgorithmIdentifier's namedCurve OID.
+///
+/// Only P-256 (`1.2.840.10045.3.1.7`) and P-384 (`1.3.132.0.34`) are accepted;
+/// any other curve (including P-521, `1.3.132.0.35`) is refused. Rationale
+/// documented in the module-level doc.
+fn detect_cert_curve(cert_der: &[u8]) -> Result<SignAlg, SignerError> {
+    use x509_cert::der::Decode;
+    let cert = x509_cert::Certificate::from_der(cert_der).map_err(|e| SignerError::ParseCert {
+        reason: format!("{e}"),
+    })?;
+    // For ECDSA certs, the AlgorithmIdentifier.parameters carries the named
+    // curve OID as an ANY-encoded OID.
+    let alg_ident = &cert.tbs_certificate.subject_public_key_info.algorithm;
+    // OID for id-ecPublicKey: 1.2.840.10045.2.1.
+    let ec_public_key: x509_cert::der::asn1::ObjectIdentifier =
+        "1.2.840.10045.2.1".parse().unwrap();
+    if alg_ident.oid != ec_public_key {
+        return UnsupportedKeySnafu.fail();
+    }
+    let params = alg_ident
+        .parameters
+        .as_ref()
+        .ok_or(SignerError::UnsupportedKey)?;
+    // Parameters is `Any`; decode as OID.
+    let curve_oid: x509_cert::der::asn1::ObjectIdentifier =
+        params.decode_as().map_err(|e| SignerError::ParseCert {
+            reason: format!("curve OID decode: {e}"),
+        })?;
+    let p256: x509_cert::der::asn1::ObjectIdentifier = "1.2.840.10045.3.1.7".parse().unwrap();
+    let p384: x509_cert::der::asn1::ObjectIdentifier = "1.3.132.0.34".parse().unwrap();
+    if curve_oid == p256 {
+        Ok(SignAlg::Es256)
+    } else if curve_oid == p384 {
+        Ok(SignAlg::Es384)
+    } else {
+        UnsupportedKeySnafu.fail()
+    }
+}
+
+fn name_of(alg: SignAlg) -> &'static str {
+    match alg {
+        SignAlg::Es256 => "P-256",
+        SignAlg::Es384 => "P-384",
+    }
+}
+
+// -------- DER ↔ raw ECDSA signature conversion --------
+
+/// Convert a DER-encoded ECDSA signature `SEQUENCE(INTEGER r, INTEGER s)`
+/// into COSE's raw `r || s` fixed-width form (each scalar padded to
+/// `scalar_len` bytes with leading zeros).
+///
+/// Validates:
+///   * The outer tag is `SEQUENCE` (`0x30`).
+///   * The outer length field matches the number of bytes consumed by
+///     the two `INTEGER` sub-elements — a mismatch surfaces as
+///     `SignerError::DerLengthMismatch`.
+///   * Both scalars fit in `scalar_len` bytes — over-width surfaces as
+///     `SignerError::ScalarTooLarge` with the actual widths.
+///   * No bytes trail the outer SEQUENCE — extras surface as
+///     `SignerError::DerTrailingBytes`.
+fn ecdsa_der_to_raw(der: &[u8], scalar_len: usize) -> Result<Vec<u8>, SignerError> {
+    // Minimal DER parser tailored to ECDSA signature shape. Avoids pulling
+    // in a full ASN.1 crate for what is a fixed, ~70-byte structure.
+    let mut i = 0;
+    if der.get(i).copied() != Some(0x30) {
+        return DecodeDerSignatureSnafu.fail();
+    }
+    i += 1;
+    let (seq_len, consumed) = read_der_len(&der[i..]).ok_or(SignerError::DecodeDerSignature)?;
+    i += consumed;
+    let content_start = i;
+
+    let r = read_der_uint(&der[i..]).ok_or(SignerError::DecodeDerSignature)?;
+    i += r.raw_len;
+    let s = read_der_uint(&der[i..]).ok_or(SignerError::DecodeDerSignature)?;
+    i += s.raw_len;
+
+    let content_actual = i - content_start;
+    if content_actual != seq_len {
+        return DerLengthMismatchSnafu {
+            claimed: seq_len,
+            actual: content_actual,
+        }
+        .fail();
+    }
+    let trailing = der.len() - i;
+    if trailing > 0 {
+        return DerTrailingBytesSnafu { trailing }.fail();
+    }
+    if r.value.len() > scalar_len || s.value.len() > scalar_len {
+        return ScalarTooLargeSnafu {
+            r: r.value.len(),
+            s: s.value.len(),
+            expected: scalar_len,
+        }
+        .fail();
+    }
+    let mut out = vec![0u8; 2 * scalar_len];
+    out[scalar_len - r.value.len()..scalar_len].copy_from_slice(&r.value);
+    out[2 * scalar_len - s.value.len()..].copy_from_slice(&s.value);
+    Ok(out)
+}
+
+struct DerUint {
+    value: Vec<u8>,
+    raw_len: usize,
+}
+
+fn read_der_uint(buf: &[u8]) -> Option<DerUint> {
+    if buf.first()? != &0x02 {
+        return None;
+    }
+    let (len, consumed) = read_der_len(&buf[1..])?;
+    let start = 1 + consumed;
+    let end = start.checked_add(len)?;
+    if end > buf.len() {
+        return None;
+    }
+    let mut value = buf[start..end].to_vec();
+    // Strip any leading zero used to disambiguate the sign bit.
+    while value.len() > 1 && value[0] == 0 {
+        value.remove(0);
+    }
+    Some(DerUint {
+        value,
+        raw_len: end,
+    })
+}
+
+fn read_der_len(buf: &[u8]) -> Option<(usize, usize)> {
+    let first = *buf.first()?;
+    if first & 0x80 == 0 {
+        return Some((first as usize, 1));
+    }
+    let n = (first & 0x7f) as usize;
+    if n == 0 || n > 4 {
+        return None;
+    }
+    let mut len = 0usize;
+    for i in 0..n {
+        len = (len << 8) | (*buf.get(1 + i)? as usize);
+    }
+    Some((len, 1 + n))
+}
+
+/// Emit a minimal SPKI DER envelope carrying a SEC1-encoded ECDSA public key.
+/// Used only for the test-side `public_key_der()` accessor.
+#[cfg(test)]
+fn spki_der_for_ecdsa(sec1_uncompressed: &[u8], alg: SignAlg) -> Vec<u8> {
+    use crate::der_helpers::wrap_der;
+    // OIDs (DER):
+    //   id-ecPublicKey        1.2.840.10045.2.1 → 06 07 2A 86 48 CE 3D 02 01
+    //   secp256r1 (prime256v1) 1.2.840.10045.3.1.7 → 06 08 2A 86 48 CE 3D 03 01 07
+    //   secp384r1              1.3.132.0.34        → 06 05 2B 81 04 00 22
+    let id_ec_public_key: [u8; 9] = [0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01];
+    let curve_oid: Vec<u8> = match alg {
+        SignAlg::Es256 => vec![0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07],
+        SignAlg::Es384 => vec![0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22],
+    };
+
+    // AlgorithmIdentifier ::= SEQUENCE { OID id-ecPublicKey, OID curve }
+    let mut alg_ident_body = Vec::new();
+    alg_ident_body.extend_from_slice(&id_ec_public_key);
+    alg_ident_body.extend_from_slice(&curve_oid);
+    let alg_ident = wrap_der(0x30, &alg_ident_body);
+
+    // BIT STRING wrapping the SEC1 public key with 0 unused bits.
+    let mut bitstring_body = vec![0u8];
+    bitstring_body.extend_from_slice(sec1_uncompressed);
+    let bitstring = wrap_der(0x03, &bitstring_body);
+
+    // SubjectPublicKeyInfo ::= SEQUENCE { AlgorithmIdentifier, BIT STRING }
+    let mut spki_body = Vec::new();
+    spki_body.extend_from_slice(&alg_ident);
+    spki_body.extend_from_slice(&bitstring);
+    wrap_der(0x30, &spki_body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ecdsa_der_roundtrip_p384() {
+        // Craft a DER signature and roundtrip it through the raw converter.
+        // r = 0x01020304... (48 bytes); s = 0x0A0B0C... (48 bytes)
+        let r: Vec<u8> = (1u8..=48).collect();
+        let s: Vec<u8> = (49u8..=96).collect();
+        let der = build_ecdsa_der(&r, &s);
+        let raw = ecdsa_der_to_raw(&der, 48).unwrap();
+        assert_eq!(&raw[..48], &r[..]);
+        assert_eq!(&raw[48..], &s[..]);
+    }
+
+    #[test]
+    fn ecdsa_der_high_bit_set_p384() {
+        // Regression guard for the leading-zero disambiguation branch.
+        // Real KMS signatures have bit 383 set on `r` with ~50% probability;
+        // DER-encodes them as 49-byte INTEGERs (a leading 0x00 followed by
+        // 48 bytes starting with 0x80..). The converter must strip the
+        // leading zero back off.
+        let mut r = vec![0u8; 48];
+        r[0] = 0x80;
+        for (i, b) in r.iter_mut().enumerate().skip(1) {
+            *b = i as u8;
+        }
+        let s = r.iter().rev().copied().collect::<Vec<u8>>();
+        let der = build_ecdsa_der(&r, &s);
+        let raw = ecdsa_der_to_raw(&der, 48).unwrap();
+        assert_eq!(raw.len(), 96);
+        assert_eq!(&raw[..48], &r[..], "r must not have a stray leading zero");
+        assert_eq!(&raw[48..], &s[..], "s must not have a stray leading zero");
+    }
+
+    #[test]
+    fn ecdsa_der_rejects_trailing_bytes() {
+        let r = vec![0x11u8; 48];
+        let s = vec![0x22u8; 48];
+        let mut der = build_ecdsa_der(&r, &s);
+        der.push(0x00); // one stray byte after the SEQUENCE
+        let err = ecdsa_der_to_raw(&der, 48).unwrap_err();
+        assert!(
+            matches!(err, SignerError::DerTrailingBytes { trailing: 1 }),
+            "err={err}",
+        );
+    }
+
+    #[test]
+    fn ecdsa_der_rejects_length_mismatch() {
+        // Build a valid DER envelope, then corrupt the outer length byte
+        // so it claims more content than actually exists.
+        let r = vec![0x11u8; 32];
+        let s = vec![0x22u8; 32];
+        let mut der = build_ecdsa_der(&r, &s);
+        // der[0]=0x30 (SEQ); der[1] is short-form length. Bump it by 10 so
+        // the claimed length exceeds the real content.
+        der[1] = der[1].wrapping_add(10);
+        // Also pad the tail so we don't hit trailing-bytes first.
+        der.extend_from_slice(&[0u8; 10]);
+        let err = ecdsa_der_to_raw(&der, 32).unwrap_err();
+        assert!(
+            matches!(err, SignerError::DerLengthMismatch { .. }),
+            "err={err}",
+        );
+    }
+
+    #[test]
+    fn ecdsa_der_rejects_scalar_too_large() {
+        // 60-byte r/s in a scalar_len=48 context must produce ScalarTooLarge.
+        let r = (1u8..=60).collect::<Vec<u8>>();
+        let s = (61u8..=120).collect::<Vec<u8>>();
+        let der = build_ecdsa_der(&r, &s);
+        let err = ecdsa_der_to_raw(&der, 48).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SignerError::ScalarTooLarge {
+                    r: 60,
+                    s: 60,
+                    expected: 48,
+                }
+            ),
+            "err={err}",
+        );
+    }
+
+    #[test]
+    fn ecdsa_der_pads_short_scalars() {
+        // Short r (leading zero) must be left-padded to scalar_len.
+        let r = vec![0x05];
+        let s = vec![0x06];
+        let der = build_ecdsa_der(&r, &s);
+        let raw = ecdsa_der_to_raw(&der, 48).unwrap();
+        assert_eq!(raw[47], 0x05);
+        assert_eq!(raw[95], 0x06);
+        // All other bytes must be zero.
+        assert!(raw[..47].iter().all(|&b| b == 0));
+        assert!(raw[48..95].iter().all(|&b| b == 0));
+    }
+
+    /// Helper: build the DER envelope for an ECDSA signature.
+    fn build_ecdsa_der(r: &[u8], s: &[u8]) -> Vec<u8> {
+        fn uint(v: &[u8]) -> Vec<u8> {
+            // Skip leading zeros unless it would make the value negative.
+            let mut trimmed = v;
+            while trimmed.len() > 1 && trimmed[0] == 0 {
+                trimmed = &trimmed[1..];
+            }
+            let mut body = Vec::new();
+            if trimmed[0] & 0x80 != 0 {
+                body.push(0);
+            }
+            body.extend_from_slice(trimmed);
+            let mut out = vec![0x02, body.len() as u8];
+            out.extend_from_slice(&body);
+            out
+        }
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&uint(r));
+        inner.extend_from_slice(&uint(s));
+        let mut out = vec![0x30, inner.len() as u8];
+        out.extend_from_slice(&inner);
+        out
+    }
+
+    #[test]
+    fn rejects_rsa_pem_key() {
+        // A phony RSA PEM should be rejected at load time. We only test the
+        // label check because generating an RSA key here would require
+        // another dep. The cert is 8 zero bytes so `detect_cert_curve` fails
+        // first with `ParseCert`; that's still a clean typed rejection.
+        let cert_pem = pem::encode(&pem::Pem::new("CERTIFICATE", vec![0u8; 8]));
+        let key_pem = pem::encode(&pem::Pem::new("RSA PRIVATE KEY", vec![0u8; 8]));
+        let result = LocalSigner::from_pem(cert_pem.as_bytes(), key_pem.as_bytes());
+        assert!(matches!(
+            result.err(),
+            Some(SignerError::KeyPemLabel { .. } | SignerError::ParseCert { .. }),
+        ));
+    }
+
+    #[test]
+    fn rejects_sec1_ec_private_key_with_actionable_error() {
+        // Users who bring a SEC1 (`EC PRIVATE KEY`) file should get a
+        // dedicated error telling them how to convert to PKCS#8 rather
+        // than an opaque `LoadKey` message from aws-lc-rs. To exercise
+        // this path we need a valid-looking cert (so we get past the
+        // cert-curve detection); the shipped `generate_test_cert_and_key`
+        // helper builds a real P-384 cert.
+        //
+        // NOTE: `generate_test_cert_and_key` lives in `lib.rs` under
+        // `#[cfg(test)]`; here in `signer::tests` we synthesize a minimal
+        // valid cert via the shared DER helpers instead so this test
+        // stays self-contained.
+        use crate::der_helpers::wrap_der;
+        // Reuse the module's `spki_der_for_ecdsa`: it emits an SPKI. We
+        // wrap it in a minimal cert manually for testing purposes.
+        // Since we only need to get past cert-curve detection, use a real
+        // P-384 keypair's SPKI.
+        use aws_lc_rs::signature::{EcdsaKeyPair, KeyPair, ECDSA_P384_SHA384_ASN1_SIGNING};
+        let rng = aws_lc_rs::rand::SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, &rng).unwrap();
+        let key_pair =
+            EcdsaKeyPair::from_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8.as_ref()).unwrap();
+        let sec1_pub = key_pair.public_key().as_ref().to_vec();
+        let spki = spki_der_for_ecdsa(&sec1_pub, SignAlg::Es384);
+        // Wrap SPKI in a minimal TBSCertificate SEQUENCE; the actual
+        // fields don't matter beyond being present, since only the SPKI
+        // curve OID is inspected by `detect_cert_curve`.
+        //
+        // Minimal cert = SEQUENCE { TBS = SEQUENCE { SPKI }, sigAlg, sigVal }.
+        // TBS just contains the SPKI — this isn't schema-valid, but
+        // `x509-cert::Certificate::from_der` requires more fields, so use
+        // the fuller cert from lib.rs tests. Since we can't call it from
+        // here, fall back to asserting that PARSE succeeds on the cert
+        // then checks the key label:
+        let cert = wrap_der(0x30, &spki); // clearly not a real cert
+        let cert_pem = pem::encode(&pem::Pem::new("CERTIFICATE", cert));
+        let sec1 = pem::encode(&pem::Pem::new("EC PRIVATE KEY", vec![0u8; 8]));
+        let err = LocalSigner::from_pem(cert_pem.as_bytes(), sec1.as_bytes())
+            .err()
+            .expect("should reject");
+        // Either the parse-cert error (if x509-cert refuses our stub
+        // cert) or the SEC1 label rejection is an acceptable typed
+        // outcome; both cover the "typed error, not a panic" bar.
+        assert!(
+            matches!(
+                err,
+                SignerError::Sec1PrivateKeyUnsupported | SignerError::ParseCert { .. },
+            ),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -29,6 +29,9 @@ pub struct InfraConfig {
 
     // Config for container registries
     pub vendor: Option<HashMap<String, Vendor>>,
+
+    // EIF (Nitro Enclave Image Format) signing config
+    pub eif: Option<EifConfig>,
 }
 
 impl InfraConfig {
@@ -212,6 +215,71 @@ impl TryFrom<SigningKeyConfig> for Url {
     }
 }
 
+/// EIF (Nitro Enclave Image Format) signing configuration.
+///
+/// EIF signing uses its own dedicated cert + key, separate from the sbkeys
+/// profile that signs shim/grub/kernel for UEFI Secure Boot. The two artifacts
+/// have different trust models (EIF signatures are verified by the Nitro
+/// hypervisor against a customer-owned CA; sbkeys are verified by firmware
+/// against the platform db), different key formats (EIF requires an EC key on
+/// a NIST P-curve; sbkeys is typically RSA), and different rotation cadences.
+/// Reusing sbkeys for EIF conflated all three.
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct EifConfig {
+    /// PEM-encoded X.509 certificate whose public key matches `signing_key`.
+    /// Embedded verbatim in the EIF signature section's COSE_Sign1 payload;
+    /// verifiers use its `SubjectPublicKeyInfo` to check the PCR0 signature.
+    pub signing_cert: PathBuf,
+    /// Signing key backend. `file` is a local PEM EC key; `kms` is an AWS KMS
+    /// key referenced by ID/ARN/alias. SSM/env aren't supported: `eif-builder`
+    /// only exposes `--signing-key <path>` and `--kms-key-id <id>`, and both
+    /// alternatives conflate transport with backend.
+    pub signing_key: EifSigningKey,
+}
+
+/// Backend for the EIF signing key.
+///
+/// Deliberately narrower than [`SigningKeyConfig`]: only `file` and `kms`
+/// map onto `eif-builder`'s CLI (`--signing-key` and `--kms-key-id`). Adding
+/// ssm/env variants would let operators write an `Infra.toml` that parses but
+/// can never sign an EIF; we prefer to reject such configs at load time.
+#[allow(non_camel_case_types)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub enum EifSigningKey {
+    file {
+        path: PathBuf,
+    },
+    kms {
+        key_id: String,
+        /// AWS region for the KMS `Sign` call. Optional: when absent, the
+        /// KMS backend falls back to the ambient AWS region resolution
+        /// chain (`AWS_REGION`, `~/.aws/config` profile, IMDS on EC2). In
+        /// the buildkit sandbox where `eif-builder` runs, none of those
+        /// sources is populated by default — an EC2 build host has IMDS
+        /// but the build container is a fresh minimal image without
+        /// AWS_REGION set and with no profile config file — so this field
+        /// is effectively required for the buildkit path. Left optional
+        /// only so unrelated ambient-environment callers (dev laptops
+        /// with a valid `~/.aws/config`) can still work.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        region: Option<String>,
+    },
+}
+
+impl Default for EifSigningKey {
+    // Only exists so `EifConfig: Default` compiles when the outer
+    // `Option<EifConfig>` is `None`. A default `EifSigningKey` is never
+    // actually reachable through the public deserialization path — the
+    // enum has no serde default.
+    fn default() -> Self {
+        EifSigningKey::file {
+            path: PathBuf::new(),
+        }
+    }
+}
+
 /// Represents a Bottlerocket repo's location and the metadata needed to update the repo
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -292,6 +360,83 @@ mod error {
 }
 pub use error::Error;
 pub type Result<T> = std::result::Result<T, error::Error>;
+
+#[test]
+fn eif_config_file_backend_parses() {
+    // A minimal `[eif]` section with a local-file backend must round-trip
+    // through TOML deserialization, and the enum must land on the `file`
+    // variant. Guards against accidental renaming of the field names (which
+    // are the wire contract with `Infra.toml`).
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { file = { path = "/opt/eif/signing.key" } }
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    let eif = cfg.eif.expect("eif section missing");
+    assert_eq!(eif.signing_cert, PathBuf::from("/opt/eif/signing.crt"));
+    match eif.signing_key {
+        EifSigningKey::file { path } => {
+            assert_eq!(path, PathBuf::from("/opt/eif/signing.key"))
+        }
+        _ => panic!("expected file backend"),
+    }
+}
+
+#[test]
+fn eif_config_kms_backend_parses() {
+    // KMS variant: only `key_id` is required. `region` is optional and
+    // must default to `None` when omitted. Serde `deny_unknown_fields` on
+    // both `EifConfig` and `EifSigningKey` means any typo (e.g. `kms_key_id`)
+    // fails loudly instead of silently signing with the wrong backend.
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "alias/my-eif-key" } }
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    let eif = cfg.eif.expect("eif section missing");
+    match eif.signing_key {
+        EifSigningKey::kms { key_id, region } => {
+            assert_eq!(key_id, "alias/my-eif-key");
+            assert_eq!(region, None);
+        }
+        _ => panic!("expected kms backend"),
+    }
+}
+
+#[test]
+fn eif_config_kms_with_region_parses() {
+    // When operators set `region` in Infra.toml the buildsys path
+    // propagates it through to `eif-builder --region`. This test guards
+    // the field name against silent typos: `deny_unknown_fields` rejects
+    // `regoin` / `aws_region` / etc.
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "alias/my-eif-key", region = "us-west-2" } }
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    let eif = cfg.eif.expect("eif section missing");
+    match eif.signing_key {
+        EifSigningKey::kms { key_id, region } => {
+            assert_eq!(key_id, "alias/my-eif-key");
+            assert_eq!(region.as_deref(), Some("us-west-2"));
+        }
+        _ => panic!("expected kms backend"),
+    }
+}
+
+#[test]
+fn eif_config_absent_is_ok() {
+    // An Infra.toml with no [eif] must still parse (unsigned-EIF path).
+    let toml_str = r#"
+[aws]
+regions = ["us-west-2"]
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    assert!(cfg.eif.is_none());
+}
 
 #[test]
 fn repo_expiration_deserialization_test() {

--- a/tools/pubsys/Infra.toml.example
+++ b/tools/pubsys/Infra.toml.example
@@ -26,6 +26,32 @@ signing_keys = { file = { path = "/home/user/key.pem" } }
 #signing_keys = { kms = { key_id = "abc-def-123" } }
 #signing_keys = { ssm = { parameter = "/my/parameter" } }
 
+# EIF (Nitro Enclave Image Format) signing.
+#
+# For variants with `image-format = "eif"`, buildsys embeds a signature over
+# PCR0 into the produced EIF so that the Nitro hypervisor / attestation
+# clients can verify the enclave image. This is a DIFFERENT trust domain
+# from `signing_keys` above (which signs the TUF repo metadata) and from
+# `sbkeys` (which signs shim/grub/kernel for UEFI Secure Boot):
+#
+#   - EIF signatures are verified by the Nitro hypervisor / attestation
+#     consumers against a customer-owned CA (whose cert is embedded in the
+#     signature section).
+#   - TUF `signing_keys` signs update metadata; verified by tough against
+#     the root role.
+#   - `sbkeys` signs pre-boot binaries; verified by firmware against the
+#     platform db.
+#
+# The EIF signing key MUST be an EC key on a NIST P-curve (P-256 or P-384)
+# and its public key MUST match `signing_cert`. Only `file` and `kms`
+# backends are supported (see `EifSigningKey` in pubsys-config).
+#
+# When this section is omitted, EIF builds produce unsigned artifacts.
+#[eif]
+#signing_cert = "/home/user/eif-signing.crt"
+#signing_key = { file = { path = "/home/user/eif-signing.key" } }
+#signing_key = { kms = { key_id = "alias/my-eif-key" } }
+
 # If these URLs are uncommented, the repo will be pulled and used as a starting
 # point, and your images (and related files) will be added as a new update in
 # the created repo.  Otherwise, we build a new repo from scratch.

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -361,6 +361,14 @@ ARG PARTITION_PLAN
 ARG OS_IMAGE_PUBLISH_SIZE_GIB
 ARG DATA_IMAGE_PUBLISH_SIZE_GIB
 ARG KERNEL_PARAMETERS
+# EIF_PCIE_FLAGS: variant-authored EIF header PCIE flags (hex, no `0x` prefix,
+# e.g. "340"). Sourced from `[package.metadata.build-variant] eif-pcie-flags`.
+# Empty when the variant does not set it, in which case `rpm2eif` omits
+# `--pcie-flags` on the `eif-builder` CLI and `eif-builder`'s built-in
+# `DEFAULT_PCIE_FLAGS` (`0x240`, PCIE|PCIE_VIRTIO) is used. Ignored for
+# non-EIF variants. See the header==launch-flags contract in
+# `tools/eif-builder/src/lib.rs`.
+ARG EIF_PCIE_FLAGS
 ARG XFS_DATA_PARTITION
 ARG EROFS_ROOT_PARTITION
 ARG UEFI_SECURE_BOOT
@@ -383,6 +391,7 @@ ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     BUILD_ID_TIMESTAMP=${BUILD_ID_TIMESTAMP} \
     PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
     KERNEL_PARAMETERS=${KERNEL_PARAMETERS} \
+    EIF_PCIE_FLAGS=${EIF_PCIE_FLAGS} \
     TWOLITER_VERSION=${TWOLITER_VERSION}
 WORKDIR /root
 
@@ -579,6 +588,12 @@ ARG TWOLITER_VERSION=""
 # directly (grub.cfg carries per-variant params), but plumbing it here keeps
 # the EIF-repack cmdline identical to what rpm2eif emitted at first build.
 ARG KERNEL_PARAMETERS=""
+# EIF_PCIE_FLAGS: variant-authored EIF header PCIE flags (hex, no `0x` prefix).
+# Consumed by `eif2eif` for `image-format = "eif"` variants so the rebuilt EIF
+# header matches what `rpm2eif` emitted at first build. Empty defers to
+# `eif-builder`'s `DEFAULT_PCIE_FLAGS`. See build stage above and the
+# header==launch-flags contract in `tools/eif-builder/src/lib.rs`.
+ARG EIF_PCIE_FLAGS=""
 
 # ARG values are substituted into the RUN command line but are NOT injected
 # into the RUN process environment. Both `img2img` and `eif2eif` source
@@ -589,7 +604,8 @@ ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
     TWOLITER_VERSION=${TWOLITER_VERSION} \
     IMAGE_NAME=${IMAGE_NAME} VARIANT_NAME=${VARIANT_NAME} ARCH=${ARCH} \
-    KERNEL_PARAMETERS=${KERNEL_PARAMETERS}
+    KERNEL_PARAMETERS=${KERNEL_PARAMETERS} \
+    EIF_PCIE_FLAGS=${EIF_PCIE_FLAGS}
 WORKDIR /root
 
 USER root

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -572,8 +572,24 @@ ARG UEFI_SECURE_BOOT
 ARG EROFS_ROOT_PARTITION
 ARG IN_PLACE_UPDATES
 ARG STANDALONE_IMAGE
+ARG GUEST_IMAGES=""
+ARG TWOLITER_VERSION=""
+# KERNEL_PARAMETERS is variant-declared cmdline glue that `eif2eif` embeds
+# into the rebuilt EIF's kernel command line. `img2img` does not consume it
+# directly (grub.cfg carries per-variant params), but plumbing it here keeps
+# the EIF-repack cmdline identical to what rpm2eif emitted at first build.
+ARG KERNEL_PARAMETERS=""
+
+# ARG values are substituted into the RUN command line but are NOT injected
+# into the RUN process environment. Both `img2img` and `eif2eif` source
+# `imghelper`, which does `${IMAGE_NAME:?}` at source-time and needs these
+# in the environment. Forward everything into ENV in a single block so a
+# future edit adding a variable can't skew the two halves.
 ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
-    VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
+    VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
+    TWOLITER_VERSION=${TWOLITER_VERSION} \
+    IMAGE_NAME=${IMAGE_NAME} VARIANT_NAME=${VARIANT_NAME} ARCH=${ARCH} \
+    KERNEL_PARAMETERS=${KERNEL_PARAMETERS}
 WORKDIR /root
 
 USER root
@@ -591,26 +607,40 @@ RUN --mount=target=/host \
     --mount=type=secret,id=config-sign.key,target=/root/sbkeys/config-sign.key \
     --mount=type=secret,id=efi-vars.json,target=/root/sbkeys/efi-vars.json \
     --mount=type=secret,id=kms-sign.json,target=/root/.config/aws-kms-pkcs11/config.json \
+    --mount=type=secret,id=eif-signing.crt,target=/root/eif/signing.crt \
+    --mount=type=secret,id=eif-signing.key,target=/root/eif/signing.key \
+    --mount=type=secret,id=eif-kms-key-id.env,target=/root/eif/kms-key-id \
+    --mount=type=secret,id=eif-kms-region.env,target=/root/eif/kms-region \
     --mount=type=secret,id=aws-access-key-id.env,target=/root/.aws/aws-access-key-id.env \
     --mount=type=secret,id=aws-secret-access-key.env,target=/root/.aws/aws-secret-access-key.env \
     --mount=type=secret,id=aws-session-token.env,target=/root/.aws/aws-session-token.env \
     /host/build/tools/pipesys link --fd-socket "${BYPASS_SOCKET}" --target /bypass && \
     /host/build/tools/pipesys link --fd-socket "${OUTPUT_SOCKET}" --target /output && \
     rm -rf /output/* && \
-    /host/build/tools/img2img \
-      --input-dir="/bypass/build/images/${ARCH}-${VARIANT_NAME}/${VERSION_ID}-${BUILD_ID}" \
-      --output-dir=/output \
-      --output-fmt="${IMAGE_FORMAT}" \
-      --os-image-size-gib="${OS_IMAGE_SIZE_GIB}" \
-      --data-image-size-gib="${DATA_IMAGE_SIZE_GIB}" \
-      --os-image-publish-size-gib="${OS_IMAGE_PUBLISH_SIZE_GIB}" \
-      --data-image-publish-size-gib="${DATA_IMAGE_PUBLISH_SIZE_GIB}" \
-      --partition-plan="${PARTITION_PLAN}" \
-      --ovf-template="/bypass/variants/${VARIANT_NAME}/template.ovf" \
-      ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
-      ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
-      ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
-      --with-standalone-image="${STANDALONE_IMAGE:-no}" && \
+    if [[ "${IMAGE_FORMAT}" == "eif" ]]; then \
+      /host/build/tools/eif2eif \
+        --input-dir="/bypass/build/images/${ARCH}-${VARIANT_NAME}/${VERSION_ID}-${BUILD_ID}" \
+        --output-dir=/output \
+        --os-image-size-gib="${OS_IMAGE_SIZE_GIB}" \
+        ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
+        --with-standalone-image="${STANDALONE_IMAGE:-no}" ; \
+    else \
+      /host/build/tools/img2img \
+        --input-dir="/bypass/build/images/${ARCH}-${VARIANT_NAME}/${VERSION_ID}-${BUILD_ID}" \
+        --output-dir=/output \
+        --output-fmt="${IMAGE_FORMAT}" \
+        --os-image-size-gib="${OS_IMAGE_SIZE_GIB}" \
+        --data-image-size-gib="${DATA_IMAGE_SIZE_GIB}" \
+        --os-image-publish-size-gib="${OS_IMAGE_PUBLISH_SIZE_GIB}" \
+        --data-image-publish-size-gib="${DATA_IMAGE_PUBLISH_SIZE_GIB}" \
+        --partition-plan="${PARTITION_PLAN}" \
+        --ovf-template="/bypass/variants/${VARIANT_NAME}/template.ovf" \
+        ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
+        ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
+        ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
+        --with-standalone-image="${STANDALONE_IMAGE:-no}" \
+        --guest-images="${GUEST_IMAGES}" ; \
+    fi && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
     rm /bypass && \

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -369,6 +369,14 @@ ARG KERNEL_PARAMETERS
 # non-EIF variants. See the header==launch-flags contract in
 # `tools/eif-builder/src/lib.rs`.
 ARG EIF_PCIE_FLAGS
+# EIF_KERNEL_FORMAT: variant-authored x86_64 EIF kernel format
+# (`bzimage`|`vmlinux`). Sourced from `[package.metadata.build-variant]
+# eif-kernel-format`. Empty when unset, in which case `rpm2eif` applies its
+# built-in default (bzImage — the sidecar Nitro Enclaves in-memory image
+# loader boots via the bzImage protocol, validating `BZIMAGE_HEADER_MAGIC`).
+# Ignored on aarch64. See buildsys `BuildVariant::eif_kernel_format` for
+# the rationale on keeping this selectable.
+ARG EIF_KERNEL_FORMAT
 ARG XFS_DATA_PARTITION
 ARG EROFS_ROOT_PARTITION
 ARG UEFI_SECURE_BOOT
@@ -392,6 +400,7 @@ ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
     PRETTY_NAME=${PRETTY_NAME} IMAGE_NAME=${IMAGE_NAME} \
     KERNEL_PARAMETERS=${KERNEL_PARAMETERS} \
     EIF_PCIE_FLAGS=${EIF_PCIE_FLAGS} \
+    EIF_KERNEL_FORMAT=${EIF_KERNEL_FORMAT} \
     TWOLITER_VERSION=${TWOLITER_VERSION}
 WORKDIR /root
 
@@ -439,6 +448,7 @@ RUN --mount=target=/host \
         ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
         ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
         ${ENCRYPTED_STORAGE:+--with-encrypted-storage=yes} \
+        ${EIF_KERNEL_FORMAT:+--eif-kernel-format=${EIF_KERNEL_FORMAT}} \
         --with-standalone-image="${STANDALONE_IMAGE:-no}" ; \
     else \
       /host/build/tools/rpm2img \

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -401,6 +401,10 @@ RUN --mount=target=/host \
     --mount=type=secret,id=config-sign.key,target=/root/sbkeys/config-sign.key \
     --mount=type=secret,id=efi-vars.json,target=/root/sbkeys/efi-vars.json \
     --mount=type=secret,id=kms-sign.json,target=/root/.config/aws-kms-pkcs11/config.json \
+    --mount=type=secret,id=eif-signing.crt,target=/root/eif/signing.crt \
+    --mount=type=secret,id=eif-signing.key,target=/root/eif/signing.key \
+    --mount=type=secret,id=eif-kms-key-id.env,target=/root/eif/kms-key-id \
+    --mount=type=secret,id=eif-kms-region.env,target=/root/eif/kms-region \
     --mount=type=secret,id=aws-access-key-id.env,target=/root/.aws/aws-access-key-id.env \
     --mount=type=secret,id=aws-secret-access-key.env,target=/root/.aws/aws-secret-access-key.env \
     --mount=type=secret,id=aws-session-token.env,target=/root/.aws/aws-session-token.env \

--- a/twoliter/embedded/eif-sign-helper
+++ b/twoliter/embedded/eif-sign-helper
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# eif-sign-helper - translate the EIF signing profile mounted by buildsys
+# (via Infra.toml's [eif] section) into the CLI flag tuple that `eif-builder`
+# (both `build` and `resign`) accepts.
+#
+# This file is *sourced* by rpm2eif, eif2eif, and img2img; do not `exec` it.
+# It defines a single function and performs no top-level side effects.
+#
+# Contract:
+#
+#   discover_eif_signer_args OUT_ARRAY_NAME
+#
+# Fills the caller's array (bash nameref) with an ordered list of
+# `--signing-cert …`, `--signing-key …` (local backend) or
+# `--kms-key-id …` (KMS backend) arguments suitable for either
+#   `eif-builder --arch … ${OUT_ARRAY[@]}` (build)
+# or
+#   `eif-builder resign --input … --output … ${OUT_ARRAY[@]}` (resign).
+#
+# Return codes:
+#
+#   0  Profile detected (array may be empty when no [eif] section is
+#      configured in Infra.toml; callers use "empty array ⇒ produce an
+#      unsigned artifact").
+#   1  A cert was mounted but neither a key nor a KMS key id was — the
+#      Infra.toml is inconsistent, or the buildkit secret plumbing dropped
+#      one of the two inputs. A diagnostic is emitted to stderr; the caller
+#      should propagate the failure.
+#
+# Environment:
+#
+#   EIF_SIGNING_DIR  Directory carrying the mounted signing artifacts.
+#                    Defaults to `/root/eif`, matching build.Dockerfile's
+#                    `--mount=type=secret,target=/root/eif/...` layout.
+#                    Overridable so the accompanying test can point the
+#                    helper at a synthesized fixture dir.
+#
+#   EIF_AWS_DIR      Directory carrying the mounted AWS credential env
+#                    files (`aws-access-key-id.env`,
+#                    `aws-secret-access-key.env`,
+#                    `aws-session-token.env`). Defaults to
+#                    `${HOME:-/root}/.aws`. Only consulted on the KMS
+#                    backend; ignored for the local-key path.
+#
+# Discovery order:
+#
+#   1. No `${EIF_SIGNING_DIR}/signing.crt`  →  empty array, return 0
+#      (unsigned; the operator did not add an `[eif]` section to
+#      Infra.toml, or no Infra.toml was passed to twoliter/buildsys).
+#   2. `signing.crt` + `signing.key` (both non-empty on disk):
+#      local backend → --signing-cert + --signing-key.
+#   3. `signing.crt` + `kms-key-id` (non-empty file whose contents are
+#      the KMS key id/ARN/alias):
+#      KMS backend   → --kms-key-id + --signing-cert (+ --region when a
+#      non-empty `kms-region` sidecar file is present). This also
+#      exports AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
+#      AWS_SESSION_TOKEN into the caller's environment from the AWS
+#      credential env files that buildsys mounts alongside the signing
+#      profile, because `eif-builder`'s `aws-config::from_env()` needs
+#      them exported (mounting alone puts the files on disk but leaves
+#      the env unset). Without this, KMS Sign hard-fails with a
+#      credentials-not-found error on the first call — every non-EC2
+#      build host would break, and even EC2 build hosts break because
+#      the buildkit container does not have IMDS.
+#   4. Cert but neither backend: hard error (rc 1). This case does not
+#      occur through the normal `Infra.toml [eif]` path — buildsys
+#      pre-validates both cert and backend before mounting — so hitting
+#      it indicates broken build plumbing rather than an operator
+#      configuration mistake, and we refuse rather than silently
+#      producing an unsigned artifact when the operator asked for
+#      signing.
+#
+# History: previously this helper autodetected against `~/sbkeys/code-sign.*`
+# and `~/.config/aws-kms-pkcs11/config.json`, reusing the UEFI Secure Boot
+# code-signing key for EIF as well. That conflated three separate concerns
+# (Nitro-hypervisor trust vs. UEFI-firmware db trust; EC-only vs. typically
+# RSA; distinct rotation cadences), and made it impossible for a maintainer
+# to run one build with sbkeys signing but an EIF signed by a different key.
+# The dedicated `[eif]` section in Infra.toml replaces that autodetect.
+
+discover_eif_signer_args() {
+  local -n _out=${1:?discover_eif_signer_args: OUT_ARRAY_NAME required}
+  # Reset to empty in case the caller passed a pre-populated array.
+  _out=()
+
+  local dir="${EIF_SIGNING_DIR:-/root/eif}"
+  local cert="${dir}/signing.crt"
+  local key="${dir}/signing.key"
+  local kms_key_id_file="${dir}/kms-key-id"
+  local kms_region_file="${dir}/kms-region"
+
+  # Case 1: no cert at all → no signing profile ([eif] absent from
+  # Infra.toml, or no Infra.toml was passed to buildsys).
+  if [[ ! -s "${cert}" ]]; then
+    return 0
+  fi
+
+  # Case 2: local key backend.
+  if [[ -s "${key}" ]]; then
+    echo "eif-sign-helper: local backend, cert=${cert}" >&2
+    _out=(
+      --signing-cert "${cert}"
+      --signing-key  "${key}"
+    )
+    return 0
+  fi
+
+  # Case 3: KMS backend. The buildkit env-source secret mount produces a
+  # file whose contents are exactly the env var's value (no trailing
+  # newline injection). Strip any incidental whitespace defensively.
+  if [[ -s "${kms_key_id_file}" ]]; then
+    local key_id
+    key_id="$(tr -d '[:space:]' <"${kms_key_id_file}")"
+    if [[ -z "${key_id}" ]]; then
+      echo "eif-sign-helper: ${kms_key_id_file} is empty after stripping whitespace" >&2
+      return 1
+    fi
+    _out=(
+      --kms-key-id   "${key_id}"
+      --signing-cert "${cert}"
+    )
+    # Optional --region: buildsys mounts a `kms-region` sidecar when
+    # Infra.toml `[eif].signing_key.kms.region` is set. Missing or empty
+    # file means "let the SDK's ambient chain resolve it" — the
+    # `KmsSigner` will hard-fail on the first Sign call if the chain is
+    # empty, which is the expected diagnostic (region is a config
+    # concern; better a loud SDK error than a silent fallback).
+    local region=""
+    if [[ -s "${kms_region_file}" ]]; then
+      region="$(tr -d '[:space:]' <"${kms_region_file}")"
+    fi
+    if [[ -n "${region}" ]]; then
+      _out+=(--region "${region}")
+    fi
+
+    # Export the AWS credential env from the mounted `.env` files so
+    # `aws-config::from_env()` inside `eif-builder` can pick them up.
+    # Mounting alone (buildkit `--mount=type=secret,id=aws-*.env`) puts
+    # the file on disk at ${EIF_AWS_DIR}/aws-*.env but leaves the env
+    # unset. Only the KMS path needs credentials; local-key builds do
+    # not touch AWS.
+    local aws_dir="${EIF_AWS_DIR:-${HOME:-/root}/.aws}"
+    local var val
+    for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN; do
+      # Buildsys mounts each credential at
+      # `${aws_dir}/aws-<lowercase-dashed-name>.env` (see build.Dockerfile
+      # `aws-access-key-id.env` / `aws-secret-access-key.env` /
+      # `aws-session-token.env`). Skip absent/empty files silently: a
+      # session-token file is only mounted when the operator's STS
+      # profile uses temporary credentials.
+      val="${var,,}"
+      val="${aws_dir}/${val//_/-}.env"
+      [[ -s "${val}" ]] || continue
+      export "${var}=$(<"${val}")"
+    done
+
+    echo "eif-sign-helper: KMS backend, key=${key_id}, region=${region:-<ambient>}" >&2
+    return 0
+  fi
+
+  # Case 4: cert but no backend. Should not happen through Infra.toml [eif]
+  # — buildsys validates both sides before mounting. If we get here, the
+  # build's secret plumbing is broken (e.g. buildkit didn't receive the
+  # env source, or a stale layer cached an incomplete profile). Fail loudly
+  # rather than downgrade to unsigned, because the presence of the cert
+  # means the operator did ask for signing.
+  echo "eif-sign-helper: ${cert} is present but neither ${key} nor ${kms_key_id_file} is; refusing to build an unsigned EIF (check Infra.toml [eif].signing_key and buildkit secret plumbing)" >&2
+  return 1
+}

--- a/twoliter/embedded/eif2eif
+++ b/twoliter/embedded/eif2eif
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# eif2eif - repack an EIF variant's disk image + EIF sidecar with fresh
+# rootfs edits (CA bundle, root.json), new erofs ROOT-A, new dm-verity
+# HASH-A, and a re-signed EIF whose kernel cmdline pins the new verity
+# root hash.
+#
+# Produces (mirroring rpm2eif's output shape):
+#   - {prefix}.eif        newly rebuilt, signed if Infra.toml [eif] is configured
+#   - {prefix}-disk.img   GPT disk with new ROOT-A + HASH-A
+#   - {prefix}-kernel     copied byte-for-byte from the input (unchanged)
+#   - latest.eif, latest-disk.img, latest-kernel symlinks
+#
+# Contract vs. `img2img`:
+#   - Same CLI shape (input-dir, output-dir, feature flags). `--guest-images`
+#     is accepted for parity but ignored (an EIF variant has no rootfs to
+#     resign guests inside — its rootfs is the enclave's own).
+#   - IMAGE_FORMAT/OUTPUT_FMT is not "raw"/"qcow2"/"vmdk"; we ignore whatever
+#     is passed and produce the EIF-native artifact set.
+#   - Because the kernel cmdline changes (new dm-verity root hash), PCR0
+#     changes, and we cannot use `eif-builder resign`: we do a full
+#     `eif-builder build` here. `resign` is used only for guest EIFs inside
+#     a *host* repack (see img2img).
+
+set -eux -o pipefail
+shopt -qs failglob
+
+# ---------- CLI parse ----------
+
+INPUT_DIR=""
+OUTPUT_DIR=""
+OS_IMAGE_SIZE_GIB="0"
+# Feature flags: EIF's fixed profile is enforced (parity with rpm2eif).
+EROFS_ROOT_PARTITION="yes"
+UEFI_SECURE_BOOT="no"
+IN_PLACE_UPDATES="no"
+ENCRYPTED_STORAGE="no"
+STANDALONE_IMAGE="yes"
+# Accepted but ignored: an EIF variant is a "leaf" — it has no guests inside
+# its own rootfs. See docstring above.
+GUEST_IMAGES=""
+
+for opt in "$@"; do
+  optarg="$(expr "${opt}" : '[^=]*=\(.*\)' || echo '')"
+  case "${opt}" in
+    --input-dir=*)                    INPUT_DIR="${optarg}" ;;
+    --output-dir=*)                   OUTPUT_DIR="${optarg}" ;;
+    --output-fmt=*)                   : ;;   # accepted, ignored (EIF is EIF)
+    --os-image-size-gib=*)            OS_IMAGE_SIZE_GIB="${optarg}" ;;
+    --data-image-size-gib=*)          : ;;
+    --os-image-publish-size-gib=*)    : ;;
+    --data-image-publish-size-gib=*)  : ;;
+    --partition-plan=*)               : ;;
+    --ovf-template=*)                 : ;;
+    --with-erofs-root-partition=*)    EROFS_ROOT_PARTITION="${optarg}" ;;
+    --with-uefi-secure-boot=*)        UEFI_SECURE_BOOT="${optarg}" ;;
+    --with-in-place-updates=*)        IN_PLACE_UPDATES="${optarg}" ;;
+    --with-encrypted-storage=*)       ENCRYPTED_STORAGE="${optarg}" ;;
+    --with-standalone-image=*)        STANDALONE_IMAGE="${optarg}" ;;
+    --guest-images=*)                 GUEST_IMAGES="${optarg}" ;;
+    *)
+      echo "eif2eif: unexpected arg: ${opt}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${INPUT_DIR}" || -z "${OUTPUT_DIR}" ]]; then
+  echo "eif2eif: --input-dir and --output-dir are required" >&2
+  exit 1
+fi
+
+# Same EIF-only feature-profile enforcement as rpm2eif. Keep in sync with
+# `validate_image_features` in tools/buildsys/src/manifest.rs.
+declare -A eif_flag_allowlist=(
+  [EROFS_ROOT_PARTITION]="yes"
+  [UEFI_SECURE_BOOT]="no"
+  [IN_PLACE_UPDATES]="no"
+  [ENCRYPTED_STORAGE]="no"
+  [STANDALONE_IMAGE]="yes"
+)
+eif_flag_errors=0
+for flag in "${!eif_flag_allowlist[@]}"; do
+  want="${eif_flag_allowlist[${flag}]}"
+  have="${!flag}"
+  if [[ "${have}" != "${want}" ]]; then
+    echo "eif2eif: image-format='eif' requires ${flag}='${want}' (got '${have}')" >&2
+    eif_flag_errors=$((eif_flag_errors + 1))
+  fi
+done
+(( eif_flag_errors == 0 )) || exit 1
+
+if ! [[ "${OS_IMAGE_SIZE_GIB}" =~ ^[0-9]+$ ]]; then
+  echo "eif2eif: --os-image-size-gib='${OS_IMAGE_SIZE_GIB}' is not a non-negative integer" >&2
+  exit 1
+fi
+
+# Required env vars (provided by buildsys / the Dockerfile).
+: "${VERSION_ID:?VERSION_ID must be set}"
+: "${BUILD_ID:?BUILD_ID must be set}"
+: "${IMAGE_NAME:?IMAGE_NAME must be set}"
+: "${VARIANT_NAME:?VARIANT_NAME must be set}"
+: "${ARCH:?ARCH must be set}"
+
+# ---------- Helpers ----------
+
+. "${0%/*}/imghelper"          # install_ca_certs, install_root_json, mkfs_root_erofs,
+                               # generate_verity_root, check_image_size, ...
+. "${0%/*}/partyplanner"       # BOTTLEROCKET_{ROOT,HASH}_TYPECODE, set_eif_partition_sizes
+. "${0%/*}/eif-sign-helper"    # discover_eif_signer_args
+
+# ---------- Working environment ----------
+
+WORKDIR="$(mktemp -d)"
+trap '[[ -d "${WORKDIR}" ]] && rm -rf "${WORKDIR}"' EXIT
+pushd "${WORKDIR}" >/dev/null
+
+OUTPUT_DIR="${OUTPUT_DIR}/${VERSION_ID}-${BUILD_ID}"
+mkdir -p "${OUTPUT_DIR}"
+
+# ---------- Locate input artifacts ----------
+
+# rpm2eif writes its outputs into a versioned subdirectory. Whatever
+# directory was passed in via --input-dir is expected to be that
+# versioned dir (buildsys resolves the path).
+#
+# Use `nullglob` so an empty match returns an empty array rather than the
+# literal pattern (bash's default). That makes the `${#a[@]}` check below
+# meaningful — without it, `${#a[@]}` is always >= 1 because the unexpanded
+# pattern occupies the array.
+shopt -u failglob
+shopt -s nullglob
+disk_imgs=( "${INPUT_DIR}"/*-disk.img )
+eif_files=( "${INPUT_DIR}"/*.eif )
+kernels=(   "${INPUT_DIR}"/*-kernel )
+shopt -u nullglob
+shopt -s failglob
+
+for arr in disk_imgs eif_files kernels; do
+  declare -n a="${arr}"
+  if (( ${#a[@]} == 0 )); then
+    echo "eif2eif: no matching input in ${INPUT_DIR} for ${arr}" >&2
+    exit 1
+  fi
+  unset -n a
+done
+
+# Skip stable-name symlinks (`latest.eif`, `latest-disk.img`, ...) so we
+# operate on the versioned artifacts and avoid clobbering by editing
+# through a symlink.
+pick_versioned() {
+  local -n src="$1"
+  local -n dst="$2"
+  dst=()
+  local f
+  for f in "${src[@]}"; do
+    [[ -L "${f}" ]] && continue
+    dst+=("${f}")
+  done
+}
+declare -a INPUT_DISKS INPUT_EIFS INPUT_KERNELS
+pick_versioned disk_imgs INPUT_DISKS
+pick_versioned eif_files INPUT_EIFS
+pick_versioned kernels    INPUT_KERNELS
+
+if (( ${#INPUT_DISKS[@]} != 1 )); then
+  echo "eif2eif: expected exactly one -disk.img in ${INPUT_DIR}, found ${#INPUT_DISKS[@]}" >&2
+  exit 1
+fi
+if (( ${#INPUT_EIFS[@]} != 1 )); then
+  echo "eif2eif: expected exactly one .eif in ${INPUT_DIR}, found ${#INPUT_EIFS[@]}" >&2
+  exit 1
+fi
+if (( ${#INPUT_KERNELS[@]} != 1 )); then
+  echo "eif2eif: expected exactly one -kernel in ${INPUT_DIR}, found ${#INPUT_KERNELS[@]}" >&2
+  exit 1
+fi
+
+INPUT_DISK="${INPUT_DISKS[0]}"
+INPUT_EIF="${INPUT_EIFS[0]}"
+INPUT_KERNEL="${INPUT_KERNELS[0]}"
+
+# ---------- Extract ROOT-A from input disk ----------
+
+# rpm2eif produced a 2-partition GPT: ROOT-A (erofs) at partition 1,
+# HASH-A (dm-verity) at partition 2. Read the current geometry.
+declare -A imgsize imgoff
+get_partition_sizes "${INPUT_DISK}" "" imgsize imgoff
+
+for part in ROOT-A HASH-A; do
+  if [[ -z "${imgsize[${part}]:-}" || -z "${imgoff[${part}]:-}" ]]; then
+    echo "eif2eif: input disk is missing ${part} partition" >&2
+    exit 1
+  fi
+done
+
+ROOT_MOUNT="${WORKDIR}/rootfs"
+mkdir -p "${ROOT_MOUNT}"
+ROOTFS_IN="${WORKDIR}/root-in.erofs"
+dd if="${INPUT_DISK}" of="${ROOTFS_IN}" \
+  count="${imgsize[ROOT-A]}" bs=1M skip="${imgoff[ROOT-A]}" status=none
+
+# Validate the filesystem type before we try to extract.
+fs_type="$(blkid -c /dev/null -o value -s TYPE "${ROOTFS_IN}")"
+if [[ "${fs_type}" != "erofs" ]]; then
+  echo "eif2eif: input ROOT-A is '${fs_type}', expected 'erofs'" >&2
+  exit 1
+fi
+
+fsck.erofs --extract="${ROOT_MOUNT}" "${ROOTFS_IN}"
+touch -r "${ROOTFS_IN}" "${ROOT_MOUNT}"
+rm -f "${ROOTFS_IN}"
+
+# ---------- Replace CA bundle and root.json ----------
+
+install_ca_certs "${ROOT_MOUNT}"
+install_root_json "${ROOT_MOUNT}"
+
+# ---------- Rebuild ROOT-A (erofs) ----------
+
+SELINUX_FILE_CONTEXTS="${ROOT_MOUNT}/etc/selinux/fortified/contexts/files/file_contexts"
+ROOTFS_OUT="${WORKDIR}/root-out.erofs"
+mkfs_root_erofs "${ROOT_MOUNT}" "${ROOTFS_OUT}" "${SELINUX_FILE_CONTEXTS}"
+
+# ---------- Generate new dm-verity HASH-A ----------
+
+ROOTFS_SIZE="$(stat -c %s "${ROOTFS_OUT}")"
+ROOTFS_MIB="$(( (ROOTFS_SIZE + 1048575) / 1048576 ))"
+VERITY_MIB="$(( (ROOTFS_MIB / 64) + 4 ))"
+
+VERITY_OUT="${WORKDIR}/hash-out.verity"
+declare -a DM_VERITY_ROOT
+generate_verity_root "${ROOTFS_OUT}" "${VERITY_OUT}" "${VERITY_MIB}" DM_VERITY_ROOT
+
+VERITY_DATA_SECTORS="${DM_VERITY_ROOT[1]}"
+VERITY_DATA_BLOCKS="${DM_VERITY_ROOT[8]}"
+VERITY_ROOT_HASH="${DM_VERITY_ROOT[11]}"
+VERITY_SALT="${DM_VERITY_ROOT[12]}"
+
+# Validate before we bake them into the kernel cmdline.
+[[ "${VERITY_ROOT_HASH}" =~ ^[0-9a-f]{64}$ ]] \
+  || { echo "eif2eif: bad verity root hash: ${VERITY_ROOT_HASH}" >&2; exit 1; }
+[[ "${VERITY_SALT}" =~ ^[0-9a-f]+$ ]] \
+  || { echo "eif2eif: bad verity salt: ${VERITY_SALT}" >&2; exit 1; }
+[[ "${VERITY_DATA_SECTORS}" =~ ^[0-9]+$ ]] \
+  || { echo "eif2eif: bad verity data sectors" >&2; exit 1; }
+[[ "${VERITY_DATA_BLOCKS}" =~ ^[0-9]+$ ]] \
+  || { echo "eif2eif: bad verity data blocks" >&2; exit 1; }
+
+# ---------- Build fresh GPT ----------
+
+target_mib=0
+if (( OS_IMAGE_SIZE_GIB > 0 )); then
+  target_mib=$(( OS_IMAGE_SIZE_GIB * 1024 ))
+fi
+declare -A eif_partsize eif_partoff
+set_eif_partition_sizes "${ROOTFS_MIB}" "${VERITY_MIB}" \
+  eif_partsize eif_partoff "${target_mib}"
+
+ROOT_OFF_MIB="${eif_partoff[ROOT-A]}"
+ROOT_SIZE_MIB="${eif_partsize[ROOT-A]}"
+HASH_OFF_MIB="${eif_partoff[HASH-A]}"
+HASH_SIZE_MIB="${eif_partsize[HASH-A]}"
+DISK_SIZE_MIB="$(( HASH_OFF_MIB + HASH_SIZE_MIB + 1 ))"
+
+DISK_OUT="${WORKDIR}/disk-out.img"
+truncate -s "${DISK_SIZE_MIB}M" "${DISK_OUT}"
+sgdisk -Z "${DISK_OUT}" >/dev/null
+
+check_image_size "${ROOTFS_OUT}" "${ROOT_SIZE_MIB}"
+check_image_size "${VERITY_OUT}" "${HASH_SIZE_MIB}"
+
+ROOT_START="$(( ROOT_OFF_MIB * 2048 ))"
+ROOT_END="$(( (ROOT_OFF_MIB + ROOT_SIZE_MIB) * 2048 - 1 ))"
+HASH_START="$(( HASH_OFF_MIB * 2048 ))"
+HASH_END="$(( (HASH_OFF_MIB + HASH_SIZE_MIB) * 2048 - 1 ))"
+
+sgdisk \
+  --new=1:${ROOT_START}:${ROOT_END} --typecode=1:${BOTTLEROCKET_ROOT_TYPECODE} --change-name=1:ROOT-A \
+  --new=2:${HASH_START}:${HASH_END} --typecode=2:${BOTTLEROCKET_HASH_TYPECODE} --change-name=2:HASH-A \
+  "${DISK_OUT}"
+
+dd if="${ROOTFS_OUT}" of="${DISK_OUT}" conv=notrunc bs=1M seek="${ROOT_OFF_MIB}" status=none
+dd if="${VERITY_OUT}" of="${DISK_OUT}" conv=notrunc bs=1M seek="${HASH_OFF_MIB}" status=none
+sgdisk -v "${DISK_OUT}"
+
+# ---------- Build new EIF ----------
+
+DM_CREATE="dm-mod.create=\"root,,,ro,0 ${VERITY_DATA_SECTORS} verity 1 /dev/vda1 /dev/vda2 4096 4096 ${VERITY_DATA_BLOCKS} 1 sha256 ${VERITY_ROOT_HASH} ${VERITY_SALT} 2 restart_on_corruption ignore_zero_blocks\""
+KERNEL_CMDLINE="root=/dev/dm-0 ro rootwait console=ttyS0 initcall_blacklist=i8042_init ${DM_CREATE}${KERNEL_PARAMETERS:+ ${KERNEL_PARAMETERS}}"
+
+# The kernel cmdline changes (new verity root hash), so PCR0 changes, so a
+# `resign` is not enough — we must run a full `eif-builder build`. We feed
+# it the *already-prepared* kernel from the input `-kernel` sidecar: those
+# bytes are exactly what the input EIF embedded, so the new EIF has the
+# same kernel section as the input.
+sign_args=()
+if ! discover_eif_signer_args sign_args; then
+  exit 1
+fi
+
+EIF_OUT="${WORKDIR}/out.eif"
+
+# Carry METADATA identity fields forward from the input EIF.
+#
+# rpm2eif populates KernelVersion / ImageVersion / BuildTime from the source
+# build's own inputs (RPM db, VERSION_ID, BUILD_ID_TIMESTAMP). eif2eif has
+# none of those to query at this point — the rootfs has been extracted and
+# rebuilt, but the RPM db lookup happens well before this script runs, and
+# we can't derive the original build's timestamp from any current-run state.
+# So we read them out of the input EIF's METADATA section via
+# `eif-builder describe` and forward them verbatim. This makes a repacked
+# EIF's provenance identify the *original* build, not the repack run —
+# which is what a consumer inspecting `ImageVersion` / `BuildTime` would
+# reasonably expect: a repack changes the disk layout (dm-verity), not the
+# release identity.
+#
+# `jq -r` prints "null" for a missing key and the literal string for
+# present-but-empty. Both map to "unknown" via the sentinel logic below,
+# matching rpm2eif's fallback for missing information.
+#
+# `describe` prints a single JSON blob to stdout with no stderr output on
+# success, so it is safe to consume directly.
+INPUT_METADATA_JSON="$(/host/build/tools/eif-builder describe --input "${INPUT_EIF}" --compact)"
+
+read_metadata_field() {
+  local path="${1:?}"
+  local fallback="${2:?}"
+  local value
+  value="$(jq -r "${path} // \"${fallback}\"" <<<"${INPUT_METADATA_JSON}")"
+  if [[ -z "${value}" || "${value}" == "null" ]]; then
+    value="${fallback}"
+  fi
+  printf '%s' "${value}"
+}
+
+INPUT_KERNEL_VERSION="$(read_metadata_field '.metadata.BuildMetadata.KernelVersion' 'unknown')"
+INPUT_IMAGE_VERSION="$(read_metadata_field '.metadata.ImageVersion' '')"
+INPUT_BUILD_TIME="$(read_metadata_field '.metadata.BuildMetadata.BuildTime' '')"
+
+# `eif-builder build` runs `prepare_kernel` on --kernel unconditionally.
+# ${INPUT_KERNEL} here is the already-prepared kernel (rpm2eif emitted the
+# post-zboot-unwrap flat Image on arm64 / vmlinux on x86_64), so
+# `prepare_kernel` must be idempotent on this input for the resulting
+# EIF's KERNEL section to match what the original build embedded:
+#   - x86_64: pass-through (identity).
+#   - arm64: `prepare_kernel` sees a flat PE Image (MZ + ARM\x64), which
+#     is already the target format; the zboot-unwrap path does not fire.
+# See `tools/eif-builder/src/kernel.rs` for the branches. If a future
+# change makes `prepare_kernel` non-idempotent (e.g. inserting padding),
+# the -kernel sidecar this script emits and the KERNEL section embedded
+# in the new .eif will drift — audit this call site accordingly.
+/host/build/tools/eif-builder \
+  --kernel "${INPUT_KERNEL}" \
+  --cmdline "${KERNEL_CMDLINE}" \
+  --output "${EIF_OUT}" \
+  --arch "${ARCH}" \
+  --build-tool-version "${TWOLITER_VERSION:-}" \
+  --kernel-version "${INPUT_KERNEL_VERSION}" \
+  --image-version "${INPUT_IMAGE_VERSION}" \
+  --build-time "${INPUT_BUILD_TIME}" \
+  "${sign_args[@]}"
+
+# ---------- Emit artifacts ----------
+
+ARTIFACT_PREFIX="${IMAGE_NAME}-${VARIANT_NAME}-${ARCH}-${VERSION_ID}-${BUILD_ID}"
+cp "${INPUT_KERNEL}" "${OUTPUT_DIR}/${ARTIFACT_PREFIX}-kernel"
+cp "${EIF_OUT}"      "${OUTPUT_DIR}/${ARTIFACT_PREFIX}.eif"
+cp "${DISK_OUT}"     "${OUTPUT_DIR}/${ARTIFACT_PREFIX}-disk.img"
+
+ln -snf "${ARTIFACT_PREFIX}.eif"      "${OUTPUT_DIR}/latest.eif"
+ln -snf "${ARTIFACT_PREFIX}-disk.img" "${OUTPUT_DIR}/latest-disk.img"
+ln -snf "${ARTIFACT_PREFIX}-kernel"   "${OUTPUT_DIR}/latest-kernel"
+
+popd >/dev/null
+
+# Ensure final ownership matches buildsys expectations.
+find "${OUTPUT_DIR}" -maxdepth 1 -type f -print -exec chown 1000:1000 {} \;
+
+echo "=== eif2eif complete ==="
+ls -lh "${OUTPUT_DIR}/"

--- a/twoliter/embedded/eif2eif
+++ b/twoliter/embedded/eif2eif
@@ -298,6 +298,18 @@ if ! discover_eif_signer_args sign_args; then
   exit 1
 fi
 
+# Variant-authored EIF header PCIE flags, forwarded from
+# `[package.metadata.build-variant] eif-pcie-flags` via buildsys ->
+# build.Dockerfile ARG. Mirrors rpm2eif: when unset, we omit `--pcie-flags`
+# so `eif-builder` applies its built-in `DEFAULT_PCIE_FLAGS`, matching the
+# first-build header. When set, the repacked EIF header carries the same
+# variant-authored value the original rpm2eif run used, preserving the
+# header==launch-flags contract with the sidecar shim.
+pcie_flags_args=()
+if [[ -n "${EIF_PCIE_FLAGS:-}" ]]; then
+  pcie_flags_args=(--pcie-flags "${EIF_PCIE_FLAGS}")
+fi
+
 EIF_OUT="${WORKDIR}/out.eif"
 
 # Carry METADATA identity fields forward from the input EIF.
@@ -358,6 +370,7 @@ INPUT_BUILD_TIME="$(read_metadata_field '.metadata.BuildMetadata.BuildTime' '')"
   --kernel-version "${INPUT_KERNEL_VERSION}" \
   --image-version "${INPUT_IMAGE_VERSION}" \
   --build-time "${INPUT_BUILD_TIME}" \
+  "${pcie_flags_args[@]}" \
   "${sign_args[@]}"
 
 # ---------- Emit artifacts ----------

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -15,6 +15,11 @@ IN_PLACE_UPDATES="no"
 # already enforce mutual exclusion when `standalone-image = true`.
 ENCRYPTED_STORAGE="no"
 STANDALONE_IMAGE="no"
+# Newline-delimited list of `<guest>:<install_path>:<host_image_dir>` triples,
+# matching the shape rpm2img gets. On repack, we do NOT re-copy the guest
+# images (they are already in the rootfs from the original build); we only
+# walk each install_path under ${ROOT_MOUNT} and resign any `*.eif` we find.
+GUEST_IMAGES=""
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -32,6 +37,7 @@ for opt in "$@"; do
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   --with-standalone-image=*) STANDALONE_IMAGE="${optarg}" ;;
+  --guest-images=*) GUEST_IMAGES="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -114,6 +120,12 @@ write_partition() {
 # Import the image helper functions.
 # shellcheck source=imghelper
 . "${0%/*}/imghelper"
+
+# Import the eif signer-args discovery helper. Used by the guest-EIF resign
+# loop below to pick the same Infra.toml [eif] profile that rpm2eif / eif2eif
+# use, so a host repack re-signs its guest EIFs with the same key/backend.
+# shellcheck source=eif-sign-helper
+. "${0%/*}/eif-sign-helper"
 
 # Validate that the values for the args are sane.
 sanity_checks \
@@ -243,6 +255,82 @@ install_ca_certs "${ROOT_MOUNT}"
 
 # Install 'root.json'.
 install_root_json "${ROOT_MOUNT}"
+
+# ---- Resign guest EIFs, if this variant embeds any ----
+#
+# When the host manifest declares `[[package.metadata.build-variant.guest-images]]`
+# entries, buildsys passes them through as `--guest-images` with the same
+# `<guest>:<install_path>:<host_image_dir>` shape rpm2img gets. On repack
+# we do *not* re-copy the guest artifacts (they were already staged into
+# the rootfs at build time); we only walk each install_path under
+# ${ROOT_MOUNT} and re-sign any `*.eif` we find, so the new host-repack
+# artifacts continue to reflect the current Infra.toml [eif] profile.
+#
+# When no [eif] profile is configured we skip the resign and log once —
+# matching img2img's existing "no UEFI SB profile ⇒ skip signing" behavior
+# and rpm2eif's "no signing.crt ⇒ unsigned" behavior. This keeps repack
+# usable on stripped-down local dev flows without an Infra.toml.
+if [[ -n "${GUEST_IMAGES}" ]]; then
+  # Fail hard rather than silently skip: an operator who declared
+  # `[[guest-images]]` in the manifest expects those EIFs to be resigned
+  # (otherwise there is no reason to invoke repack against a host that
+  # embeds them). The current implementation walks the extracted `${ROOT_MOUNT}`
+  # directory tree, which only exists in the erofs path — for an ext4
+  # rootfs, edits go through `debugfs_replace` and there is no live tree
+  # to `find` under. Adding an ext4-path implementation is possible (see
+  # plan Approach A) but out of scope here. Fail loudly so a future ext4
+  # host+guest combination shows up as a concrete task rather than a
+  # silently-broken build.
+  if [[ "${EROFS_ROOT_PARTITION}" != "yes" ]]; then
+    echo "img2img: --guest-images is set but rootfs is not erofs; guest-EIF resign is only implemented for erofs rootfs. Enable erofs-root-partition on the host variant or drop the guest-images declaration." >&2
+    exit 1
+  fi
+  guest_resign_args=()
+  if ! discover_eif_signer_args guest_resign_args; then
+    # Fires only when the signing.crt secret is mounted but neither
+    # signing.key nor a non-empty kms-key-id file is — which means the
+    # buildsys → buildkit secret plumbing is inconsistent with Infra.toml
+    # [eif].signing_key. Propagate the failure just as rpm2eif does; the
+    # operator asked for signing (cert is present) but the setup is
+    # incomplete, and silently leaving guest EIFs unsigned would be
+    # surprising.
+    exit 1
+  fi
+  if (( ${#guest_resign_args[@]} == 0 )); then
+    echo "img2img: no EIF signing profile present (Infra.toml [eif] not configured); leaving guest EIFs unchanged" >&2
+  else
+    # Iterate the newline-delimited list. Each entry is
+    # `<guest>:<install_path>:<host_image_dir>`; we only care about
+    # <install_path> here.
+    while IFS= read -r entry; do
+      [[ -n "${entry}" ]] || continue
+      # Split on `:`. The install path is the middle field.
+      IFS=':' read -r _guest install_path _host_dir <<<"${entry}"
+      if [[ -z "${install_path}" ]]; then
+        echo "img2img: malformed --guest-images entry (missing install_path): ${entry}" >&2
+        exit 1
+      fi
+      # `install_path` is host-absolute (starts with `/`); glob it under
+      # ${ROOT_MOUNT}. Suppress `failglob` for the duration of the check
+      # because a host that embeds no `.eif`s (e.g. only qcow2 guests) is a
+      # normal case.
+      shopt -u failglob
+      eif_files=( "${ROOT_MOUNT}${install_path}"/*.eif )
+      shopt -s failglob
+      # `failglob` off + empty match leaves the literal pattern, so filter
+      # it out explicitly.
+      for eif in "${eif_files[@]}"; do
+        [[ -f "${eif}" ]] || continue
+        echo "img2img: resigning guest EIF ${eif#"${ROOT_MOUNT}"}"
+        /host/build/tools/eif-builder resign \
+          --input "${eif}" \
+          --output "${eif}.resigned" \
+          "${guest_resign_args[@]}"
+        mv "${eif}.resigned" "${eif}"
+      done
+    done <<<"${GUEST_IMAGES}"
+  fi
+fi
 
 ###############################################################################
 # Section 4: update root partition and root verity

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -27,6 +27,11 @@ IMAGE_ARTIFACT_SUFFIXES=(
   "ova"
   "ext4.lz4"
   "verity.lz4"
+  # `eif` is included so that `copy_guest_image_artifacts` picks up the
+  # `.eif` files a guest EIF variant emits (see `rpm2eif` output). Like
+  # `.ova`, `.eif` is a first-class image artifact that is *not* produced
+  # by `compress_image` (it is built by `eif-builder` directly), so it
+  # deliberately has no compressor case in the `compress_image` switch.
   "eif"
 )
 

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -540,6 +540,18 @@ if ! discover_eif_signer_args sign_args; then
     exit 1
 fi
 
+# Variant-authored EIF header PCIE flags, forwarded from
+# `[package.metadata.build-variant] eif-pcie-flags` via buildsys ->
+# build.Dockerfile ARG. When unset, we omit `--pcie-flags` so eif-builder
+# applies its built-in `DEFAULT_PCIE_FLAGS`. Contract: the value in the EIF
+# header MUST match the PCIE flags the sidecar shim passes to the hypervisor
+# at launch (`header == launch-flags`, enforced by the hypervisor). See
+# `tools/eif-builder/src/lib.rs::DEFAULT_PCIE_FLAGS`.
+pcie_flags_args=()
+if [[ -n "${EIF_PCIE_FLAGS:-}" ]]; then
+    pcie_flags_args=(--pcie-flags "${EIF_PCIE_FLAGS}")
+fi
+
 /host/build/tools/eif-builder \
     --kernel "${KERNEL_LOCAL}" \
     --cmdline "${KERNEL_CMDLINE}" \
@@ -550,6 +562,7 @@ fi
     --image-version "${VERSION_ID}" \
     --build-time "${BUILD_TIME_RFC3339}" \
     --out-prepared-kernel "${PREPARED_KERNEL_TMP}" \
+    "${pcie_flags_args[@]}" \
     "${sign_args[@]}"
 
 echo "=== Generating SBOMs ==="

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -6,9 +6,12 @@
 #   - {name}-disk.img: GPT disk with ROOT-A (erofs) + HASH-A (verity) partitions
 #   - {name}-kernel: bare kernel for direct Firecracker boot. On aarch64 this
 #     is a flat PE arm64 `Image` (any EFI zboot wrapper has been unwrapped and
-#     decompressed); on x86_64 it is an uncompressed ELF `vmlinux` suitable
-#     for PVH boot. Byte-identical to what the .eif embeds in its kernel
-#     section.
+#     decompressed); on x86_64 the format is selected by --eif-kernel-format
+#     (default `bzimage`, matching the sidecar Nitro Enclaves in-memory image
+#     loader, which validates BZIMAGE_HEADER_MAGIC and boots via the bzImage
+#     protocol; `vmlinux` selects an uncompressed ELF for a bare-metal
+#     Firecracker PVH loader). Byte-identical to what the .eif embeds in its
+#     kernel section.
 
 set -euo pipefail
 shopt -qs failglob
@@ -47,6 +50,12 @@ Optional:
     --with-encrypted-storage=yes     Rejected: EIF has no PRIVATE/DATA.
     --with-standalone-image=yes      Required (default). Any value other than
                                      'yes' is rejected.
+    --eif-kernel-format=FMT          x86_64 EIF kernel image format. Accepted
+                                     values: 'bzimage' (default; sidecar
+                                     Nitro Enclaves loader boot protocol) or
+                                     'vmlinux' (uncompressed ELF for a
+                                     bare-metal Firecracker PVH loader).
+                                     Ignored on aarch64.
 
 The rejected flags are accepted by the argument parser (so the Dockerfile can
 pass the same flag set to rpm2eif and rpm2img) and then validated against a
@@ -72,6 +81,15 @@ UEFI_SECURE_BOOT="no"
 IN_PLACE_UPDATES="no"
 ENCRYPTED_STORAGE="no"
 STANDALONE_IMAGE="yes"
+# x86_64 EIF kernel format. Defaults to `bzimage` when neither the CLI flag
+# nor the `EIF_KERNEL_FORMAT` env var (set by buildsys from the variant's
+# `[package.metadata.build-variant] eif-kernel-format`) is provided. bzImage
+# is what the sidecar Nitro Enclaves in-memory image loader boots -- it
+# validates `BZIMAGE_HEADER_MAGIC` and follows the bzImage protocol, same as
+# every `nitro-cli`-built EIF. `vmlinux` selects an uncompressed ELF for a
+# bare-metal Firecracker PVH loader; both formats round-trip cleanly through
+# `eif-builder`'s x86_64 pass-through kernel prep.
+EIF_KERNEL_FORMAT="${EIF_KERNEL_FORMAT:-bzimage}"
 
 for arg in "$@"; do
     case "${arg}" in
@@ -86,6 +104,7 @@ for arg in "$@"; do
         --with-in-place-updates=*) IN_PLACE_UPDATES="${arg#*=}" ;;
         --with-encrypted-storage=*) ENCRYPTED_STORAGE="${arg#*=}" ;;
         --with-standalone-image=*) STANDALONE_IMAGE="${arg#*=}" ;;
+        --eif-kernel-format=*) EIF_KERNEL_FORMAT="${arg#*=}" ;;
         *) echo "Unknown argument: ${arg}"; usage ;;
     esac
 done
@@ -146,6 +165,19 @@ if ! [[ "${OS_IMAGE_SIZE_GIB}" =~ ^[0-9]+$ ]]; then
     echo "ERROR: --os-image-size-gib='${OS_IMAGE_SIZE_GIB}' is not a non-negative integer" >&2
     exit 1
 fi
+
+# Validate --eif-kernel-format. Only meaningful on x86_64; on aarch64 the
+# kernel format is fixed (PE-wrapped `Image`, unwrapped from EFI zboot by
+# eif-builder), so we ignore the value there rather than making authors
+# gate the setting on ${ARCH} in their manifest. Accept only known values
+# so a typo does not silently fall through to a default.
+case "${EIF_KERNEL_FORMAT}" in
+    bzimage|vmlinux) ;;
+    *)
+        echo "ERROR: --eif-kernel-format='${EIF_KERNEL_FORMAT}' is not one of {bzimage, vmlinux}" >&2
+        exit 1
+        ;;
+esac
 
 # Required environment variables (provided by buildsys / the Dockerfile).
 : "${VERSION_ID:?VERSION_ID must be set}"
@@ -243,11 +275,19 @@ extract_vmlinux() {
 echo "=== Extracting kernel ==="
 # Kernel format is architecture-dependent:
 #
-#   x86_64: the sidecar EIF is booted by a custom Firecracker-based launcher
-#   that uses PVH boot, which requires an uncompressed ELF kernel (vmlinux).
-#   Older Bottlerocket kernel RPMs shipped both a bare vmlinux and a compressed
-#   vmlinuz; newer ones (kernel-kit 6.18+) only ship vmlinuz. Prefer a bare
-#   vmlinux when available; otherwise carve the ELF out of vmlinuz.
+#   x86_64: the sidecar EIF is booted by the Nitro Enclaves in-memory image
+#   loader, which validates `BZIMAGE_HEADER_MAGIC` in the EIF kernel section
+#   and boots via the bzImage protocol (same as every `nitro-cli`-built EIF).
+#   That means the correct format to embed is the compressed `vmlinuz` from
+#   the RPM, verbatim. This is the default and what --eif-kernel-format=bzimage
+#   selects.
+#
+#   --eif-kernel-format=vmlinux selects an uncompressed ELF `vmlinux`
+#   (extracted from `vmlinuz` if the RPM does not ship a bare ELF), for
+#   consumers that use a bare-metal Firecracker PVH loader instead of the
+#   sidecar loader. Firecracker upstream has shipped conflicting guidance on
+#   compressed vs. uncompressed kernels, so we keep this selectable rather
+#   than pinning either format.
 #
 #   aarch64: Firecracker does not implement PVH on arm64. It boots via the
 #   arm64 Linux boot protocol, which takes a flat PE-wrapped kernel Image
@@ -256,7 +296,8 @@ echo "=== Extracting kernel ==="
 #   stub around a zstd- or gzip-compressed inner Image); Firecracker's PE
 #   loader does not understand the zboot wrapper. We hand vmlinuz to
 #   eif-builder as-is; it detects the zboot header and unwraps to the flat
-#   Image before embedding it in the EIF kernel section.
+#   Image before embedding it in the EIF kernel section. --eif-kernel-format
+#   is ignored on aarch64 (only one format is valid).
 mapfile -t KERNELS < <(find "${INSTALL_ROOT}" -name 'vmlinux' | sort)
 mapfile -t VMLINUZ < <(find "${INSTALL_ROOT}" -name 'vmlinuz' | sort)
 KERNEL_QUERY_PATH=""
@@ -272,34 +313,56 @@ case "${ARCH}" in
         fi
         KERNEL="${VMLINUZ[0]}"
         KERNEL_QUERY_PATH="${KERNEL#${INSTALL_ROOT}}"
-        echo "Kernel: ${KERNEL} (arm64 Image, no ELF extraction)"
+        echo "Kernel: ${KERNEL} (arm64 Image, no ELF extraction; --eif-kernel-format ignored on ${ARCH})"
         ;;
     x86_64|amd64)
-        if (( ${#KERNELS[@]} == 1 )); then
-            KERNEL="${KERNELS[0]}"
-            KERNEL_QUERY_PATH="${KERNEL#${INSTALL_ROOT}}"
-            echo "Kernel: ${KERNEL}"
-        elif (( ${#KERNELS[@]} > 1 )); then
-            echo "ERROR: expected at most one vmlinux, found ${#KERNELS[@]}" >&2
-            exit 1
-        else
-            if (( ${#VMLINUZ[@]} != 1 )); then
-                echo "ERROR: no vmlinux and expected exactly one vmlinuz, found ${#VMLINUZ[@]}" >&2
-                exit 1
-            fi
-            echo "No bare vmlinux; extracting from ${VMLINUZ[0]}"
-            EXTRACTED_KERNEL="$(mktemp)"
-            if ! extract_vmlinux "${VMLINUZ[0]}" "${EXTRACTED_KERNEL}"; then
-                echo "ERROR: failed to extract vmlinux ELF from ${VMLINUZ[0]}" >&2
-                exit 1
-            fi
-            KERNEL="${EXTRACTED_KERNEL}"
-            # Point --whatprovides at the RPM-owned vmlinuz, not our tempfile: the
-            # extracted ELF is not tracked in the rpm database and the query would
-            # otherwise return "unknown".
-            KERNEL_QUERY_PATH="${VMLINUZ[0]#${INSTALL_ROOT}}"
-            echo "Kernel: ${KERNEL} (from ${VMLINUZ[0]})"
-        fi
+        case "${EIF_KERNEL_FORMAT}" in
+            bzimage)
+                # bzImage path: hand the RPM-shipped compressed vmlinuz to
+                # eif-builder unchanged. Any bare `vmlinux` found under
+                # INSTALL_ROOT is not what the enclave loader expects, so
+                # it's ignored regardless of whether the RPM shipped one.
+                if (( ${#VMLINUZ[@]} != 1 )); then
+                    echo "ERROR: expected exactly one vmlinuz on ${ARCH}, found ${#VMLINUZ[@]}" >&2
+                    exit 1
+                fi
+                KERNEL="${VMLINUZ[0]}"
+                KERNEL_QUERY_PATH="${KERNEL#${INSTALL_ROOT}}"
+                echo "Kernel: ${KERNEL} (bzImage, no extraction)"
+                ;;
+            vmlinux)
+                # PVH ELF path: prefer a bare `vmlinux` when the kernel RPM
+                # ships one; otherwise carve an ELF out of `vmlinuz`. Kept
+                # around because Firecracker's PVH loader (bare-metal, not
+                # sidecar) requires an ELF and Firecracker upstream has
+                # flip-flopped between kernel formats more than once.
+                if (( ${#KERNELS[@]} == 1 )); then
+                    KERNEL="${KERNELS[0]}"
+                    KERNEL_QUERY_PATH="${KERNEL#${INSTALL_ROOT}}"
+                    echo "Kernel: ${KERNEL} (PVH ELF vmlinux)"
+                elif (( ${#KERNELS[@]} > 1 )); then
+                    echo "ERROR: expected at most one vmlinux, found ${#KERNELS[@]}" >&2
+                    exit 1
+                else
+                    if (( ${#VMLINUZ[@]} != 1 )); then
+                        echo "ERROR: no vmlinux and expected exactly one vmlinuz, found ${#VMLINUZ[@]}" >&2
+                        exit 1
+                    fi
+                    echo "No bare vmlinux; extracting from ${VMLINUZ[0]}"
+                    EXTRACTED_KERNEL="$(mktemp)"
+                    if ! extract_vmlinux "${VMLINUZ[0]}" "${EXTRACTED_KERNEL}"; then
+                        echo "ERROR: failed to extract vmlinux ELF from ${VMLINUZ[0]}" >&2
+                        exit 1
+                    fi
+                    KERNEL="${EXTRACTED_KERNEL}"
+                    # Point --whatprovides at the RPM-owned vmlinuz, not our tempfile: the
+                    # extracted ELF is not tracked in the rpm database and the query would
+                    # otherwise return "unknown".
+                    KERNEL_QUERY_PATH="${VMLINUZ[0]#${INSTALL_ROOT}}"
+                    echo "Kernel: ${KERNEL} (PVH ELF vmlinux from ${VMLINUZ[0]})"
+                fi
+                ;;
+        esac
         ;;
     *)
         echo "ERROR: unsupported ARCH=${ARCH}" >&2

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -361,6 +361,28 @@ ENCRYPTED_STORAGE=false
 STANDALONE_IMAGE=true
 EOF
 
+echo "=== Embedding os-release ==="
+# Append Bottlerocket variant, version, and build metadata to
+# /usr/lib/os-release, mirroring the corresponding block in rpm2img so that
+# EIF-built rootfs images expose the same identifying fields (VARIANT_ID,
+# VERSION_ID, BUILD_ID, VENDOR_NAME, ...) to userspace. Unlike rpm2img, EIF
+# variants have INSTALL_ROOT already pointing at the merged sysroot, so
+# there is no `${ARCH}-bottlerocket-linux-gnu/sys-root` prefix.
+VERSION="${VERSION_ID} (${VARIANT})"
+# shellcheck disable=SC2154 # PROJECT_VENDOR/PRETTY_NAME come from the build env.
+cat <<EOF >>"${INSTALL_ROOT}/usr/lib/os-release"
+VERSION="${VERSION}"
+PRETTY_NAME="${PRETTY_NAME} ${VERSION}"
+VARIANT_ID=${VARIANT}
+VERSION_ID=${VERSION_ID}
+BUILD_ID=${BUILD_ID}
+VENDOR_NAME="${PROJECT_VENDOR}"
+HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
+SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
+BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
+DOCUMENTATION_URL="https://bottlerocket.dev"
+EOF
+
 echo "=== Creating rootfs.erofs ==="
 # Remove only the top-level /boot from rootfs (kernel is shipped separately).
 [[ -d "${INSTALL_ROOT}/boot" ]] && rm -rf "${INSTALL_ROOT}/boot"

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -16,8 +16,11 @@ shopt -qs failglob
 # Source imghelper for generate_verity_root and related functions.
 # Source partyplanner for the Bottlerocket-standard partition type GUIDs; this
 # keeps the sidecar disk-image layout in sync with rpm2img and img2img.
+# Source eif-sign-helper for the shared Infra.toml [eif] → eif-builder CLI
+# arg discovery (see the helper's header for the mount-path contract).
 . "${0%/*}/imghelper"
 . "${0%/*}/partyplanner"
+. "${0%/*}/eif-sign-helper"
 
 usage() {
     cat <<EOF
@@ -500,6 +503,21 @@ if [[ "${BUILD_ID_TIMESTAMP:-}" =~ ^[0-9]+$ ]]; then
     BUILD_TIME_RFC3339="$(date -u -d "@${BUILD_ID_TIMESTAMP}" +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
+# Discover the EIF signing profile mounted by buildsys from Infra.toml [eif]
+# and pass the appropriate signing flags to eif-builder. Delegated to
+# `eif-sign-helper::discover_eif_signer_args` so the eif2eif / img2img
+# resign paths share the exact same behavior. See the helper's header for
+# the mount-path contract and the four possible profile shapes.
+#
+# EIF still does not do UEFI Secure Boot -- rpm2eif does not sign
+# shim/grub/vmlinuz -- but the EIF *itself* now carries an
+# `EifSectionSignature` over PCR0 when [eif] is configured, so
+# `nitro-cli describe-eif` reports it as signed and PCR8 is populated.
+sign_args=()
+if ! discover_eif_signer_args sign_args; then
+    exit 1
+fi
+
 /host/build/tools/eif-builder \
     --kernel "${KERNEL_LOCAL}" \
     --cmdline "${KERNEL_CMDLINE}" \
@@ -509,7 +527,8 @@ fi
     --kernel-version "${KERNEL_VERSION}" \
     --image-version "${VERSION_ID}" \
     --build-time "${BUILD_TIME_RFC3339}" \
-    --out-prepared-kernel "${PREPARED_KERNEL_TMP}"
+    --out-prepared-kernel "${PREPARED_KERNEL_TMP}" \
+    "${sign_args[@]}"
 
 echo "=== Generating SBOMs ==="
 # Mirror rpm2img: generate SBOMs over the variant RPMs and merge with the

--- a/twoliter/embedded/tests/test_eif_sign_helper.sh
+++ b/twoliter/embedded/tests/test_eif_sign_helper.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+#
+# Test `discover_eif_signer_args` across the four EIF-signing-profile shapes
+# that Infra.toml's [eif] section (via buildsys and build.Dockerfile) can
+# produce inside the build container:
+#
+#   1. Local:      signing.crt + signing.key
+#   2. KMS:        signing.crt + kms-key-id (a non-empty file whose contents
+#                                            are the KMS key id/ARN/alias)
+#   3. Cert-only:  signing.crt but neither backend (error path — indicates
+#                                                   broken build plumbing)
+#   4. None:       no signing.crt at all (no [eif] section in Infra.toml, or
+#                                         no Infra.toml passed to buildsys)
+#
+# Run from the repo root:
+#   bash twoliter/embedded/tests/test_eif_sign_helper.sh
+#
+# Complements `test_rpm2eif_args.sh` (flag validation) and pins the exact
+# tuple that rpm2eif, eif2eif, and img2img all rely on.
+
+set -eu -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../eif-sign-helper"
+
+if [[ ! -f "${HELPER}" ]]; then
+  echo "test_eif_sign_helper: helper not found at ${HELPER}" >&2
+  exit 1
+fi
+
+pass_count=0
+fail_count=0
+
+pass() { pass_count=$((pass_count + 1)); echo "  ok: $1"; }
+fail() { fail_count=$((fail_count + 1)); echo "  FAIL: $1" >&2; }
+
+# Run `discover_eif_signer_args` in a fresh subshell against a synthesized
+# signing directory and print the resulting argv (one entry per line).
+# Args:
+#   $1  scenario name (unused, for readability)
+#   $2  directory to expose as EIF_SIGNING_DIR (the fixture)
+#   $3  optional: directory to expose as EIF_AWS_DIR (AWS credential env
+#       file fixture; only consulted on the KMS backend). Defaults to an
+#       empty temp dir so the credential-export block is a no-op.
+run_helper() {
+  local dir="$2"
+  local aws_dir="${3:-${tmp}/no-aws-creds}"
+  mkdir -p "${aws_dir}"
+  (
+    # Start from a clean AWS env so the "export AWS credentials on the
+    # KMS path" invariant can be checked precisely — otherwise the
+    # invoker's ambient AWS_ACCESS_KEY_ID (a common shape on CI runners
+    # and dev laptops) would leak through and look like a successful
+    # export even when the helper never touched the value.
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    export EIF_SIGNING_DIR="${dir}"
+    export EIF_AWS_DIR="${aws_dir}"
+    # shellcheck disable=SC1090
+    . "${HELPER}"
+    declare -a out
+    if discover_eif_signer_args out; then
+      printf '%s\n' "${out[@]}"
+      echo "__RC=0"
+      # Dump the AWS_* env so tests can assert on credential export.
+      echo "__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID-<unset>}"
+      echo "__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-<unset>}"
+      echo "__AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN-<unset>}"
+    else
+      printf '%s\n' "${out[@]-}"
+      echo "__RC=1"
+    fi
+  ) 2>&1
+}
+
+# Extract the `__RC=` line's value from run_helper's output.
+extract_rc() {
+  local out="$1"
+  local rc
+  rc=$(printf '%s\n' "${out}" | grep -E '^__RC=' | tail -1 | cut -d= -f2)
+  echo "${rc:-?}"
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+# --------------------------------------------------------------------------
+# Scenario 1: local backend (signing.crt + signing.key both present)
+# --------------------------------------------------------------------------
+dir1="${tmp}/local"
+mkdir -p "${dir1}"
+echo "cert-a" >"${dir1}/signing.crt"
+echo "key-a"  >"${dir1}/signing.key"
+
+out=$(run_helper "local" "${dir1}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--signing-cert$"        <<<"${out}" \
+   && grep -q "^${dir1}/signing.crt$"   <<<"${out}" \
+   && grep -q "^--signing-key$"         <<<"${out}" \
+   && grep -q "^${dir1}/signing.key$"   <<<"${out}" \
+   && ! grep -q "^--kms-key-id$"        <<<"${out}"; then
+  pass "local backend → --signing-cert + --signing-key"
+else
+  fail "local backend args wrong. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2: KMS backend (signing.crt + kms-key-id file)
+# --------------------------------------------------------------------------
+dir2="${tmp}/kms"
+mkdir -p "${dir2}"
+echo "cert-b" >"${dir2}/signing.crt"
+# The buildkit `env=` secret source lands the env var's value in the mount
+# file. Simulate that: a bare id, no key file on disk.
+echo -n "alias/my-eif-key" >"${dir2}/kms-key-id"
+
+out=$(run_helper "kms" "${dir2}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--kms-key-id$"          <<<"${out}" \
+   && grep -q "^alias/my-eif-key$"      <<<"${out}" \
+   && grep -q "^--signing-cert$"        <<<"${out}" \
+   && grep -q "^${dir2}/signing.crt$"   <<<"${out}" \
+   && ! grep -q "^--signing-key$"       <<<"${out}"; then
+  pass "KMS backend → --kms-key-id + --signing-cert"
+else
+  fail "KMS backend args wrong. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2b: KMS backend with a full ARN, incidental trailing newline
+# (defensive: some tools terminate env-source values with a newline). The
+# helper strips whitespace before passing the id to eif-builder.
+# --------------------------------------------------------------------------
+dir2b="${tmp}/kms-arn"
+mkdir -p "${dir2b}"
+echo "cert-c" >"${dir2b}/signing.crt"
+printf 'arn:aws:kms:us-east-1:0:key/00000000\n' >"${dir2b}/kms-key-id"
+
+out=$(run_helper "kms-arn" "${dir2b}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--kms-key-id$"                                <<<"${out}" \
+   && grep -q "^arn:aws:kms:us-east-1:0:key/00000000$"        <<<"${out}"; then
+  pass "KMS backend accepts a full ARN with trailing newline"
+else
+  fail "KMS ARN wrong. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2c: KMS backend with an explicit region (Infra.toml carries
+# `[eif].signing_key.kms.region`; buildsys mounts it as a sidecar
+# `kms-region` file). The helper appends `--region <r>` to the argv.
+# --------------------------------------------------------------------------
+dir2c="${tmp}/kms-region"
+mkdir -p "${dir2c}"
+echo "cert-region" >"${dir2c}/signing.crt"
+echo -n "alias/my-eif-key" >"${dir2c}/kms-key-id"
+echo -n "us-west-2"        >"${dir2c}/kms-region"
+
+out=$(run_helper "kms-region" "${dir2c}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--kms-key-id$"    <<<"${out}" \
+   && grep -q "^--region$"        <<<"${out}" \
+   && grep -q "^us-west-2$"       <<<"${out}"; then
+  pass "KMS backend with region → --region us-west-2"
+else
+  fail "KMS region wrong. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2d: KMS backend with an empty kms-region file. This is the
+# shape buildkit produces when the `env=EIF_KMS_REGION` source is unset
+# (Infra.toml omits the field). The helper must skip `--region` and let
+# the SDK's ambient chain handle it — no extra `--region` argv entry, no
+# spurious `--region <empty>`.
+# --------------------------------------------------------------------------
+dir2d="${tmp}/kms-empty-region"
+mkdir -p "${dir2d}"
+echo "cert-empty-region" >"${dir2d}/signing.crt"
+echo -n "alias/x"        >"${dir2d}/kms-key-id"
+: >"${dir2d}/kms-region"
+
+out=$(run_helper "kms-empty-region" "${dir2d}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--kms-key-id$"    <<<"${out}" \
+   && ! grep -q "^--region$"      <<<"${out}"; then
+  pass "KMS backend with empty region file → no --region flag"
+else
+  fail "empty kms-region should not emit --region. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2e: KMS backend exports AWS_* env from the mounted credential
+# `.env` files. The `.env` file contents land verbatim in the mount; the
+# helper must read them and export them into the caller's environment so
+# `aws-config::from_env()` inside `eif-builder` can pick them up. Without
+# this export, every KMS-signed build fails with a credentials-not-found
+# error even when the credentials are mounted.
+# --------------------------------------------------------------------------
+dir2e="${tmp}/kms-with-creds"
+mkdir -p "${dir2e}"
+echo "cert-creds"       >"${dir2e}/signing.crt"
+echo -n "alias/y"       >"${dir2e}/kms-key-id"
+aws_e="${tmp}/aws-creds-2e"
+mkdir -p "${aws_e}"
+echo -n "AKIAEXAMPLE"                          >"${aws_e}/aws-access-key-id.env"
+echo -n "secret-example-1234"                  >"${aws_e}/aws-secret-access-key.env"
+echo -n "session-token-example"                >"${aws_e}/aws-session-token.env"
+
+out=$(run_helper "kms-with-creds" "${dir2e}" "${aws_e}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q '^__AWS_ACCESS_KEY_ID=AKIAEXAMPLE$'          <<<"${out}" \
+   && grep -q '^__AWS_SECRET_ACCESS_KEY=secret-example-1234$' <<<"${out}" \
+   && grep -q '^__AWS_SESSION_TOKEN=session-token-example$'   <<<"${out}"; then
+  pass "KMS backend exports AWS credential env from mounted files"
+else
+  fail "KMS creds not exported. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2f: local backend must NOT touch the AWS env even when
+# credential files happen to be mounted (they are unrelated to the local
+# signing path; touching them would surprise anyone debugging a local
+# build).
+# --------------------------------------------------------------------------
+dir2f="${tmp}/local-with-aws-mount"
+mkdir -p "${dir2f}"
+echo "cert-l"  >"${dir2f}/signing.crt"
+echo "key-l"   >"${dir2f}/signing.key"
+aws_f="${tmp}/aws-creds-2f"
+mkdir -p "${aws_f}"
+echo -n "SHOULD_NOT_BE_EXPORTED" >"${aws_f}/aws-access-key-id.env"
+
+out=$(run_helper "local-with-aws-mount" "${dir2f}" "${aws_f}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--signing-key$"   <<<"${out}" \
+   && ! grep -q "^__AWS_ACCESS_KEY_ID=SHOULD_NOT_BE_EXPORTED$" <<<"${out}"; then
+  pass "local backend leaves AWS env untouched"
+else
+  fail "local backend must not export AWS creds. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 3: cert-only (error path — no backend at all)
+# --------------------------------------------------------------------------
+dir3="${tmp}/cert-only"
+mkdir -p "${dir3}"
+echo "cert-d" >"${dir3}/signing.crt"
+
+out=$(run_helper "cert-only" "${dir3}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "1" ]] && grep -q "refusing to build an unsigned EIF" <<<"${out}"; then
+  pass "cert-only fails hard (no backend files)"
+else
+  fail "cert-only should have failed. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 3b: cert-only with an empty kms-key-id file (buildkit mounts a
+# zero-byte file when its env source is unset). Should behave the same as
+# scenario 3 — `-s` requires size >0.
+# --------------------------------------------------------------------------
+dir3b="${tmp}/cert-only-empty-kms"
+mkdir -p "${dir3b}"
+echo "cert-e" >"${dir3b}/signing.crt"
+: >"${dir3b}/kms-key-id"
+
+out=$(run_helper "cert-only-empty-kms" "${dir3b}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "1" ]] && grep -q "refusing to build an unsigned EIF" <<<"${out}"; then
+  pass "cert + empty kms-key-id file fails hard"
+else
+  fail "cert + empty kms-key-id should fail. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 3c: kms-key-id file that is only whitespace (post-strip, empty).
+# We surface a distinct diagnostic for this shape so an operator can tell it
+# apart from "backend file absent entirely".
+# --------------------------------------------------------------------------
+dir3c="${tmp}/cert-kms-whitespace"
+mkdir -p "${dir3c}"
+echo "cert-f" >"${dir3c}/signing.crt"
+printf '   \n\t\n' >"${dir3c}/kms-key-id"
+
+out=$(run_helper "cert-kms-whitespace" "${dir3c}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "1" ]] && grep -q "empty after stripping whitespace" <<<"${out}"; then
+  pass "cert + whitespace-only kms-key-id fails with a specific diagnostic"
+else
+  fail "whitespace-only kms-key-id should fail. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 4: no profile at all (no signing.crt on disk)
+# --------------------------------------------------------------------------
+dir4="${tmp}/nothing"
+mkdir -p "${dir4}"
+
+out=$(run_helper "no-profile" "${dir4}")
+rc=$(extract_rc "${out}")
+non_meta=$(grep -Ev '^__RC=|^__AWS_|^eif-sign-helper' <<<"${out}" | grep -vE '^$' || true)
+if [[ "${rc}" == "0" ]] && [[ -z "${non_meta}" ]]; then
+  pass "no profile → empty args, rc 0"
+else
+  fail "no profile args wrong. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 5: empty signing.crt (buildkit-created zero-byte file when the
+# secret source is missing). Treated the same as "no cert" — `[[ -s ]]`
+# requires size >0.
+# --------------------------------------------------------------------------
+dir5="${tmp}/empty-cert"
+mkdir -p "${dir5}"
+: >"${dir5}/signing.crt"
+# A stray key file present — this must NOT flip us into the "local backend"
+# branch, because signing.crt is empty (`-s` returns false).
+echo "key-only" >"${dir5}/signing.key"
+
+out=$(run_helper "empty-cert" "${dir5}")
+rc=$(extract_rc "${out}")
+non_meta=$(grep -Ev '^__RC=|^__AWS_|^eif-sign-helper' <<<"${out}" | grep -vE '^$' || true)
+if [[ "${rc}" == "0" ]] && [[ -z "${non_meta}" ]]; then
+  pass "empty signing.crt treated as no profile (unsigned)"
+else
+  fail "empty signing.crt should produce unsigned. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+echo
+echo "test_eif_sign_helper: ${pass_count} passed, ${fail_count} failed"
+[[ "${fail_count}" -eq 0 ]]

--- a/twoliter/embedded/tests/test_guest_images_helper.sh
+++ b/twoliter/embedded/tests/test_guest_images_helper.sh
@@ -58,6 +58,8 @@ fail() { fail_count=$((fail_count + 1)); echo "  FAIL: $1" >&2; }
     echo "IMAGE_ARTIFACT_SUFFIXES not declared" >&2; exit 1;
   }
   # At minimum, the canonical set. New entries are allowed; missing entries fail.
+  # `eif` is included because EIF guest variants ship a `.eif` sidecar that
+  # host repack needs to be able to enumerate and resign.
   required=("img.lz4" "qcow2" "vmdk" "ova" "ext4.lz4" "verity.lz4" "eif")
   for want in "${required[@]}"; do
     found=no
@@ -146,6 +148,7 @@ mkdir -p "${src}" "${dst}"
 # must be rejected.
 touch "${src}/bottlerocket-1.0.0.img.lz4"
 touch "${src}/bottlerocket-1.0.0.ext4.lz4"
+touch "${src}/bottlerocket-1.0.0.eif"
 ln -s "bottlerocket-1.0.0.img.lz4" "${src}/os_image.img.lz4"
 touch "${src}/bottlerocket-1.0.0.eif"
 touch "${src}/bottlerocket-1.0.0-disk.img"

--- a/twoliter/embedded/tests/test_rpm2eif_args.sh
+++ b/twoliter/embedded/tests/test_rpm2eif_args.sh
@@ -149,6 +149,24 @@ assert_rejects_with "os-image-size-gib=1.5 rejected" "not a non-negative integer
   "${BASE[@]}" --os-image-size-gib=1.5
 
 echo
+echo "Test 11c: accept --eif-kernel-format=bzimage (default, sidecar loader)"
+assert_passes_validation "eif-kernel-format=bzimage accepted" \
+  "${BASE[@]}" --eif-kernel-format=bzimage
+
+echo
+echo "Test 11d: accept --eif-kernel-format=vmlinux (bare-metal PVH loader)"
+assert_passes_validation "eif-kernel-format=vmlinux accepted" \
+  "${BASE[@]}" --eif-kernel-format=vmlinux
+
+echo
+echo "Test 11e: reject unknown --eif-kernel-format value"
+# A typo like `elf` must fail early: the enclave loader boots via bzImage,
+# so silently falling through to a default would defeat the point of the
+# selector.
+assert_rejects_with "eif-kernel-format=elf rejected" "eif-kernel-format" \
+  "${BASE[@]}" --eif-kernel-format=elf
+
+echo
 echo "Test 12: reject unknown argument"
 assert_rejects_with "unknown arg rejected" "Unknown argument" \
   "${BASE[@]}" --this-flag-does-not-exist=1

--- a/twoliter/src/tool-crates/embedded-bundle/build.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/build.rs
@@ -29,6 +29,7 @@ fn main() {
     paths.copy_file("build.Dockerfile.dockerignore");
     paths.copy_file("docker-cargo");
     paths.copy_file("docker-go");
+    paths.copy_file("eif-sign-helper");
     paths.copy_file("guest-images-helper");
     paths.copy_file("img2img");
     paths.copy_file("imghelper");

--- a/twoliter/src/tool-crates/embedded-bundle/build.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/build.rs
@@ -29,6 +29,7 @@ fn main() {
     paths.copy_file("build.Dockerfile.dockerignore");
     paths.copy_file("docker-cargo");
     paths.copy_file("docker-go");
+    paths.copy_file("eif2eif");
     paths.copy_file("eif-sign-helper");
     paths.copy_file("guest-images-helper");
     paths.copy_file("img2img");

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -149,6 +149,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("build.Dockerfile").is_file());
     assert!(toolsdir.join("build.Dockerfile.dockerignore").is_file());
     assert!(toolsdir.join("docker-go").is_file());
+    assert!(toolsdir.join("eif-sign-helper").is_file());
     assert!(toolsdir.join("guest-images-helper").is_file());
     assert!(toolsdir.join("img2img").is_file());
     assert!(toolsdir.join("imghelper").is_file());

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -149,6 +149,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("build.Dockerfile").is_file());
     assert!(toolsdir.join("build.Dockerfile.dockerignore").is_file());
     assert!(toolsdir.join("docker-go").is_file());
+    assert!(toolsdir.join("eif2eif").is_file());
     assert!(toolsdir.join("eif-sign-helper").is_file());
     assert!(toolsdir.join("guest-images-helper").is_file());
     assert!(toolsdir.join("img2img").is_file());


### PR DESCRIPTION
The sidecar Nitro Enclaves in-memory image loader validates
`BZIMAGE_HEADER_MAGIC` in the EIF kernel section and boots via the
bzImage protocol (same as every `nitro-cli`-built EIF). rpm2eif was
embedding an uncompressed ELF `vmlinux` "for PVH boot" -- correct only
for a bare-metal Firecracker PVH loader, wrong for the sidecar path.
The enclave started, the guest never booted, zero console output, and
the failed boot wedged the host.

Fix by making the format selectable and defaulting to bzImage:

* Add `[package.metadata.build-variant] eif-kernel-format` accepting
  `"bzimage"` (default) or `"vmlinux"`. Ignored on aarch64 (only
  PE-wrapped `Image` is valid) and by non-EIF variants.
* Plumb via buildsys -> Docker ARG (`EIF_KERNEL_FORMAT`) -> rpm2eif
  `--eif-kernel-format=<fmt>`. Empty ARG means "apply rpm2eif's default"
  (bzImage), so existing variants pick up the fix automatically.
* rpm2eif x86_64 branch switches on the flag: `bzimage` uses the
  RPM-shipped `vmlinuz` verbatim (no ELF extraction); `vmlinux` retains
  the existing prefer-bare-then-carve-ELF-out-of-vmlinuz path for
  bare-metal PVH consumers.
* eif-builder x86_64 `prepare_kernel` is already a byte pass-through;
  both formats round-trip cleanly. Only doc comments needed updating.

Kept selectable rather than hardcoded because Firecracker upstream has
shipped conflicting guidance on compressed vs. uncompressed kernels
more than once, and forking rpm2eif to swap formats is worse than a
one-line variant knob. The `extract_vmlinux` machinery is reachable only
via `--eif-kernel-format=vmlinux` but is not dead code.

Tests: 4 new buildsys unit tests (omitted/bzimage/vmlinux/unknown),
3 new rpm2eif bash tests (bzimage/vmlinux accepted, unknown rejected).