### PR TITLE
feat(eif): add [eif] signing config schema in pubsys-config

### DIFF
--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -29,6 +29,9 @@ pub struct InfraConfig {
 
     // Config for container registries
     pub vendor: Option<HashMap<String, Vendor>>,
+
+    // EIF (Nitro Enclave Image Format) signing config
+    pub eif: Option<EifConfig>,
 }
 
 impl InfraConfig {
@@ -212,6 +215,47 @@ impl TryFrom<SigningKeyConfig> for Url {
     }
 }
 
+/// EIF (Nitro Enclave Image Format) signing configuration.
+///
+/// Signs an EIF's PCR0 with a dedicated cert/key pair. Independent of
+/// `signing_keys` (TUF metadata) and `sbkeys` (UEFI Secure Boot).
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct EifConfig {
+    /// PEM-encoded X.509 cert whose public key matches `signing_key`.
+    /// Embedded in the EIF's COSE_Sign1 signature section.
+    pub signing_cert: PathBuf,
+    /// Signing key backend: local PEM file or AWS KMS.
+    pub signing_key: EifSigningKey,
+}
+
+/// Backend for the EIF signing key. Only `file` and `kms` are supported;
+/// these map to `eif-builder`'s `--signing-key` and `--kms-key-id` flags.
+#[allow(non_camel_case_types)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub enum EifSigningKey {
+    file {
+        path: PathBuf,
+    },
+    kms {
+        key_id: String,
+        /// AWS region for the KMS `Sign` call. When `None`, the KMS backend
+        /// resolves the region from the ambient AWS SDK chain (env, profile, IMDS).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        region: Option<String>,
+    },
+}
+
+impl Default for EifSigningKey {
+    // Placeholder to satisfy `EifConfig: Default`; never observed via serde.
+    fn default() -> Self {
+        EifSigningKey::file {
+            path: PathBuf::new(),
+        }
+    }
+}
+
 /// Represents a Bottlerocket repo's location and the metadata needed to update the repo
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -292,6 +336,71 @@ mod error {
 }
 pub use error::Error;
 pub type Result<T> = std::result::Result<T, error::Error>;
+
+#[test]
+fn eif_config_file_backend_parses() {
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { file = { path = "/opt/eif/signing.key" } }
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    let eif = cfg.eif.expect("eif section missing");
+    assert_eq!(eif.signing_cert, PathBuf::from("/opt/eif/signing.crt"));
+    match eif.signing_key {
+        EifSigningKey::file { path } => {
+            assert_eq!(path, PathBuf::from("/opt/eif/signing.key"))
+        }
+        _ => panic!("expected file backend"),
+    }
+}
+
+#[test]
+fn eif_config_kms_backend_parses() {
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "alias/my-eif-key" } }
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    let eif = cfg.eif.expect("eif section missing");
+    match eif.signing_key {
+        EifSigningKey::kms { key_id, region } => {
+            assert_eq!(key_id, "alias/my-eif-key");
+            assert_eq!(region, None);
+        }
+        _ => panic!("expected kms backend"),
+    }
+}
+
+#[test]
+fn eif_config_kms_with_region_parses() {
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "alias/my-eif-key", region = "us-west-2" } }
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    let eif = cfg.eif.expect("eif section missing");
+    match eif.signing_key {
+        EifSigningKey::kms { key_id, region } => {
+            assert_eq!(key_id, "alias/my-eif-key");
+            assert_eq!(region.as_deref(), Some("us-west-2"));
+        }
+        _ => panic!("expected kms backend"),
+    }
+}
+
+#[test]
+fn eif_config_absent_is_ok() {
+    // An Infra.toml with no [eif] must still parse (unsigned-EIF path).
+    let toml_str = r#"
+[aws]
+regions = ["us-west-2"]
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    assert!(cfg.eif.is_none());
+}
 
 #[test]
 fn repo_expiration_deserialization_test() {

--- a/tools/pubsys/Infra.toml.example
+++ b/tools/pubsys/Infra.toml.example
@@ -26,6 +26,15 @@ signing_keys = { file = { path = "/home/user/key.pem" } }
 #signing_keys = { kms = { key_id = "abc-def-123" } }
 #signing_keys = { ssm = { parameter = "/my/parameter" } }
 
+# EIF (Nitro Enclave Image Format) signing for Nitro Enclave variants.
+# Separate trust domain from `signing_keys` (TUF) and `sbkeys` (UEFI SB).
+# Requires an EC key on a NIST P-curve (P-256 / P-384); public key must
+# match `signing_cert`. If omitted, EIF builds are unsigned.
+#[eif]
+#signing_cert = "/home/user/eif-signing.crt"
+#signing_key = { file = { path = "/home/user/eif-signing.key" } }
+#signing_key = { kms = { key_id = "alias/my-eif-key" } }
+
 # If these URLs are uncommented, the repo will be pulled and used as a starting
 # point, and your images (and related files) will be added as a new update in
 # the created repo.  Otherwise, we build a new repo from scratch.


### PR DESCRIPTION
Introduce a dedicated [eif] section in Infra.toml carrying EIF signing
config, decoupled from `signing_keys` (TUF metadata) and `sbkeys` (UEFI
Secure Boot). Two backends: `file` (local PEM EC key) and `kms` (AWS
KMS key id/ARN/alias with optional region).

Adds `EifConfig` and `EifSigningKey` types to pubsys-config with three
serde round-trip unit tests. Documents the section in Infra.toml.example
alongside the existing signing profiles.

No consumers yet — this is the schema foundation. Buildsys plumbing and
the eif-builder CLI land in follow-up commits in this stack.