### PR TITLE
feat(eif-builder): add PCR0-covering signature section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -137,15 +137,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -169,7 +169,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -256,13 +256,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -307,9 +307,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -324,7 +324,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.4.2",
+ "http 1.5.0",
  "time",
  "tokio",
  "tracing",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -356,21 +356,22 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.5"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -383,8 +384,8 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -393,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ebs"
-version = "1.102.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd441b7628638de78e364d0f6623c99126af85177b9935454b5f684d3e783a5"
+checksum = "1b0b5ec306e54e955ea3a6c22cb65e3b7ee4d8b0258283d03dccc98a31a5a96c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -407,21 +408,22 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.232.0"
+version = "1.246.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed1c72b10833ce8a789a21c1b95df11387932d7e9ee9a2931635bdb6770a0ad"
+checksum = "366e913d6ae975b6c0c79c61841026714ed5dd4e3284dac6b9ab00d9f06d96b2"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -433,21 +435,22 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.111.0"
+version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62d6d9b9c60e08be622a6bfc98e483d75683795caaf9704886970aa07ed8529"
+checksum = "c0b7d906608ee41e7ddea9983577ba82200435644d567d63dc34e822e088b453"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -458,21 +461,22 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssm"
-version = "1.113.0"
+version = "1.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fbb033ddd700b6475dd8da44623fab28f5e6d8d1b91d839a7b5e09ed0e5c1e"
+checksum = "2d5bd0c0ae0fc69f63b9beb68a28beba71617070d504444944e97bbfb0851d8a"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -483,21 +487,22 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.107.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -509,21 +514,22 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.5"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -534,7 +540,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -543,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -554,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -564,8 +570,8 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -575,15 +581,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -599,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -610,28 +616,31 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
+ "aws-smithy-xml",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -643,9 +652,9 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -655,16 +664,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -673,40 +682,40 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "aws-smithy-schema"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -721,18 +730,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.16"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -794,9 +806,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -851,7 +863,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -882,17 +894,17 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -909,7 +921,7 @@ dependencies = [
  "lazy_static",
  "nonzero_ext",
  "pipesys",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "reqwest",
  "semver",
@@ -949,9 +961,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytes-utils"
@@ -965,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -998,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1026,15 +1038,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1055,10 +1067,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.1"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1066,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1078,14 +1117,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1143,7 +1182,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "snafu 0.9.1",
+ "snafu 0.9.2",
  "tempfile",
  "tokio",
 ]
@@ -1175,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1223,6 +1262,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coset"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1276,18 +1325,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1367,7 +1422,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1381,7 +1436,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1394,7 +1449,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1405,7 +1460,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1416,7 +1471,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1427,7 +1482,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1451,6 +1506,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,7 +1557,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1498,7 +1584,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1508,7 +1594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1536,13 +1622,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1579,20 +1665,32 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "eif-builder"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-lc-rs",
+ "aws-sdk-kms",
+ "aws-types",
  "clap",
+ "coset",
  "crc32fast",
+ "error-utils",
  "flate2",
+ "minicbor-serde",
+ "pem",
+ "serde",
  "serde_json",
  "snafu 0.8.9",
  "tempfile",
+ "tokio",
+ "x509-cert",
  "zstd",
 ]
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1619,14 +1717,14 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1634,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1672,11 +1770,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1697,15 +1794,15 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecf18f4817ea4baf95d700eb763642e65f77a94e630867028024b6725848a028"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatfs"
@@ -1731,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixedbitset"
@@ -1802,9 +1899,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1817,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1827,15 +1924,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1844,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -1863,26 +1960,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -1892,9 +1989,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1951,9 +2048,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1964,9 +2063,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1992,7 +2091,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.4",
+ "rand 0.9.5",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -2054,7 +2153,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
@@ -2063,10 +2162,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "handlebars"
-version = "6.4.1"
+name = "half"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43ccdfe15a81ab0a8af639e90254227c9a46afd9c5f5b6ec7efaa345c4b0f00"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "handlebars"
+version = "6.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4633d16a2350341713c379d6d06a4b9e1845329386026a49ce4fd09c2f3b16f6"
 dependencies = [
  "derive_builder",
  "log",
@@ -2171,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2192,24 +2302,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -2221,26 +2331,26 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2255,7 +2365,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2275,8 +2385,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "hyper",
  "ipnet",
  "libc",
@@ -2436,7 +2546,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "snafu 0.8.9",
- "syn 2.0.118",
+ "syn 2.0.119",
  "zstd",
 ]
 
@@ -2452,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2465,11 +2575,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "futures-util",
  "inotify-sys",
  "libc",
@@ -2478,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -2495,7 +2605,7 @@ dependencies = [
  "libc",
  "lzma-rs",
  "once_cell",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "reqwest",
  "semver",
@@ -2511,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2538,10 +2648,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -2552,21 +2664,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.28"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -2604,7 +2726,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2623,24 +2745,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2674,7 +2796,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2700,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2744,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2782,9 +2904,25 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minicbor"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12b4033ffaa92fbf9df03df38d19324f52bad130dd223f811734a8006dd2d69"
+
+[[package]]
+name = "minicbor-serde"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7abdec9761edcb452764c68564ae4b77ec62f6c1a361aa68f5de15fd788c679"
+dependencies = [
+ "minicbor",
+ "serde",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2798,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2830,7 +2968,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2845,7 +2983,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2882,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2901,7 +3039,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -2929,7 +3067,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2943,20 +3081,19 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-modular"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+checksum = "bd8e500409e6cd603b03e477c26a6caecdc27ac58979a53e881c75eafc079f44"
 
 [[package]]
 name = "num-order"
@@ -3028,7 +3165,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "urlencoding",
 ]
 
@@ -3243,9 +3380,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3253,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3263,25 +3400,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3312,7 +3448,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3383,9 +3519,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -3453,7 +3589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3482,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3594,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3614,15 +3750,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3636,23 +3773,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3671,9 +3808,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -3681,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3691,9 +3828,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3742,12 +3879,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3776,14 +3922,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3793,9 +3939,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3825,8 +3971,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3874,7 +4020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834393db3afd30c31d6ecde41d8dad7f081ac692f82c5a7a05fc0a0915343e6b"
 dependencies = [
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "digest 0.10.7",
  "enum-display-derive",
  "enum-primitive-derive",
@@ -3915,15 +4061,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3940,7 +4086,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3949,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3976,9 +4122,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4025,9 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ruzstd"
@@ -4083,7 +4229,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4112,9 +4258,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4144,36 +4290,37 @@ dependencies = [
  "serde",
  "serde-templated",
  "serde_json",
- "syn 2.0.118",
+ "syn 2.0.119",
  "test-case",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4214,9 +4361,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4327,15 +4474,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4384,11 +4531,11 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
 dependencies = [
- "snafu-derive 0.9.1",
+ "snafu-derive 0.9.2",
 ]
 
 [[package]]
@@ -4400,26 +4547,26 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4427,9 +4574,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"
@@ -4486,7 +4633,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4508,9 +4655,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4534,7 +4692,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4635,7 +4793,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4646,35 +4804,35 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -4694,9 +4852,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4724,9 +4882,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4738,10 +4896,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.52.3"
+name = "tls_codec"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4756,13 +4935,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4772,7 +4951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -4788,9 +4967,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4799,13 +4978,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4836,18 +5016,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tough"
@@ -4936,11 +5116,11 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -4980,7 +5160,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5174,9 +5354,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typed-path"
@@ -5328,9 +5508,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5391,9 +5571,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5404,9 +5584,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5414,9 +5594,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5424,22 +5604,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5459,9 +5639,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5479,18 +5659,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -5547,7 +5727,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5571,7 +5751,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5582,7 +5762,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5773,9 +5953,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -5798,6 +5978,7 @@ dependencies = [
  "const-oid 0.9.6",
  "der",
  "spki",
+ "tls_codec",
 ]
 
 [[package]]
@@ -5835,28 +6016,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5876,7 +6057,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5885,6 +6066,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"
@@ -5916,14 +6111,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ async-trait = "0.1"
 async-walkdir = "1"
 authenticode = "0.5"
 aws-config = { version = "1", default-features = false, features = ["credentials-process", "default-https-client", "rt-tokio" ] }
+aws-lc-rs = { version = "1.17", default-features = false, features = ["aws-lc-sys"] }
 aws-credential-types = "1"
 aws-sdk-ebs = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-ec2 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
@@ -119,6 +120,7 @@ bounded-integer = "0.5"
 bytes = "1"
 clap = "4"
 coldsnap = { version = "0.11", default-features = false }
+coset = { version = "0.3", features = ["std"] }
 crc32fast = "1"
 daemonize = "0.5"
 darling = "0.23"
@@ -145,6 +147,7 @@ libc = "0.2"
 log = "0.4"
 lzma-rs = "0.3"
 maplit = "1"
+minicbor-serde = { version = "0.7", features = ["std"] }
 mockall = "0.13"
 nix = "0.31"
 nonzero_ext = "0.3"
@@ -153,6 +156,7 @@ num-traits = "0.2"
 object = "0.37"
 once_cell = "1.21"
 olpc-cjson = "0.1"
+pem = "3"
 pest = "2.8"
 pest_derive = "2.8"
 proc-macro2 = "1"
@@ -192,6 +196,7 @@ url = "2"
 uuid = "1"
 walkdir = "2"
 which = "8"
+x509-cert = { version = "0.2", default-features = false, features = ["std", "pem"] }
 zstd = "0.13"
 
 [profile.dev.package]

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
+    "BlueOak-1.0.0",
     # "CC0-1.0",
     "ISC",
     "MIT",
@@ -60,8 +61,6 @@ multiple-versions = "deny"
 wildcards = "deny"
 
 skip = [
-    # several dependencies are using multiple versions of base64
-    { name = "base64" },
     # governor and guppy collide bringing two versions of hashbrown and foldhash
     { name = "hashbrown" },
     { name = "foldhash" },

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -573,6 +573,20 @@ twoliter make \
 
 Because `repack-variant` skips package builds entirely, it is significantly faster than a full `build-variant`.
 
+### EIF variants
+
+For variants with `image-format = "eif"`, `repack-variant` dispatches to `eif2eif` instead of `img2img`.
+`eif2eif` extracts ROOT-A from the input `-disk.img`, replaces the CA bundle and `root.json` in the rootfs, rebuilds erofs ROOT-A and the dm-verity HASH-A tree, and produces a new signed `.eif` whose kernel command line pins the new verity root hash.
+The `-kernel` artifact is copied byte-for-byte from the input (its bytes are what the input EIF's kernel section already carried, so the new EIF embeds the identical kernel).
+Because the kernel command line changes (new verity root hash), PCR0 changes, and the EIF is rebuilt end-to-end via `eif-builder` — the `resign` subcommand is not used here.
+
+### Guest EIF resign during host repack
+
+When a non-EIF host variant declares `[[package.metadata.build-variant.guest-images]]` entries and any of those guest images is an EIF, the host repack path resigns every guest `*.eif` in place inside the extracted host rootfs before rebuilding host dm-verity.
+This is done by `img2img` walking each declared guest install path under the mounted rootfs, invoking `eif-builder resign` on each match, and then letting the standard verity rebuild pick up the new bytes.
+The resign preserves the guest kernel, cmdline, ramdisk, and metadata sections byte-for-byte; only the signature section (and header CRC) change.
+When no `[eif]` section is configured in `Infra.toml`, guest EIFs are left unchanged and the repack proceeds — matching the behavior of a repack of a host without Secure Boot keys.
+
 ## Publishing
 
 Common publishing steps such as `cargo make repo` and `cargo make ami` will be hoisted to Twoliter.

--- a/tools/eif-builder/Cargo.toml
+++ b/tools/eif-builder/Cargo.toml
@@ -6,11 +6,23 @@ license = "Apache-2.0 OR MIT"
 publish = false
 
 [dependencies]
-crc32fast.workspace = true
+async-trait.workspace = true
+aws-config.workspace = true
+aws-lc-rs.workspace = true
+aws-sdk-kms.workspace = true
+aws-types.workspace = true
 clap = { workspace = true, features = ["derive"] }
+coset.workspace = true
+crc32fast.workspace = true
+error-utils.workspace = true
 flate2.workspace = true
+pem.workspace = true
+minicbor-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 snafu.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }
+x509-cert.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]

--- a/tools/eif-builder/src/lib.rs
+++ b/tools/eif-builder/src/lib.rs
@@ -7,23 +7,42 @@
 //! All multi-byte fields are big-endian.
 
 pub mod kernel;
+pub mod signer;
 
 pub use kernel::KernelPrepError;
+pub use signer::{Signer, SignerError};
 
+use std::borrow::Cow;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crc32fast::Hasher as Crc32Hasher;
+use serde::{Deserialize, Serialize};
 use snafu::{ensure, ResultExt, Snafu};
 
 const EIF_MAGIC: [u8; 4] = [0x2e, 0x65, 0x69, 0x66]; // ".eif"
+/// EIF header version. v4 adds the METADATA section (0x05) and retains the
+/// v3 SIGNATURE section (0x04).
 const EIF_HDR_VERSION: u16 = 4;
 
 const EIF_SECTION_KERNEL: u16 = 1;
 const EIF_SECTION_CMDLINE: u16 = 2;
 const EIF_SECTION_RAMDISK: u16 = 3;
+const EIF_SECTION_SIGNATURE: u16 = 4;
 const EIF_SECTION_METADATA: u16 = 5;
+
+/// Human-readable EIF section type name; `"UNKNOWN"` for unregistered types.
+fn section_type_name(ty: u16) -> &'static str {
+    match ty {
+        EIF_SECTION_KERNEL => "KERNEL",
+        EIF_SECTION_CMDLINE => "CMDLINE",
+        EIF_SECTION_RAMDISK => "RAMDISK",
+        EIF_SECTION_SIGNATURE => "SIGNATURE",
+        EIF_SECTION_METADATA => "METADATA",
+        _ => "UNKNOWN",
+    }
+}
 
 const EIF_ARCH_X86_64: u16 = 0;
 const EIF_ARCH_AARCH64: u16 = 1;
@@ -32,6 +51,9 @@ const MAX_NUM_SECTIONS: usize = 32;
 const EIF_HEADER_SIZE: usize = 548;
 const EIF_CRC32_OFFSET: usize = EIF_HEADER_SIZE - 4;
 const EIF_SECTION_HEADER_SIZE: usize = 12;
+
+/// Upper bound on the CBOR-encoded EIF signature section, per the spec.
+pub const SIGNATURE_MAX_SIZE: usize = 32768;
 
 /// PCIE flag constants.
 pub const EIF_HDR_FLAG_PCIE: u16 = 1 << 6;
@@ -101,6 +123,69 @@ pub enum EifError {
         path: PathBuf,
         source: std::io::Error,
     },
+
+    #[snafu(display("signing failed: {source}"))]
+    Sign { source: SignerError },
+
+    #[snafu(display("failed to construct signer: {source}"))]
+    SignerBuild { source: SignerError },
+
+    #[snafu(display("failed to read signing certificate: {source}"))]
+    ReadCert { source: std::io::Error },
+
+    #[snafu(display("failed to read signing key: {source}"))]
+    ReadKey { source: std::io::Error },
+
+    #[snafu(display(
+        "encoded EIF signature section is {size} bytes (cert PEM: {cert_pem_size}, \
+         COSE_Sign1: {cose_size}), exceeding the {SIGNATURE_MAX_SIZE}-byte \
+         SIGNATURE_MAX_SIZE limit; shrink the certificate (drop chain \
+         intermediates if any) or shorten the payload"
+    ))]
+    SignatureTooLarge {
+        size: usize,
+        cert_pem_size: usize,
+        cose_size: usize,
+    },
+
+    #[snafu(display("failed to CBOR-encode signature section: {source}"))]
+    CborEncodeSignature {
+        source: minicbor_serde::error::EncodeError<std::convert::Infallible>,
+    },
+
+    #[snafu(display("failed to CBOR-encode signature payload: {source}"))]
+    CborEncodePayload {
+        source: minicbor_serde::error::EncodeError<std::convert::Infallible>,
+    },
+
+    #[snafu(display("failed to build COSE_Sign1: {source}"))]
+    CoseBuild { source: coset::CoseError },
+
+    #[snafu(display("too many EIF sections: {count} > {MAX_NUM_SECTIONS}"))]
+    TooManySections { count: usize },
+
+    #[snafu(display("failed to read input EIF {}: {source}", path.display()))]
+    ReadInput {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to parse input EIF: {reason}"))]
+    ParseInput { reason: String },
+
+    #[snafu(display(
+        "failed to decode METADATA section as UTF-8 JSON: {reason}. \
+         The METADATA section is expected to be a JSON document produced by \
+         `build_metadata`; a binary or non-UTF-8 payload here indicates a \
+         corrupt or foreign-tool-produced EIF."
+    ))]
+    MetadataDecode { reason: String },
+}
+
+/// One EIF section (type + data) staged in memory before layout.
+struct SectionEntry<'a> {
+    ty: u16,
+    data: Cow<'a, [u8]>,
 }
 
 /// Build a minimal metadata JSON matching the schema expected by the NE hypervisor.
@@ -169,112 +254,61 @@ pub struct MetadataFields<'a> {
     pub build_time: &'a str,
 }
 
-fn write_section(eif: &mut Vec<u8>, section_type: u16, data: &[u8]) {
-    eif.extend_from_slice(&section_type.to_be_bytes());
-    eif.extend_from_slice(&0u16.to_be_bytes()); // flags
-    eif.extend_from_slice(&(data.len() as u64).to_be_bytes());
-    eif.extend_from_slice(data);
-}
-
-/// Build and write an EIF to the specified output path.
+/// Assemble the final EIF bytes for a section list.
 ///
-/// `target_arch` selects the architecture flag written into the EIF header;
-/// it must match the kernel image at `kernel_path` (cross-arch builds are
-/// legitimate and expected in cross-compile pipelines).
-///
-/// `metadata` populates the METADATA section. Every field is optional
-/// (empty string = unknown); the JSON keys themselves are always emitted so
-/// the NE hypervisor's `EifIdentityInfo` / `EifBuildInfo` deserializers
-/// (which use `String`, not `Option<String>`) accept the output.
-#[allow(clippy::too_many_arguments)]
-pub fn build_eif(
-    kernel_path: &Path,
-    cmdline: &str,
-    output_path: &Path,
+/// Fixed-size header carries offset/size tables (up to `MAX_NUM_SECTIONS`
+/// entries); sections are laid out in `entries` order; CRC32 is computed
+/// over the whole buffer with the CRC field zeroed.
+fn write_eif_bytes(
     default_mem: u64,
     default_cpus: u64,
-    pcie_flags: u16,
-    target_arch: TargetArch,
-    metadata: &MetadataFields<'_>,
-) -> Result<(), EifError> {
-    let kernel_data = fs::read(kernel_path).context(ReadKernelSnafu { path: kernel_path })?;
-    ensure!(!kernel_data.is_empty(), EmptyKernelSnafu);
-    // Arch-specific pre-processing. On arm64 this unwraps EFI zboot images
-    // (recent Bottlerocket kernel-kit ships `vmlinuz` as a zboot-wrapped
-    // zstd-compressed `Image`) so Firecracker's PE loader sees the flat
-    // arm64 `Image` it expects. On x86_64 this is a no-op.
-    let kernel_data =
-        kernel::prepare_kernel(kernel_data, target_arch).context(PrepareKernelSnafu)?;
-
-    let cmdline_data = cmdline.as_bytes();
-    // Empty RAMDISK section (12-byte header, zero payload). This is well-formed
-    // per the EIF spec: `EifSectionRamdisk` has no minimum-count requirement,
-    // only an ordering constraint (must follow the kernel section). Bottlerocket
-    // sidecar EIFs mount the rootfs from a virtio-blk device with dm-verity, so
-    // no initramfs is needed. NOTE: stock `nitro-cli`-produced EIFs always have
-    // two ramdisks (bootstrap + customer); consumers that assume that convention
-    // (e.g. anything computing PCR2 over concatenated ramdisks) will see empty
-    // input here. Our custom launcher handles this correctly.
-    let ramdisk_data: &[u8] = &[];
-    let metadata_json = build_metadata(
-        metadata.build_tool_version,
-        metadata.kernel_version,
-        metadata.image_version,
-        metadata.build_time,
+    header_flags: u16,
+    entries: &[SectionEntry<'_>],
+) -> Result<Vec<u8>, EifError> {
+    ensure!(
+        entries.len() <= MAX_NUM_SECTIONS,
+        TooManySectionsSnafu {
+            count: entries.len(),
+        },
     );
-    let metadata_data = metadata_json.as_bytes();
+    let num_sections: u16 = entries
+        .len()
+        .try_into()
+        .expect("checked <= MAX_NUM_SECTIONS above");
 
-    let num_sections: u16 = 4;
-    debug_assert!(
-        (num_sections as usize) <= MAX_NUM_SECTIONS,
-        "num_sections must fit within the EIF v4 header's section table"
-    );
-
-    // Calculate total size
-    let sections_size = (EIF_SECTION_HEADER_SIZE * num_sections as usize)
-        + kernel_data.len()
-        + cmdline_data.len()
-        + ramdisk_data.len()
-        + metadata_data.len();
-    let total_size = EIF_HEADER_SIZE + sections_size;
+    // Precompute offsets and sizes so the header table and section writes stay in lockstep.
+    let mut offsets: Vec<u64> = Vec::with_capacity(entries.len());
+    let mut sizes: Vec<u64> = Vec::with_capacity(entries.len());
+    let mut cursor: u64 = EIF_HEADER_SIZE as u64;
+    for entry in entries {
+        offsets.push(cursor);
+        let size = entry.data.len() as u64;
+        sizes.push(size);
+        cursor = cursor
+            .checked_add(EIF_SECTION_HEADER_SIZE as u64)
+            .and_then(|c| c.checked_add(size))
+            .expect("EIF total size overflow");
+    }
+    let total_size = cursor as usize;
 
     let mut eif = Vec::with_capacity(total_size);
 
     // --- Header ---
     eif.extend_from_slice(&EIF_MAGIC);
     eif.extend_from_slice(&EIF_HDR_VERSION.to_be_bytes());
-    eif.extend_from_slice(&(target_arch.flags() | pcie_flags).to_be_bytes());
+    eif.extend_from_slice(&header_flags.to_be_bytes());
     eif.extend_from_slice(&default_mem.to_be_bytes());
     eif.extend_from_slice(&default_cpus.to_be_bytes());
     eif.extend_from_slice(&0u16.to_be_bytes()); // reserved
     eif.extend_from_slice(&num_sections.to_be_bytes());
 
-    // Section offsets
-    let kernel_offset = EIF_HEADER_SIZE as u64;
-    let cmdline_offset = kernel_offset + EIF_SECTION_HEADER_SIZE as u64 + kernel_data.len() as u64;
-    let ramdisk_offset =
-        cmdline_offset + EIF_SECTION_HEADER_SIZE as u64 + cmdline_data.len() as u64;
-    let metadata_offset =
-        ramdisk_offset + EIF_SECTION_HEADER_SIZE as u64 + ramdisk_data.len() as u64;
-
-    let offsets = [
-        kernel_offset,
-        cmdline_offset,
-        ramdisk_offset,
-        metadata_offset,
-    ];
+    // Section offset table (fixed length: MAX_NUM_SECTIONS entries).
     for i in 0..MAX_NUM_SECTIONS {
         let val = if i < offsets.len() { offsets[i] } else { 0 };
         eif.extend_from_slice(&val.to_be_bytes());
     }
 
-    // Section sizes
-    let sizes = [
-        kernel_data.len() as u64,
-        cmdline_data.len() as u64,
-        ramdisk_data.len() as u64,
-        metadata_data.len() as u64,
-    ];
+    // Section size table (fixed length).
     for i in 0..MAX_NUM_SECTIONS {
         let val = if i < sizes.len() { sizes[i] } else { 0 };
         eif.extend_from_slice(&val.to_be_bytes());
@@ -286,24 +320,537 @@ pub fn build_eif(
     debug_assert_eq!(eif.len(), EIF_HEADER_SIZE);
 
     // --- Sections ---
-    write_section(&mut eif, EIF_SECTION_KERNEL, &kernel_data);
-    write_section(&mut eif, EIF_SECTION_CMDLINE, cmdline_data);
-    write_section(&mut eif, EIF_SECTION_RAMDISK, ramdisk_data);
-    write_section(&mut eif, EIF_SECTION_METADATA, metadata_data);
+    for entry in entries {
+        eif.extend_from_slice(&entry.ty.to_be_bytes());
+        eif.extend_from_slice(&0u16.to_be_bytes()); // flags
+        eif.extend_from_slice(&(entry.data.len() as u64).to_be_bytes());
+        eif.extend_from_slice(&entry.data);
+    }
 
-    // Compute CRC32 (exclude CRC field itself)
+    // Compute CRC32 (exclude CRC field itself).
     let mut hasher = Crc32Hasher::new();
     hasher.update(&eif[..EIF_CRC32_OFFSET]);
     hasher.update(&eif[EIF_CRC32_OFFSET + 4..]);
     let crc = hasher.finalize();
     eif[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4].copy_from_slice(&crc.to_be_bytes());
 
-    // Write to file
+    Ok(eif)
+}
+
+/// Bundle of prepared section data (kernel/cmdline/ramdisk/metadata) shared
+/// by the unsigned and signed builders.
+struct KernelPayload {
+    kernel: Vec<u8>,
+    cmdline: Vec<u8>,
+    ramdisk: Vec<u8>,
+    metadata: Vec<u8>,
+}
+
+fn prepare_payload(
+    kernel_path: &Path,
+    cmdline: &str,
+    metadata: &MetadataFields<'_>,
+) -> Result<KernelPayload, EifError> {
+    let kernel_data = fs::read(kernel_path).context(ReadKernelSnafu { path: kernel_path })?;
+    ensure!(!kernel_data.is_empty(), EmptyKernelSnafu);
+    Ok(KernelPayload {
+        kernel: kernel_data,
+        cmdline: cmdline.as_bytes().to_vec(),
+        // Empty RAMDISK section; sidecar mounts rootfs via virtio-blk + dm-verity.
+        // NOTE: stock nitro-cli produces two ramdisks, so PCR2 consumers see empty input here.
+        ramdisk: Vec::new(),
+        metadata: build_metadata(
+            metadata.build_tool_version,
+            metadata.kernel_version,
+            metadata.image_version,
+            metadata.build_time,
+        )
+        .into_bytes(),
+    })
+}
+
+/// Build and write an EIF to the specified output path.
+///
+/// `target_arch` selects the header architecture flag and must match the
+/// kernel image. `metadata` populates the METADATA section; missing fields
+/// default to empty strings (all keys are always emitted).
+#[allow(clippy::too_many_arguments)]
+pub fn build_eif(
+    kernel_path: &Path,
+    cmdline: &str,
+    output_path: &Path,
+    default_mem: u64,
+    default_cpus: u64,
+    pcie_flags: u16,
+    target_arch: TargetArch,
+    metadata: &MetadataFields<'_>,
+) -> Result<(), EifError> {
+    let mut payload = prepare_payload(kernel_path, cmdline, metadata)?;
+    payload.kernel =
+        kernel::prepare_kernel(payload.kernel, target_arch).context(PrepareKernelSnafu)?;
+
+    // Layout: KERNEL, CMDLINE, RAMDISK, METADATA.
+    let entries = [
+        SectionEntry {
+            ty: EIF_SECTION_KERNEL,
+            data: Cow::Borrowed(&payload.kernel),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_CMDLINE,
+            data: Cow::Borrowed(&payload.cmdline),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_RAMDISK,
+            data: Cow::Borrowed(&payload.ramdisk),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_METADATA,
+            data: Cow::Borrowed(&payload.metadata),
+        },
+    ];
+
+    let header_flags = target_arch.flags() | pcie_flags;
+    let eif = write_eif_bytes(default_mem, default_cpus, header_flags, &entries)?;
+
     let mut file = fs::File::create(output_path).context(WriteOutputSnafu { path: output_path })?;
     file.write_all(&eif)
         .context(WriteOutputSnafu { path: output_path })?;
 
     Ok(())
+}
+
+/// Build and write a signed EIF.
+///
+/// Layout: KERNEL, CMDLINE, RAMDISK, METADATA, SIGNATURE (last).
+/// PCR0 = `SHA-384(48 zero bytes || SHA-384(kernel || cmdline || ramdisk_data))`;
+/// metadata and signature sections are excluded from the hash.
+#[allow(clippy::too_many_arguments)]
+pub async fn build_signed_eif(
+    kernel_path: &Path,
+    cmdline: &str,
+    output_path: &Path,
+    default_mem: u64,
+    default_cpus: u64,
+    pcie_flags: u16,
+    target_arch: TargetArch,
+    metadata: &MetadataFields<'_>,
+    signer: &dyn Signer,
+) -> Result<(), EifError> {
+    let mut payload = prepare_payload(kernel_path, cmdline, metadata)?;
+    payload.kernel =
+        kernel::prepare_kernel(payload.kernel, target_arch).context(PrepareKernelSnafu)?;
+
+    let pcr0 = compute_pcr0(&payload.kernel, &payload.cmdline, &[&payload.ramdisk]);
+    let signature_bytes = build_signature_section(signer, &pcr0).await?;
+
+    let entries = [
+        SectionEntry {
+            ty: EIF_SECTION_KERNEL,
+            data: Cow::Borrowed(&payload.kernel),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_CMDLINE,
+            data: Cow::Borrowed(&payload.cmdline),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_RAMDISK,
+            data: Cow::Borrowed(&payload.ramdisk),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_METADATA,
+            data: Cow::Borrowed(&payload.metadata),
+        },
+        SectionEntry {
+            ty: EIF_SECTION_SIGNATURE,
+            data: Cow::Borrowed(&signature_bytes),
+        },
+    ];
+
+    let header_flags = target_arch.flags() | pcie_flags;
+    let eif = write_eif_bytes(default_mem, default_cpus, header_flags, &entries)?;
+
+    let mut file = fs::File::create(output_path).context(WriteOutputSnafu { path: output_path })?;
+    file.write_all(&eif)
+        .context(WriteOutputSnafu { path: output_path })?;
+
+    Ok(())
+}
+
+/// One parsed EIF section: type + payload (section header stripped).
+#[derive(Debug)]
+pub struct ParsedSection {
+    /// Section type (one of the `EIF_SECTION_*` constants).
+    pub ty: u16,
+    /// Section payload bytes (no section header).
+    pub data: Vec<u8>,
+}
+
+/// Header fields recovered from an EIF's fixed header.
+struct EifHeader {
+    default_mem: u64,
+    default_cpus: u64,
+    flags: u16,
+}
+
+/// Parse the fixed header of an EIF and validate the magic and version.
+fn read_header(bytes: &[u8]) -> Result<EifHeader, EifError> {
+    ensure!(
+        bytes.len() >= EIF_HEADER_SIZE,
+        ParseInputSnafu {
+            reason: format!(
+                "input is {} bytes, smaller than the {}-byte EIF header",
+                bytes.len(),
+                EIF_HEADER_SIZE
+            ),
+        }
+    );
+    ensure!(
+        bytes[0..4] == EIF_MAGIC,
+        ParseInputSnafu {
+            reason: "bad EIF magic".to_string(),
+        }
+    );
+    let version = u16::from_be_bytes([bytes[4], bytes[5]]);
+    ensure!(
+        version == EIF_HDR_VERSION,
+        ParseInputSnafu {
+            reason: format!(
+                "unsupported EIF header version {version} (expected {EIF_HDR_VERSION})"
+            ),
+        }
+    );
+    let flags = u16::from_be_bytes([bytes[6], bytes[7]]);
+    let default_mem = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
+    let default_cpus = u64::from_be_bytes(bytes[16..24].try_into().unwrap());
+    Ok(EifHeader {
+        default_mem,
+        default_cpus,
+        flags,
+    })
+}
+
+/// Parse the section list from a serialized EIF.
+///
+/// Sections come back in header-table order; the 12-byte section headers are
+/// validated against the table and stripped.
+pub fn read_sections(eif_bytes: &[u8]) -> Result<Vec<ParsedSection>, EifError> {
+    read_header(eif_bytes)?;
+    let num_sections_off = 4 + 2 + 2 + 8 + 8 + 2; // magic+ver+flags+mem+cpus+reserved
+    let num_sections =
+        u16::from_be_bytes([eif_bytes[num_sections_off], eif_bytes[num_sections_off + 1]]) as usize;
+    ensure!(
+        num_sections <= MAX_NUM_SECTIONS,
+        ParseInputSnafu {
+            reason: format!(
+                "num_sections={num_sections} exceeds MAX_NUM_SECTIONS={MAX_NUM_SECTIONS}"
+            ),
+        }
+    );
+
+    let offsets_start = num_sections_off + 2;
+    let sizes_start = offsets_start + MAX_NUM_SECTIONS * 8;
+
+    let mut sections = Vec::with_capacity(num_sections);
+    for i in 0..num_sections {
+        let off = u64::from_be_bytes(
+            eif_bytes[offsets_start + i * 8..offsets_start + (i + 1) * 8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let size = u64::from_be_bytes(
+            eif_bytes[sizes_start + i * 8..sizes_start + (i + 1) * 8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        // Reject offsets inside the header so `compute_pcr0` can't be tricked
+        // into hashing header bytes as section data.
+        ensure!(
+            off >= EIF_HEADER_SIZE,
+            ParseInputSnafu {
+                reason: format!(
+                    "section {i} offset {off} lies within the fixed EIF header (< {EIF_HEADER_SIZE})"
+                ),
+            }
+        );
+        ensure!(
+            off.checked_add(EIF_SECTION_HEADER_SIZE)
+                .and_then(|o| o.checked_add(size))
+                .is_some_and(|end| end <= eif_bytes.len()),
+            ParseInputSnafu {
+                reason: format!(
+                    "section {i} at offset {off} size {size} exceeds file length {}",
+                    eif_bytes.len(),
+                ),
+            }
+        );
+        let ty = u16::from_be_bytes([eif_bytes[off], eif_bytes[off + 1]]);
+        // Cross-check the size in the section header against the size table.
+        let hdr_size =
+            u64::from_be_bytes(eif_bytes[off + 4..off + 12].try_into().unwrap()) as usize;
+        ensure!(
+            hdr_size == size,
+            ParseInputSnafu {
+                reason: format!(
+                    "section {i} header size {hdr_size} disagrees with table size {size}",
+                ),
+            }
+        );
+        let data_off = off + EIF_SECTION_HEADER_SIZE;
+        sections.push(ParsedSection {
+            ty,
+            data: eif_bytes[data_off..data_off + size].to_vec(),
+        });
+    }
+    Ok(sections)
+}
+
+/// Summarize an EIF's contents as JSON.
+///
+/// `metadata` is `null` when no METADATA section is present. `cmdline` is
+/// lossy-decoded UTF-8 with an optional trailing NUL stripped.
+/// Fails with `MetadataDecode` when METADATA is present but not UTF-8 JSON.
+pub fn describe_eif(input: &Path) -> Result<serde_json::Value, EifError> {
+    let bytes = fs::read(input).context(ReadInputSnafu { path: input })?;
+    let sections = read_sections(&bytes)?;
+
+    let mut kernel_size: u64 = 0;
+    let mut cmdline_bytes: Option<Vec<u8>> = None;
+    let mut ramdisk_count: usize = 0;
+    let mut is_signed = false;
+    let mut metadata_bytes: Option<Vec<u8>> = None;
+    let mut section_summaries: Vec<serde_json::Value> = Vec::with_capacity(sections.len());
+    for s in &sections {
+        section_summaries.push(serde_json::json!({
+            "type": section_type_name(s.ty),
+            "type_id": s.ty,
+            "size": s.data.len(),
+        }));
+        match s.ty {
+            EIF_SECTION_KERNEL => kernel_size = s.data.len() as u64,
+            EIF_SECTION_CMDLINE => cmdline_bytes = Some(s.data.clone()),
+            EIF_SECTION_RAMDISK => ramdisk_count += 1,
+            EIF_SECTION_SIGNATURE => is_signed = true,
+            EIF_SECTION_METADATA => metadata_bytes = Some(s.data.clone()),
+            _ => {} // still reported in `sections`, just not summarized
+        }
+    }
+
+    // METADATA must be valid UTF-8 JSON when present; fail loudly rather than substitute null.
+    let metadata_value = match metadata_bytes {
+        Some(raw) => {
+            let text = std::str::from_utf8(&raw).map_err(|e| EifError::MetadataDecode {
+                reason: format!("invalid UTF-8 at byte {}: {e}", e.valid_up_to()),
+            })?;
+            serde_json::from_str::<serde_json::Value>(text).map_err(|e| {
+                EifError::MetadataDecode {
+                    reason: format!("JSON parse: {e}"),
+                }
+            })?
+        }
+        None => serde_json::Value::Null,
+    };
+
+    // Strip optional trailing NUL, lossy-decode UTF-8.
+    let cmdline_str = cmdline_bytes.as_deref().map(|b| {
+        let trimmed = match b.last() {
+            Some(&0) => &b[..b.len() - 1],
+            _ => b,
+        };
+        String::from_utf8_lossy(trimmed).into_owned()
+    });
+
+    Ok(serde_json::json!({
+        "eif_version": EIF_HDR_VERSION,
+        "is_signed": is_signed,
+        "cmdline": cmdline_str,
+        "kernel_size": kernel_size,
+        "ramdisk_count": ramdisk_count,
+        "sections": section_summaries,
+        "metadata": metadata_value,
+    }))
+}
+
+/// Re-sign an EIF: replace (or append) its SIGNATURE section, byte-preserving
+/// all other sections. Kernel bytes are treated as opaque (no `prepare_kernel`
+/// re-run) so PCR0 covers exactly what's on disk. Any existing SIGNATURE is
+/// dropped; a new one is appended last.
+pub async fn resign_eif(input: &Path, output: &Path, signer: &dyn Signer) -> Result<(), EifError> {
+    let bytes = fs::read(input).context(ReadInputSnafu { path: input })?;
+    let header = read_header(&bytes)?;
+    let sections = read_sections(&bytes)?;
+
+    // PCR0 is computed from the input's on-disk bytes so we don't need to know
+    // how they were prepared.
+    let mut kernel: Option<&[u8]> = None;
+    let mut cmdline: Option<&[u8]> = None;
+    let mut ramdisks: Vec<&[u8]> = Vec::new();
+    for s in &sections {
+        match s.ty {
+            EIF_SECTION_KERNEL => kernel = Some(&s.data),
+            EIF_SECTION_CMDLINE => cmdline = Some(&s.data),
+            EIF_SECTION_RAMDISK => ramdisks.push(&s.data),
+            _ => {}
+        }
+    }
+    let kernel = kernel.ok_or_else(|| EifError::ParseInput {
+        reason: "input EIF has no KERNEL section".to_string(),
+    })?;
+    let cmdline = cmdline.ok_or_else(|| EifError::ParseInput {
+        reason: "input EIF has no CMDLINE section".to_string(),
+    })?;
+    // RAMDISK is not required; `compute_pcr0` accepts an empty slice.
+    let pcr0 = compute_pcr0(kernel, cmdline, &ramdisks);
+    let signature_bytes = build_signature_section(signer, &pcr0).await?;
+
+    // Preserve non-signature sections in order; append the new signature last.
+    let mut entries: Vec<SectionEntry<'_>> = Vec::with_capacity(sections.len() + 1);
+    for s in &sections {
+        if s.ty == EIF_SECTION_SIGNATURE {
+            continue; // drop the old signature
+        }
+        entries.push(SectionEntry {
+            ty: s.ty,
+            data: Cow::Borrowed(&s.data),
+        });
+    }
+    // Check MAX_NUM_SECTIONS here so the error attributes overflow to resign.
+    ensure!(
+        entries.len() < MAX_NUM_SECTIONS,
+        TooManySectionsSnafu {
+            count: entries.len() + 1
+        },
+    );
+    entries.push(SectionEntry {
+        ty: EIF_SECTION_SIGNATURE,
+        data: Cow::Borrowed(&signature_bytes),
+    });
+
+    let eif = write_eif_bytes(
+        header.default_mem,
+        header.default_cpus,
+        header.flags,
+        &entries,
+    )?;
+    let mut file = fs::File::create(output).context(WriteOutputSnafu { path: output })?;
+    file.write_all(&eif)
+        .context(WriteOutputSnafu { path: output })?;
+    Ok(())
+}
+
+/// Compute PCR0 = `SHA-384(48 zero bytes || SHA-384(kernel || cmdline || ramdisks))`,
+/// matching the reference `EifBuilder::image_hasher`.
+fn compute_pcr0(kernel_data: &[u8], cmdline_data: &[u8], ramdisks: &[&[u8]]) -> Vec<u8> {
+    use aws_lc_rs::digest::{digest, SHA384};
+
+    let mut inner = Vec::with_capacity(kernel_data.len() + cmdline_data.len() + 64);
+    inner.extend_from_slice(kernel_data);
+    inner.extend_from_slice(cmdline_data);
+    for r in ramdisks {
+        inner.extend_from_slice(r);
+    }
+    let inner_digest = digest(&SHA384, &inner);
+
+    let mut outer_input = vec![0u8; 48];
+    outer_input.extend_from_slice(inner_digest.as_ref());
+    let outer_digest = digest(&SHA384, &outer_input);
+    outer_digest.as_ref().to_vec()
+}
+
+/// Wire-compatible mirror of upstream `PcrInfo`. Serde encodes `Vec<u8>`
+/// as a CBOR array-of-integers, matching what the verifier reconstructs
+/// and byte-compares. Field names, order, and types must match upstream
+/// exactly.
+#[derive(Serialize, Deserialize)]
+struct PcrInfo {
+    register_index: i32, // do not widen: upstream uses i32
+    register_value: Vec<u8>,
+}
+
+/// Wire-compatible mirror of upstream `PcrSignature`. Must use `Vec<u8>`
+/// (not `serde_bytes::ByteBuf`) so serde-based CBOR decodes match upstream.
+#[derive(Serialize, Deserialize)]
+struct PcrSignature {
+    signing_certificate: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+/// Build CBOR bytes for the `EifSectionSignature` section:
+/// `Array(1) { Map { "signing_certificate": PEM, "signature": COSE_Sign1 } }`.
+/// Byte fields are CBOR array-of-integers (serde's default `Vec<u8>` shape),
+/// matching what the upstream consumer expects.
+async fn build_signature_section(signer: &dyn Signer, pcr0: &[u8]) -> Result<Vec<u8>, EifError> {
+    use coset::{CborSerializable, CoseSign1Builder, HeaderBuilder};
+
+    let payload = minicbor_serde::to_vec(&PcrInfo {
+        register_index: 0,
+        register_value: pcr0.to_vec(),
+    })
+    .context(CborEncodePayloadSnafu)?;
+
+    let alg = match signer.algorithm() {
+        signer::SignAlg::Es256 => coset::iana::Algorithm::ES256,
+        signer::SignAlg::Es384 => coset::iana::Algorithm::ES384,
+    };
+    let protected = HeaderBuilder::new().algorithm(alg).build();
+
+    // `CoseSign1Builder::{create,try_create}_signature` take a sync closure,
+    // so we build the shell first, compute the `Sig_structure1` TBS bytes,
+    // await the async signer, then attach the signature. Semantically
+    // identical to `try_create_signature(&[], sign)`.
+    let mut sign1 = CoseSign1Builder::new()
+        .protected(protected)
+        .payload(payload)
+        .build();
+    let tbs = sign1.tbs_data(&[]);
+    sign1.signature = signer.sign_cose(&tbs).await.context(SignSnafu)?;
+
+    let cose_bytes = sign1.to_vec().context(CoseBuildSnafu)?;
+    let cose_size = cose_bytes.len();
+
+    let cert_pem = signer.cert_pem().to_vec();
+    let cert_pem_size = cert_pem.len();
+
+    let envelope = vec![PcrSignature {
+        signing_certificate: cert_pem,
+        signature: cose_bytes,
+    }];
+    let out = minicbor_serde::to_vec(&envelope).context(CborEncodeSignatureSnafu)?;
+    // Enforce SIGNATURE_MAX_SIZE here; the error attributes bytes to cert vs. COSE.
+    ensure!(
+        out.len() <= SIGNATURE_MAX_SIZE,
+        SignatureTooLargeSnafu {
+            size: out.len(),
+            cert_pem_size,
+            cose_size,
+        },
+    );
+    Ok(out)
+}
+
+/// Shared DER TLV helper for test code (short + long-form length encoding).
+#[cfg(test)]
+pub(crate) mod der_helpers {
+    pub(crate) fn wrap_der(tag: u8, body: &[u8]) -> Vec<u8> {
+        let mut out = vec![tag];
+        let n = body.len();
+        if n < 0x80 {
+            out.push(n as u8);
+        } else if n < 0x100 {
+            out.push(0x81);
+            out.push(n as u8);
+        } else if n < 0x10000 {
+            out.push(0x82);
+            out.push((n >> 8) as u8);
+            out.push((n & 0xff) as u8);
+        } else {
+            out.push(0x83);
+            out.push((n >> 16) as u8);
+            out.push((n >> 8) as u8);
+            out.push((n & 0xff) as u8);
+        }
+        out.extend_from_slice(body);
+        out
+    }
 }
 
 #[cfg(test)]
@@ -375,9 +922,6 @@ mod tests {
 
     #[test]
     fn test_metadata_schema() {
-        // Verify the metadata JSON has all keys the NE hypervisor expects,
-        // including nested BuildMetadata sub-keys, and that caller-supplied
-        // values are embedded verbatim.
         let json = build_metadata("0.20.0", "6.1.152-0.br1", "1.63.0", "2026-07-28T22:20:54Z");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(v.get("ImageName").is_some());
@@ -394,8 +938,7 @@ mod tests {
 
     #[test]
     fn test_metadata_empty_values() {
-        // Empty strings must still round-trip through the schema (keys present,
-        // values empty) rather than being omitted.
+        // Keys must be present with empty values, not omitted.
         let json = build_metadata("", "", "", "");
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v.get("ImageVersion").unwrap(), "");
@@ -430,9 +973,7 @@ mod tests {
 
     #[test]
     fn test_header_arch_flag_is_target_not_host() {
-        // Building for a target arch different from cfg!(target_arch=...) must
-        // still yield the *target* arch flag in the EIF header. This guards
-        // against regressions where the arch is derived from the build host.
+        // Header arch must reflect the target, not the build host.
         let dir = tempfile::tempdir().unwrap();
         let output = dir.path().join("test.eif");
 
@@ -440,8 +981,7 @@ mod tests {
         let x86_kernel = dir.path().join("x86-kernel");
         fs::write(&x86_kernel, b"FAKE_KERNEL").unwrap();
 
-        // aarch64 shape-check: must look like an arm64 PE Image (MZ + ARM\x64
-        // at offset 56). Build the smallest plausible one.
+        // Minimal arm64 PE Image shape: MZ header + ARM\x64 at offset 56.
         let arm_kernel = dir.path().join("arm-kernel");
         let mut arm_bytes = vec![0u8; 60];
         arm_bytes[0..2].copy_from_slice(b"MZ");
@@ -466,6 +1006,7 @@ mod tests {
             let eif = fs::read(&output).unwrap();
             // flags is u16 at offset 6; PCIE bits are 0 here so the full value
             // equals just the arch bits.
+            // flags is u16 at offset 6; PCIE bits are 0 so full value equals arch bits.
             let flags = u16::from_be_bytes([eif[6], eif[7]]);
             assert_eq!(flags, expected_low_bits, "arch={arch:?}");
         }
@@ -473,14 +1014,9 @@ mod tests {
 
     #[test]
     fn test_arm64_non_pe_kernel_is_rejected() {
-        // A verbatim gzip-compressed vmlinuz (or anything else that isn't a
-        // flat PE-wrapped arm64 Image) must be rejected up-front with a
-        // KernelPrepError, rather than producing an EIF that Firecracker's
-        // PE loader will reject at launch. This is the regression the
-        // KernelPrep pass was introduced to prevent.
+        // Non-PE arm64 kernels must be rejected upfront, not at launch time.
         let dir = tempfile::tempdir().unwrap();
         let kernel = dir.path().join("vmlinuz.gz");
-        // Gzip magic + a bit of body — decidedly not an MZ/ARM\x64 header.
         fs::write(&kernel, [0x1f, 0x8b, 0x08, 0x00, b'j', b'u', b'n', b'k']).unwrap();
         let output = dir.path().join("test.eif");
 
@@ -496,5 +1032,786 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, EifError::PrepareKernel { .. }), "err={err:?}");
+    }
+
+    // -------- PCR0 / signature tests --------
+
+    #[test]
+    fn test_pcr0_matches_spec() {
+        // Recompute PCR0 independently to guard against drift in `compute_pcr0`.
+        use aws_lc_rs::digest::{digest, SHA384};
+
+        let kernel = b"FAKE_KERNEL".to_vec();
+        let cmdline = b"console=ttyS0".to_vec();
+        let ramdisk: Vec<u8> = Vec::new();
+
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&kernel);
+        inner.extend_from_slice(&cmdline);
+        inner.extend_from_slice(&ramdisk);
+        let inner_d = digest(&SHA384, &inner);
+        let mut outer = vec![0u8; 48];
+        outer.extend_from_slice(inner_d.as_ref());
+        let expected = digest(&SHA384, &outer).as_ref().to_vec();
+
+        let got = compute_pcr0(&kernel, &cmdline, &[&ramdisk]);
+        assert_eq!(got, expected, "PCR0 must match the reference spec");
+        assert_eq!(got.len(), 48, "SHA-384 output is 48 bytes");
+    }
+
+    #[test]
+    fn test_unsigned_eif_layout_unchanged() {
+        // First section header (KERNEL) lives at EIF_HEADER_SIZE.
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("test.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+        )
+        .unwrap();
+        let eif = fs::read(&output).unwrap();
+        let ty = u16::from_be_bytes([eif[EIF_HEADER_SIZE], eif[EIF_HEADER_SIZE + 1]]);
+        assert_eq!(ty, EIF_SECTION_KERNEL);
+    }
+
+    /// Build a self-signed ECDSA P-384 cert + private key for tests. The DER
+    /// is hand-rolled to avoid pulling in `x509-cert`'s `builder` feature.
+    /// The cert's own `signatureValue` is not a valid signature; only the
+    /// COSE signature is verified downstream.
+    #[cfg(test)]
+    fn generate_test_cert_and_key() -> (Vec<u8>, Vec<u8>) {
+        use aws_lc_rs::signature::{EcdsaKeyPair, KeyPair, ECDSA_P384_SHA384_ASN1_SIGNING};
+        let rng = aws_lc_rs::rand::SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, &rng).unwrap();
+        let pem_key = pem::Pem::new("PRIVATE KEY", pkcs8.as_ref().to_vec());
+        let key_pem = pem::encode(&pem_key).into_bytes();
+
+        let key_pair =
+            EcdsaKeyPair::from_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8.as_ref()).unwrap();
+        let sec1_pub = key_pair.public_key().as_ref().to_vec();
+
+        let cert_der = build_p384_self_signed_der(&sec1_pub);
+        let cert_pem_obj = pem::Pem::new("CERTIFICATE", cert_der);
+        let cert_pem = pem::encode(&cert_pem_obj).into_bytes();
+
+        (cert_pem, key_pem)
+    }
+
+    /// Minimal syntactically-valid X.509 cert with a P-384 SPKI over the
+    /// given SEC1 public key.
+    #[cfg(test)]
+    fn build_p384_self_signed_der(sec1_pub: &[u8]) -> Vec<u8> {
+        // id-ecPublicKey 1.2.840.10045.2.1, secp384r1 1.3.132.0.34,
+        // ecdsa-with-SHA384 1.2.840.10045.4.3.3, id-at-commonName 2.5.4.3.
+        let id_ec_pub = [0x06u8, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01];
+        let secp384r1 = [0x06u8, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22];
+        let ecdsa_sha384 = [0x06u8, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x03];
+        let id_cn = [0x06u8, 0x03, 0x55, 0x04, 0x03];
+
+        let mut spki_alg_body = Vec::new();
+        spki_alg_body.extend_from_slice(&id_ec_pub);
+        spki_alg_body.extend_from_slice(&secp384r1);
+        let spki_alg = crate::der_helpers::wrap_der(0x30, &spki_alg_body);
+
+        let mut spki_key = vec![0u8];
+        spki_key.extend_from_slice(sec1_pub);
+        let spki_key_bs = crate::der_helpers::wrap_der(0x03, &spki_key);
+
+        let mut spki_body = Vec::new();
+        spki_body.extend_from_slice(&spki_alg);
+        spki_body.extend_from_slice(&spki_key_bs);
+        let spki = crate::der_helpers::wrap_der(0x30, &spki_body);
+
+        // Name = SEQUENCE OF RDN(SET OF ATV(SEQUENCE OID + UTF8String("test"))).
+        let cn_value = crate::der_helpers::wrap_der(0x0C, b"test"); // UTF8String
+        let mut atv = Vec::new();
+        atv.extend_from_slice(&id_cn);
+        atv.extend_from_slice(&cn_value);
+        let atv_seq = crate::der_helpers::wrap_der(0x30, &atv);
+        let rdn = crate::der_helpers::wrap_der(0x31, &atv_seq); // SET
+        let name = crate::der_helpers::wrap_der(0x30, &rdn); // SEQUENCE OF RDN
+
+        // Fixed UTCTime range well in the past/future to satisfy validity checks.
+        let not_before = crate::der_helpers::wrap_der(0x17, b"200101000000Z"); // UTCTime
+        let not_after = crate::der_helpers::wrap_der(0x17, b"400101000000Z");
+        let mut validity_body = Vec::new();
+        validity_body.extend_from_slice(&not_before);
+        validity_body.extend_from_slice(&not_after);
+        let validity = crate::der_helpers::wrap_der(0x30, &validity_body);
+
+        let sig_alg = crate::der_helpers::wrap_der(0x30, &ecdsa_sha384);
+
+        // TBSCertificate: version[0] serial sigAlg issuer validity subject SPKI.
+        let version_inner = crate::der_helpers::wrap_der(0x02, &[2u8]); // INTEGER 2
+        let version = crate::der_helpers::wrap_der(0xA0, &version_inner); // [0] EXPLICIT
+        let serial = crate::der_helpers::wrap_der(0x02, &[0x01u8]); // INTEGER 1
+        let mut tbs_body = Vec::new();
+        tbs_body.extend_from_slice(&version);
+        tbs_body.extend_from_slice(&serial);
+        tbs_body.extend_from_slice(&sig_alg);
+        tbs_body.extend_from_slice(&name); // issuer
+        tbs_body.extend_from_slice(&validity);
+        tbs_body.extend_from_slice(&name); // subject (self-signed)
+        tbs_body.extend_from_slice(&spki);
+        let tbs = crate::der_helpers::wrap_der(0x30, &tbs_body);
+
+        // Fake signatureValue: minimal BIT STRING (0 unused bits) for structural presence.
+        let fake_sig_bytes = [0x00u8];
+        let sig_val = crate::der_helpers::wrap_der(0x03, &fake_sig_bytes);
+
+        let mut cert_body = Vec::new();
+        cert_body.extend_from_slice(&tbs);
+        cert_body.extend_from_slice(&sig_alg);
+        cert_body.extend_from_slice(&sig_val);
+        crate::der_helpers::wrap_der(0x30, &cert_body)
+    }
+
+    #[tokio::test]
+    async fn test_signed_eif_structure() {
+        // Outer envelope must decode via `minicbor_serde::from_slice::<Vec<PcrSignature>>`,
+        // the exact shape the upstream consumer path uses.
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .await
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let sig = extract_section(&eif, EIF_SECTION_SIGNATURE)
+            .expect("signature section must be present");
+
+        let envelope: Vec<PcrSignature> = minicbor_serde::from_slice(&sig)
+            .expect("outer envelope must decode via minicbor_serde");
+        assert_eq!(envelope.len(), 1, "outer envelope must hold one signature");
+        assert_eq!(
+            envelope[0].signing_certificate, cert_pem,
+            "signing_certificate must equal the embedded PEM"
+        );
+        assert!(
+            !envelope[0].signature.is_empty(),
+            "signature bytes must be present"
+        );
+    }
+
+    /// Scan an EIF for a section of the given type and return its payload,
+    /// using the header offset+size tables.
+    fn extract_section(eif: &[u8], ty: u16) -> Option<Vec<u8>> {
+        let num_sections =
+            u16::from_be_bytes([eif[4 + 2 + 2 + 8 + 8 + 2], eif[4 + 2 + 2 + 8 + 8 + 2 + 1]])
+                as usize;
+        let offsets_start = 4 + 2 + 2 + 8 + 8 + 2 + 2;
+        let sizes_start = offsets_start + MAX_NUM_SECTIONS * 8;
+        for i in 0..num_sections {
+            let off = u64::from_be_bytes(
+                eif[offsets_start + i * 8..offsets_start + (i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
+            let size = u64::from_be_bytes(
+                eif[sizes_start + i * 8..sizes_start + (i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
+            let this_ty = u16::from_be_bytes([eif[off], eif[off + 1]]);
+            if this_ty == ty {
+                let data_off = off + EIF_SECTION_HEADER_SIZE;
+                return Some(eif[data_off..data_off + size].to_vec());
+            }
+        }
+        None
+    }
+
+    #[tokio::test]
+    async fn test_signed_eif_crc_valid() {
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .await
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let stored_crc = u32::from_be_bytes(
+            eif[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4]
+                .try_into()
+                .unwrap(),
+        );
+        let mut hasher = Crc32Hasher::new();
+        hasher.update(&eif[..EIF_CRC32_OFFSET]);
+        hasher.update(&eif[EIF_CRC32_OFFSET + 4..]);
+        assert_eq!(hasher.finalize(), stored_crc);
+    }
+
+    /// The COSE payload we emit must be byte-identical to
+    /// serde-driven `to_vec(&PcrInfo)` on the verifier side, or `sign_check`
+    /// silently returns false.
+    #[tokio::test]
+    async fn test_pcr_info_payload_matches_upstream_shape() {
+        use coset::{CborSerializable, CoseSign1};
+
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .await
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let sig = extract_section(&eif, EIF_SECTION_SIGNATURE).unwrap();
+
+        let envelope: Vec<PcrSignature> = minicbor_serde::from_slice(&sig).unwrap();
+        assert_eq!(envelope.len(), 1);
+        let cose_bytes = &envelope[0].signature;
+
+        let sign1 = CoseSign1::from_slice(cose_bytes).unwrap();
+        let coses_payload = sign1.payload.expect("payload must be present");
+
+        // Recompute PCR0 and the upstream `measured_payload` for exact byte compare.
+        let pcr0 = compute_pcr0(b"FAKE_KERNEL", b"cmd", &[&[][..]]);
+        let measured_payload = minicbor_serde::to_vec(&PcrInfo {
+            register_index: 0,
+            register_value: pcr0,
+        })
+        .unwrap();
+
+        assert_eq!(
+            coses_payload, measured_payload,
+            "COSE payload must be byte-identical to serde-CBOR(PcrInfo) — \
+             any drift here means downstream `sign_check` returns false"
+        );
+
+        // Also decode as `PcrInfo` to catch shape drift that happens to byte-match.
+        let decoded: PcrInfo = minicbor_serde::from_slice(&coses_payload).unwrap();
+        assert_eq!(decoded.register_index, 0);
+        assert_eq!(
+            decoded.register_value.len(),
+            48,
+            "PCR0 must be a 48-byte SHA-384 digest"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_signed_eif_verifies() {
+        // COSE_Sign1 must verify with the cert's public key over recomputed TBS.
+        use aws_lc_rs::signature::{UnparsedPublicKey, ECDSA_P384_SHA384_ASN1};
+        use coset::{CborSerializable, CoseSign1};
+
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+        let pub_key_spki_der = signer.public_key_der();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .await
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let sig_section = extract_section(&eif, EIF_SECTION_SIGNATURE).unwrap();
+
+        let envelope: Vec<PcrSignature> = minicbor_serde::from_slice(&sig_section).unwrap();
+        let cose_bytes = envelope[0].signature.clone();
+
+        // Recompute Sig_structure1 and verify directly (no dependence on coset).
+        let sign1 = CoseSign1::from_slice(&cose_bytes).unwrap();
+        let tbs = sign1.tbs_data(&[]);
+        let public_key = UnparsedPublicKey::new(&ECDSA_P384_SHA384_ASN1, &pub_key_spki_der);
+        // aws-lc-rs' _ASN1 verifier needs DER; re-encode from raw `r||s`.
+        let sig_der = ecdsa_raw_to_der(&sign1.signature);
+        public_key
+            .verify(&tbs, &sig_der)
+            .expect("signature must verify");
+    }
+
+    /// Decode the signature section outer envelope via the upstream serde CBOR path.
+    fn decode_envelope(sig_section: &[u8]) -> Vec<PcrSignature> {
+        minicbor_serde::from_slice(sig_section).expect("envelope must decode via minicbor_serde")
+    }
+
+    /// Convert raw ECDSA `r || s` to DER `SEQUENCE(INTEGER r, INTEGER s)`.
+    fn ecdsa_raw_to_der(raw: &[u8]) -> Vec<u8> {
+        let n = raw.len() / 2;
+        let r = &raw[..n];
+        let s = &raw[n..];
+        let r_der = der_uint(r);
+        let s_der = der_uint(s);
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&r_der);
+        inner.extend_from_slice(&s_der);
+        let mut out = Vec::new();
+        out.push(0x30); // SEQUENCE
+        out.extend_from_slice(&der_len(inner.len()));
+        out.extend_from_slice(&inner);
+        out
+    }
+
+    fn der_uint(bytes: &[u8]) -> Vec<u8> {
+        let mut v = bytes;
+        while v.len() > 1 && v[0] == 0 {
+            v = &v[1..];
+        }
+        let mut out = Vec::new();
+        out.push(0x02); // INTEGER
+        let body_len = if v[0] & 0x80 != 0 {
+            v.len() + 1
+        } else {
+            v.len()
+        };
+        out.extend_from_slice(&der_len(body_len));
+        if v[0] & 0x80 != 0 {
+            out.push(0);
+        }
+        out.extend_from_slice(v);
+        out
+    }
+
+    fn der_len(n: usize) -> Vec<u8> {
+        if n < 0x80 {
+            vec![n as u8]
+        } else if n < 0x100 {
+            vec![0x81, n as u8]
+        } else {
+            vec![0x82, (n >> 8) as u8, (n & 0xff) as u8]
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pcr8_digestable_from_signature() {
+        // PCR8 = SHA-384(48 zero bytes || SHA-384(cert_DER)); verify PEM
+        // extraction + digest steps are reachable from the signature section.
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .await
+        .unwrap();
+
+        let eif = fs::read(&output).unwrap();
+        let sig = extract_section(&eif, EIF_SECTION_SIGNATURE).unwrap();
+        let envelope = decode_envelope(&sig);
+        let cert = envelope[0].signing_certificate.clone();
+        let parsed = pem::parse(&cert).unwrap();
+        assert_eq!(parsed.tag(), "CERTIFICATE");
+        use aws_lc_rs::digest::{digest, SHA384};
+        let _ = digest(&SHA384, parsed.contents());
+    }
+
+    // -------- resign tests --------
+
+    /// Non-signature sections must be byte-identical after `resign_eif`.
+    #[tokio::test]
+    async fn test_resign_preserves_non_signature_sections() {
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let input = dir.path().join("in.eif");
+        let output = dir.path().join("out.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &input,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields {
+                build_tool_version: "0.20.0",
+                kernel_version: "6.1.152-0.br1",
+                image_version: "",
+                build_time: "",
+            },
+            &signer,
+        )
+        .await
+        .unwrap();
+
+        // Resign with a fresh key so the signature bytes must change.
+        let (cert2, key2) = generate_test_cert_and_key();
+        let signer2 = signer::LocalSigner::from_pem(&cert2, &key2).unwrap();
+        resign_eif(&input, &output, &signer2).await.unwrap();
+
+        let in_bytes = fs::read(&input).unwrap();
+        let out_bytes = fs::read(&output).unwrap();
+
+        for ty in [
+            EIF_SECTION_KERNEL,
+            EIF_SECTION_CMDLINE,
+            EIF_SECTION_RAMDISK,
+            EIF_SECTION_METADATA,
+        ] {
+            let a = extract_section(&in_bytes, ty).expect("input has section");
+            let b = extract_section(&out_bytes, ty).expect("output has section");
+            assert_eq!(a, b, "section 0x{ty:02x} differs after resign");
+        }
+    }
+
+    /// Resigning an unsigned EIF appends a SIGNATURE section and keeps CRC valid.
+    #[tokio::test]
+    async fn test_resign_unsigned_to_signed() {
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let input = dir.path().join("in.eif");
+        let output = dir.path().join("out.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_eif(
+            &kernel,
+            "cmd",
+            &input,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+        )
+        .unwrap();
+        let in_bytes = fs::read(&input).unwrap();
+        assert!(
+            extract_section(&in_bytes, EIF_SECTION_SIGNATURE).is_none(),
+            "unsigned input must not carry a signature section"
+        );
+
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+        resign_eif(&input, &output, &signer).await.unwrap();
+
+        let out_bytes = fs::read(&output).unwrap();
+        let sig = extract_section(&out_bytes, EIF_SECTION_SIGNATURE)
+            .expect("resigned output must have a signature section");
+        let _envelope = decode_envelope(&sig);
+
+        let stored_crc = u32::from_be_bytes(
+            out_bytes[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4]
+                .try_into()
+                .unwrap(),
+        );
+        let mut hasher = Crc32Hasher::new();
+        hasher.update(&out_bytes[..EIF_CRC32_OFFSET]);
+        hasher.update(&out_bytes[EIF_CRC32_OFFSET + 4..]);
+        assert_eq!(hasher.finalize(), stored_crc);
+    }
+
+    /// Resigning a signed EIF with a different cert swaps the SIGNATURE section
+    /// but preserves PCR0.
+    #[tokio::test]
+    async fn test_resign_signed_to_resigned_with_different_cert() {
+        let (cert_a, key_a) = generate_test_cert_and_key();
+        let (cert_b, key_b) = generate_test_cert_and_key();
+        let signer_a = signer::LocalSigner::from_pem(&cert_a, &key_a).unwrap();
+        let signer_b = signer::LocalSigner::from_pem(&cert_b, &key_b).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let input = dir.path().join("in.eif");
+        let output = dir.path().join("out.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &input,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer_a,
+        )
+        .await
+        .unwrap();
+        resign_eif(&input, &output, &signer_b).await.unwrap();
+
+        let in_bytes = fs::read(&input).unwrap();
+        let out_bytes = fs::read(&output).unwrap();
+        let sig_in = extract_section(&in_bytes, EIF_SECTION_SIGNATURE).unwrap();
+        let sig_out = extract_section(&out_bytes, EIF_SECTION_SIGNATURE).unwrap();
+        assert_ne!(
+            sig_in, sig_out,
+            "signature section must change after resign"
+        );
+
+        let envelope = decode_envelope(&sig_out);
+        assert_eq!(
+            envelope[0].signing_certificate, cert_b,
+            "resigned EIF must embed the resign cert",
+        );
+    }
+
+    /// Section offsets inside the fixed header must be rejected.
+    #[test]
+    fn test_read_sections_rejects_offset_in_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let eif_path = dir.path().join("in.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_eif(
+            &kernel,
+            "cmd",
+            &eif_path,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+        )
+        .unwrap();
+        let mut bytes = fs::read(&eif_path).unwrap();
+
+        // Overwrite the first offset-table entry with 0 (inside the header).
+        let offsets_start = 4 + 2 + 2 + 8 + 8 + 2 + 2;
+        for b in &mut bytes[offsets_start..offsets_start + 8] {
+            *b = 0;
+        }
+        // Recompute CRC for hygiene; keeps the failure attributable to the offset check.
+        let mut hasher = Crc32Hasher::new();
+        hasher.update(&bytes[..EIF_CRC32_OFFSET]);
+        hasher.update(&bytes[EIF_CRC32_OFFSET + 4..]);
+        let crc = hasher.finalize();
+        bytes[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4].copy_from_slice(&crc.to_be_bytes());
+
+        let err = read_sections(&bytes).unwrap_err();
+        match err {
+            EifError::ParseInput { reason } => {
+                assert!(
+                    reason.contains("lies within the fixed EIF header"),
+                    "unexpected error reason: {reason}"
+                );
+            }
+            other => panic!("expected ParseInput, got {other:?}"),
+        }
+    }
+
+    /// `describe_eif` surfaces BuildMetadata and the top-level shape that
+    /// downstream carry-forward relies on.
+    #[test]
+    fn test_describe_eif_surfaces_build_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let eif_path = dir.path().join("in.eif");
+        fs::write(&kernel, b"FAKE_KERNEL_BYTES_FOR_DESCRIBE").unwrap();
+        build_eif(
+            &kernel,
+            "root=/dev/vda1 console=ttyS0",
+            &eif_path,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields {
+                build_tool_version: "0.99.0",
+                kernel_version: "6.18.30-1.br1",
+                image_version: "",
+                build_time: "",
+            },
+        )
+        .unwrap();
+
+        let v = describe_eif(&eif_path).unwrap();
+        assert_eq!(v["eif_version"], EIF_HDR_VERSION);
+        assert_eq!(v["is_signed"], false);
+        assert_eq!(v["cmdline"], "root=/dev/vda1 console=ttyS0");
+        assert!(v["kernel_size"].as_u64().unwrap() > 0);
+        // Every builder-produced EIF has exactly one (empty) RAMDISK section.
+        assert_eq!(v["ramdisk_count"], 1);
+
+        let bm = &v["metadata"]["BuildMetadata"];
+        assert_eq!(bm["BuildToolVersion"], "0.99.0");
+        assert_eq!(bm["KernelVersion"], "6.18.30-1.br1");
+        assert_eq!(bm["OperatingSystem"], "Linux");
+        assert_eq!(bm["BuildTool"], "twoliter");
+
+        // Unsigned builds emit KERNEL, CMDLINE, METADATA and no SIGNATURE.
+        let types: Vec<String> = v["sections"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["type"].as_str().unwrap().to_string())
+            .collect();
+        assert!(types.contains(&"KERNEL".to_string()));
+        assert!(types.contains(&"CMDLINE".to_string()));
+        assert!(types.contains(&"METADATA".to_string()));
+        assert!(!types.contains(&"SIGNATURE".to_string()));
+    }
+
+    /// Signed EIFs report `is_signed: true` and list SIGNATURE in `sections`.
+    #[tokio::test]
+    async fn test_describe_eif_reports_signed_flag() {
+        let (cert_pem, key_pem) = generate_test_cert_and_key();
+        let signer = signer::LocalSigner::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let output = dir.path().join("signed.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_signed_eif(
+            &kernel,
+            "cmd",
+            &output,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+            &signer,
+        )
+        .await
+        .unwrap();
+
+        let v = describe_eif(&output).unwrap();
+        assert_eq!(v["is_signed"], true);
+        let types: Vec<String> = v["sections"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["type"].as_str().unwrap().to_string())
+            .collect();
+        assert!(types.contains(&"SIGNATURE".to_string()));
+    }
+
+    /// Garbled METADATA must surface as `MetadataDecode`, never silent `null`.
+    #[test]
+    fn test_describe_eif_rejects_garbled_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("kernel");
+        let eif_path = dir.path().join("in.eif");
+        fs::write(&kernel, b"FAKE_KERNEL").unwrap();
+        build_eif(
+            &kernel,
+            "cmd",
+            &eif_path,
+            512 << 20,
+            2,
+            0,
+            TargetArch::X86_64,
+            &MetadataFields::default(),
+        )
+        .unwrap();
+        let mut bytes = fs::read(&eif_path).unwrap();
+
+        // Corrupt the first METADATA payload byte to 0xff so UTF-8 decode fails
+        // while `read_sections` still succeeds.
+        let num_sections_off = 4 + 2 + 2 + 8 + 8 + 2;
+        let num_sections =
+            u16::from_be_bytes([bytes[num_sections_off], bytes[num_sections_off + 1]]) as usize;
+        let offsets_start = num_sections_off + 2;
+        let mut patched = false;
+        for i in 0..num_sections {
+            let off = u64::from_be_bytes(
+                bytes[offsets_start + i * 8..offsets_start + (i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
+            let ty = u16::from_be_bytes([bytes[off], bytes[off + 1]]);
+            if ty == EIF_SECTION_METADATA {
+                let data_off = off + EIF_SECTION_HEADER_SIZE;
+                bytes[data_off] = 0xff;
+                patched = true;
+                break;
+            }
+        }
+        assert!(patched, "test setup: no METADATA section found");
+        // Recompute CRC for hygiene.
+        let mut hasher = Crc32Hasher::new();
+        hasher.update(&bytes[..EIF_CRC32_OFFSET]);
+        hasher.update(&bytes[EIF_CRC32_OFFSET + 4..]);
+        let crc = hasher.finalize();
+        bytes[EIF_CRC32_OFFSET..EIF_CRC32_OFFSET + 4].copy_from_slice(&crc.to_be_bytes());
+        fs::write(&eif_path, &bytes).unwrap();
+
+        let err = describe_eif(&eif_path).unwrap_err();
+        match err {
+            EifError::MetadataDecode { reason } => {
+                assert!(
+                    reason.contains("UTF-8") || reason.contains("JSON"),
+                    "unexpected MetadataDecode reason: {reason}"
+                );
+            }
+            other => panic!("expected MetadataDecode, got {other:?}"),
+        }
     }
 }

--- a/tools/eif-builder/src/signer.rs
+++ b/tools/eif-builder/src/signer.rs
@@ -1,0 +1,742 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! EIF signature production for the `EifSectionSignature` (0x04) section.
+//!
+//! [`LocalSigner`] signs in-process from a PEM ECDSA key.
+//! [`KmsSigner`] delegates to AWS KMS. Both emit the COSE raw ECDSA
+//! encoding `I2OSP(R, n) | I2OSP(S, n)` with `n = ceil(key_length / 8)`
+//! (RFC 9053 §2.1: https://www.rfc-editor.org/rfc/rfc9053#section-2.1);
+//! P-256 → ES256, P-384 → ES384; other curves rejected. The TBS bytes
+//! passed to [`Signer::sign_cose`] are the COSE `Sig_structure1`
+//! serialization defined in (RFC 9052 §4.4: https://www.rfc-editor.org/rfc/rfc9052#section-4.4),
+//!  built by the caller.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use aws_lc_rs::rand::SystemRandom;
+use aws_lc_rs::signature::{
+    EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_ASN1_SIGNING, ECDSA_P384_SHA384_ASN1_SIGNING,
+};
+use snafu::{ResultExt, Snafu};
+
+/// Errors from any signer backend.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum SignerError {
+    #[snafu(display("failed to read signing key file: {source}"))]
+    ReadKey { source: std::io::Error },
+
+    #[snafu(display("failed to read signing cert file: {source}"))]
+    ReadCert { source: std::io::Error },
+
+    #[snafu(display("failed to parse PEM: {source}"))]
+    Pem { source: pem::PemError },
+
+    #[snafu(display("expected a PEM label of 'CERTIFICATE', got {label:?}"))]
+    CertPemLabel { label: String },
+
+    #[snafu(display("expected a PEM key label of 'PRIVATE KEY' (PKCS#8), got {label:?}"))]
+    KeyPemLabel { label: String },
+
+    #[snafu(display(
+        "PEM key label 'EC PRIVATE KEY' (SEC1) is not supported yet; convert with \
+         `openssl pkcs8 -topk8 -nocrypt -in sec1.key -out pkcs8.key`"
+    ))]
+    Sec1PrivateKeyUnsupported,
+
+    #[snafu(display(
+        "unsupported signing key: only ECDSA P-256 (ES256) and P-384 (ES384) are supported"
+    ))]
+    UnsupportedKey,
+
+    #[snafu(display("failed to parse X.509 certificate: {reason}"))]
+    ParseCert { reason: String },
+
+    #[snafu(display(
+        "certificate curve does not match signing key curve; cert uses {cert_curve}, key uses {key_curve}"
+    ))]
+    CurveMismatch {
+        cert_curve: &'static str,
+        key_curve: &'static str,
+    },
+
+    #[snafu(display("failed to load private key: {reason}"))]
+    LoadKey { reason: String },
+
+    #[snafu(display("aws-lc-rs signing failed"))]
+    Sign,
+
+    #[snafu(display("KMS Sign call failed: {reason}"))]
+    Kms { reason: String },
+
+    #[snafu(display("KMS AccessDenied: {reason}"))]
+    KmsAccessDenied { reason: String },
+
+    #[snafu(display("KMS key is disabled: {reason}"))]
+    KmsKeyDisabled { reason: String },
+
+    #[snafu(display("KMS key state does not allow signing: {reason}"))]
+    KmsInvalidKeyState { reason: String },
+
+    #[snafu(display("KMS did not return a signature blob"))]
+    KmsEmptySignature,
+
+    #[snafu(display("failed to decode ECDSA DER signature"))]
+    DecodeDerSignature,
+
+    #[snafu(display(
+        "ECDSA signature scalars exceed the expected width: r={r} bytes, \
+         s={s} bytes, expected each ≤ {expected}"
+    ))]
+    ScalarTooLarge { r: usize, s: usize, expected: usize },
+
+    #[snafu(display("ECDSA DER signature has {trailing} trailing byte(s) after the SEQUENCE"))]
+    DerTrailingBytes { trailing: usize },
+
+    #[snafu(display(
+        "ECDSA DER outer SEQUENCE length ({claimed}) does not match content length ({actual})"
+    ))]
+    DerLengthMismatch { claimed: usize, actual: usize },
+}
+
+/// Signing algorithm selection. Drives COSE `alg` header and raw scalar width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignAlg {
+    Es256,
+    Es384,
+}
+
+impl SignAlg {
+    /// Width (in bytes) of each ECDSA scalar (r and s) in COSE raw form.
+    fn scalar_len(self) -> usize {
+        match self {
+            Self::Es256 => 32,
+            Self::Es384 => 48,
+        }
+    }
+}
+
+/// Backend for producing the COSE_Sign1 signature over the pre-hash TBS bytes.
+#[async_trait]
+pub trait Signer: Send + Sync {
+    /// Sign the given `to_be_signed` bytes (the COSE `Sig_structure1` payload)
+    /// and return a fixed-width raw ECDSA `r || s` signature.
+    async fn sign_cose(&self, to_be_signed: &[u8]) -> Result<Vec<u8>, SignerError>;
+
+    /// PEM-encoded signing certificate, embedded verbatim in the CBOR section.
+    fn cert_pem(&self) -> &[u8];
+
+    /// COSE algorithm to advertise.
+    fn algorithm(&self) -> SignAlg;
+}
+
+/// In-process ECDSA signer backed by `aws-lc-rs`.
+pub struct LocalSigner {
+    key_pair: EcdsaKeyPair,
+    cert_pem: Vec<u8>,
+    alg: SignAlg,
+    rng: Arc<SystemRandom>,
+}
+
+impl LocalSigner {
+    /// Build a `LocalSigner` from PEM-encoded cert and key bytes.
+    pub fn from_pem(cert_pem: &[u8], key_pem: &[u8]) -> Result<Self, SignerError> {
+        // Parse the cert PEM to detect the SPKI curve; this dictates the
+        // signing algorithm and must match the key material.
+        let parsed_cert = pem::parse(cert_pem).context(PemSnafu)?;
+        if parsed_cert.tag() != "CERTIFICATE" {
+            return CertPemLabelSnafu {
+                label: parsed_cert.tag().to_string(),
+            }
+            .fail();
+        }
+        let cert_alg = detect_cert_curve(parsed_cert.contents())?;
+
+        // Only PKCS#8 is accepted; SEC1 gets a dedicated error with a conversion recipe.
+        let parsed_key = pem::parse(key_pem).context(PemSnafu)?;
+        let key_alg = match parsed_key.tag() {
+            "PRIVATE KEY" => cert_alg,
+            "EC PRIVATE KEY" => return Sec1PrivateKeyUnsupportedSnafu.fail(),
+            other => {
+                return KeyPemLabelSnafu {
+                    label: other.to_string(),
+                }
+                .fail()
+            }
+        };
+
+        // Load the keypair.
+        let ring_alg = match key_alg {
+            SignAlg::Es256 => &ECDSA_P256_SHA256_ASN1_SIGNING,
+            SignAlg::Es384 => &ECDSA_P384_SHA384_ASN1_SIGNING,
+        };
+        let rng = Arc::new(SystemRandom::new());
+        let key_pair = EcdsaKeyPair::from_pkcs8(ring_alg, parsed_key.contents()).map_err(|e| {
+            SignerError::LoadKey {
+                reason: format!("{e}"),
+            }
+        })?;
+
+        // Cross-check the key's curve against the cert's via SEC1 point length
+        // (P-256 = 65 bytes, P-384 = 97 bytes).
+        let raw_pub = key_pair.public_key().as_ref().to_vec();
+        let key_curve = match raw_pub.len() {
+            65 => SignAlg::Es256,
+            97 => SignAlg::Es384,
+            _ => return UnsupportedKeySnafu.fail(),
+        };
+        if key_curve != cert_alg {
+            return CurveMismatchSnafu {
+                cert_curve: name_of(cert_alg),
+                key_curve: name_of(key_curve),
+            }
+            .fail();
+        }
+
+        Ok(Self {
+            key_pair,
+            cert_pem: cert_pem.to_vec(),
+            alg: cert_alg,
+            rng,
+        })
+    }
+}
+
+#[async_trait]
+impl Signer for LocalSigner {
+    async fn sign_cose(&self, to_be_signed: &[u8]) -> Result<Vec<u8>, SignerError> {
+        // aws-lc-rs' EcdsaKeyPair::sign returns DER; convert to raw `r||s`.
+        // The work is CPU-bound and short; no yield point is needed.
+        let der = self
+            .key_pair
+            .sign(&*self.rng, to_be_signed)
+            .map_err(|_| SignerError::Sign)?;
+        ecdsa_der_to_raw(der.as_ref(), self.alg.scalar_len())
+    }
+
+    fn cert_pem(&self) -> &[u8] {
+        &self.cert_pem
+    }
+
+    fn algorithm(&self) -> SignAlg {
+        self.alg
+    }
+}
+
+#[cfg(test)]
+impl LocalSigner {
+    /// SPKI DER for the signing key, derived on demand. Test-only.
+    pub fn public_key_der(&self) -> Vec<u8> {
+        let raw_pub = self.key_pair.public_key().as_ref();
+        spki_der_for_ecdsa(raw_pub, self.alg)
+    }
+}
+
+/// KMS-backed ECDSA signer. The private key stays in KMS; only the cert
+/// is provided locally. KMS returns DER; we convert to raw `r||s`.
+pub struct KmsSigner {
+    client: aws_sdk_kms::Client,
+    key_id: String,
+    cert_pem: Vec<u8>,
+    alg: SignAlg,
+}
+
+impl KmsSigner {
+    /// Build a `KmsSigner`. Region resolves as: explicit `region` arg,
+    /// else the region embedded in `key_id` when it is a full ARN, else
+    /// the ambient AWS SDK chain (env, profile, IMDS). Credentials come
+    /// from the process environment.
+    pub async fn from_key_id(
+        key_id: String,
+        cert_pem: Vec<u8>,
+        region: Option<String>,
+    ) -> Result<Self, SignerError> {
+        let parsed_cert = pem::parse(&cert_pem).context(PemSnafu)?;
+        if parsed_cert.tag() != "CERTIFICATE" {
+            return CertPemLabelSnafu {
+                label: parsed_cert.tag().to_string(),
+            }
+            .fail();
+        }
+        let alg = detect_cert_curve(parsed_cert.contents())?;
+
+        let resolved_region = region.or_else(|| region_from_kms_arn(&key_id));
+
+        #[allow(deprecated)]
+        let client = {
+            let mut loader = aws_config::from_env();
+            if let Some(r) = resolved_region {
+                loader = loader.region(aws_types::region::Region::new(r));
+            }
+            let conf = loader.load().await;
+            aws_sdk_kms::Client::new(&conf)
+        };
+
+        Ok(Self {
+            client,
+            key_id,
+            cert_pem,
+            alg,
+        })
+    }
+}
+
+/// Return the region from a KMS ARN (`arn:<partition>:kms:<region>:...`),
+/// or `None` for bare key ids/aliases, non-KMS ARNs, or an empty region.
+fn region_from_kms_arn(key_id: &str) -> Option<String> {
+    let mut parts = key_id.splitn(6, ':');
+    if parts.next()? != "arn" {
+        return None;
+    }
+    let _partition = parts.next()?;
+    if parts.next()? != "kms" {
+        return None;
+    }
+    let region = parts.next()?;
+    (!region.is_empty()).then(|| region.to_string())
+}
+
+/// Map a KMS `Sign` SDK error to a typed [`SignerError`]. `AccessDenied` is
+/// not a distinct `SignError` variant; probe smithy metadata for its code.
+fn map_sign_error(
+    e: error_utils::SdkError<aws_sdk_kms::operation::sign::SignError>,
+) -> SignerError {
+    use aws_sdk_kms::operation::sign::SignError;
+    let wrapper = error_utils::AwsSdkError::from(e);
+    let display = wrapper.to_string();
+    let Some(svc) = wrapper.as_service_error() else {
+        return SignerError::Kms { reason: display };
+    };
+    match svc {
+        SignError::DisabledException(inner) => SignerError::KmsKeyDisabled {
+            reason: format!("{inner}"),
+        },
+        SignError::KmsInvalidStateException(inner) => SignerError::KmsInvalidKeyState {
+            reason: format!("{inner}"),
+        },
+        other if other.meta().code() == Some("AccessDeniedException") => {
+            SignerError::KmsAccessDenied { reason: display }
+        }
+        _ => SignerError::Kms { reason: display },
+    }
+}
+
+#[async_trait]
+impl Signer for KmsSigner {
+    async fn sign_cose(&self, to_be_signed: &[u8]) -> Result<Vec<u8>, SignerError> {
+        use aws_sdk_kms::primitives::Blob;
+        use aws_sdk_kms::types::{MessageType, SigningAlgorithmSpec};
+
+        let (algo, hash_alg) = match self.alg {
+            SignAlg::Es256 => (
+                SigningAlgorithmSpec::EcdsaSha256,
+                &aws_lc_rs::digest::SHA256,
+            ),
+            SignAlg::Es384 => (
+                SigningAlgorithmSpec::EcdsaSha384,
+                &aws_lc_rs::digest::SHA384,
+            ),
+        };
+
+        // Hash locally; KMS' `Digest` message type takes the hash, not the TBS,
+        // which lets payloads exceed the 4 KiB KMS raw-message limit.
+        let digest = aws_lc_rs::digest::digest(hash_alg, to_be_signed);
+
+        let out = self
+            .client
+            .sign()
+            .key_id(&self.key_id)
+            .message(Blob::new(digest.as_ref().to_vec()))
+            .message_type(MessageType::Digest)
+            .signing_algorithm(algo)
+            .send()
+            .await
+            .map_err(map_sign_error)?;
+
+        let sig_der = out.signature().ok_or(SignerError::KmsEmptySignature)?;
+        ecdsa_der_to_raw(sig_der.as_ref(), self.alg.scalar_len())
+    }
+
+    fn cert_pem(&self) -> &[u8] {
+        &self.cert_pem
+    }
+
+    fn algorithm(&self) -> SignAlg {
+        self.alg
+    }
+}
+
+// -------- Curve detection --------
+
+/// Detect the ECDSA curve of an X.509 cert via its SPKI namedCurve OID.
+/// Only P-256 and P-384 are accepted.
+fn detect_cert_curve(cert_der: &[u8]) -> Result<SignAlg, SignerError> {
+    use x509_cert::der::Decode;
+    let cert = x509_cert::Certificate::from_der(cert_der).map_err(|e| SignerError::ParseCert {
+        reason: format!("{e}"),
+    })?;
+    let alg_ident = &cert.tbs_certificate.subject_public_key_info.algorithm;
+    // id-ecPublicKey OID.
+    let ec_public_key: x509_cert::der::asn1::ObjectIdentifier =
+        "1.2.840.10045.2.1".parse().unwrap();
+    if alg_ident.oid != ec_public_key {
+        return UnsupportedKeySnafu.fail();
+    }
+    let params = alg_ident
+        .parameters
+        .as_ref()
+        .ok_or(SignerError::UnsupportedKey)?;
+    let curve_oid: x509_cert::der::asn1::ObjectIdentifier =
+        params.decode_as().map_err(|e| SignerError::ParseCert {
+            reason: format!("curve OID decode: {e}"),
+        })?;
+    let p256: x509_cert::der::asn1::ObjectIdentifier = "1.2.840.10045.3.1.7".parse().unwrap();
+    let p384: x509_cert::der::asn1::ObjectIdentifier = "1.3.132.0.34".parse().unwrap();
+    if curve_oid == p256 {
+        Ok(SignAlg::Es256)
+    } else if curve_oid == p384 {
+        Ok(SignAlg::Es384)
+    } else {
+        UnsupportedKeySnafu.fail()
+    }
+}
+
+fn name_of(alg: SignAlg) -> &'static str {
+    match alg {
+        SignAlg::Es256 => "P-256",
+        SignAlg::Es384 => "P-384",
+    }
+}
+
+// -------- DER ↔ raw ECDSA signature conversion --------
+
+/// Convert a DER-encoded ECDSA signature `SEQUENCE(INTEGER r, INTEGER s)`
+/// into COSE's raw `r || s` form, left-padded to `scalar_len` per scalar.
+/// Rejects trailing bytes, length mismatches, and over-wide scalars via
+/// the corresponding [`SignerError`] variants.
+fn ecdsa_der_to_raw(der: &[u8], scalar_len: usize) -> Result<Vec<u8>, SignerError> {
+    let mut i = 0;
+    if der.get(i).copied() != Some(0x30) {
+        return DecodeDerSignatureSnafu.fail();
+    }
+    i += 1;
+    let (seq_len, consumed) = read_der_len(&der[i..]).ok_or(SignerError::DecodeDerSignature)?;
+    i += consumed;
+    let content_start = i;
+
+    let r = read_der_uint(&der[i..]).ok_or(SignerError::DecodeDerSignature)?;
+    i += r.raw_len;
+    let s = read_der_uint(&der[i..]).ok_or(SignerError::DecodeDerSignature)?;
+    i += s.raw_len;
+
+    let content_actual = i - content_start;
+    if content_actual != seq_len {
+        return DerLengthMismatchSnafu {
+            claimed: seq_len,
+            actual: content_actual,
+        }
+        .fail();
+    }
+    let trailing = der.len() - i;
+    if trailing > 0 {
+        return DerTrailingBytesSnafu { trailing }.fail();
+    }
+    if r.value.len() > scalar_len || s.value.len() > scalar_len {
+        return ScalarTooLargeSnafu {
+            r: r.value.len(),
+            s: s.value.len(),
+            expected: scalar_len,
+        }
+        .fail();
+    }
+    let mut out = vec![0u8; 2 * scalar_len];
+    out[scalar_len - r.value.len()..scalar_len].copy_from_slice(&r.value);
+    out[2 * scalar_len - s.value.len()..].copy_from_slice(&s.value);
+    Ok(out)
+}
+
+struct DerUint {
+    value: Vec<u8>,
+    raw_len: usize,
+}
+
+fn read_der_uint(buf: &[u8]) -> Option<DerUint> {
+    if buf.first()? != &0x02 {
+        return None;
+    }
+    let (len, consumed) = read_der_len(&buf[1..])?;
+    let start = 1 + consumed;
+    let end = start.checked_add(len)?;
+    if end > buf.len() {
+        return None;
+    }
+    let mut value = buf[start..end].to_vec();
+    // Strip any leading zero used to disambiguate the sign bit.
+    while value.len() > 1 && value[0] == 0 {
+        value.remove(0);
+    }
+    Some(DerUint {
+        value,
+        raw_len: end,
+    })
+}
+
+fn read_der_len(buf: &[u8]) -> Option<(usize, usize)> {
+    let first = *buf.first()?;
+    if first & 0x80 == 0 {
+        return Some((first as usize, 1));
+    }
+    let n = (first & 0x7f) as usize;
+    if n == 0 || n > 4 {
+        return None;
+    }
+    let mut len = 0usize;
+    for i in 0..n {
+        len = (len << 8) | (*buf.get(1 + i)? as usize);
+    }
+    Some((len, 1 + n))
+}
+
+/// Minimal SPKI DER envelope over a SEC1 ECDSA public key. Test-only.
+#[cfg(test)]
+fn spki_der_for_ecdsa(sec1_uncompressed: &[u8], alg: SignAlg) -> Vec<u8> {
+    use crate::der_helpers::wrap_der;
+    // id-ecPublicKey 1.2.840.10045.2.1.
+    let id_ec_public_key: [u8; 9] = [0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01];
+    // secp256r1 1.2.840.10045.3.1.7; secp384r1 1.3.132.0.34.
+    let curve_oid: Vec<u8> = match alg {
+        SignAlg::Es256 => vec![0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07],
+        SignAlg::Es384 => vec![0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22],
+    };
+
+    let mut alg_ident_body = Vec::new();
+    alg_ident_body.extend_from_slice(&id_ec_public_key);
+    alg_ident_body.extend_from_slice(&curve_oid);
+    let alg_ident = wrap_der(0x30, &alg_ident_body);
+
+    let mut bitstring_body = vec![0u8];
+    bitstring_body.extend_from_slice(sec1_uncompressed);
+    let bitstring = wrap_der(0x03, &bitstring_body);
+
+    let mut spki_body = Vec::new();
+    spki_body.extend_from_slice(&alg_ident);
+    spki_body.extend_from_slice(&bitstring);
+    wrap_der(0x30, &spki_body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ecdsa_der_roundtrip_p384() {
+        let r: Vec<u8> = (1u8..=48).collect();
+        let s: Vec<u8> = (49u8..=96).collect();
+        let der = build_ecdsa_der(&r, &s);
+        let raw = ecdsa_der_to_raw(&der, 48).unwrap();
+        assert_eq!(&raw[..48], &r[..]);
+        assert_eq!(&raw[48..], &s[..]);
+    }
+
+    #[test]
+    fn ecdsa_der_high_bit_set_p384() {
+        // Regression guard: high-bit-set scalars are DER-encoded with a
+        // leading 0x00 that must be stripped in the raw form.
+        let mut r = vec![0u8; 48];
+        r[0] = 0x80;
+        for (i, b) in r.iter_mut().enumerate().skip(1) {
+            *b = i as u8;
+        }
+        let s = r.iter().rev().copied().collect::<Vec<u8>>();
+        let der = build_ecdsa_der(&r, &s);
+        let raw = ecdsa_der_to_raw(&der, 48).unwrap();
+        assert_eq!(raw.len(), 96);
+        assert_eq!(&raw[..48], &r[..], "r must not have a stray leading zero");
+        assert_eq!(&raw[48..], &s[..], "s must not have a stray leading zero");
+    }
+
+    #[test]
+    fn ecdsa_der_rejects_trailing_bytes() {
+        let r = vec![0x11u8; 48];
+        let s = vec![0x22u8; 48];
+        let mut der = build_ecdsa_der(&r, &s);
+        der.push(0x00); // one stray byte after the SEQUENCE
+        let err = ecdsa_der_to_raw(&der, 48).unwrap_err();
+        assert!(
+            matches!(err, SignerError::DerTrailingBytes { trailing: 1 }),
+            "err={err}",
+        );
+    }
+
+    #[test]
+    fn ecdsa_der_rejects_length_mismatch() {
+        let r = vec![0x11u8; 32];
+        let s = vec![0x22u8; 32];
+        let mut der = build_ecdsa_der(&r, &s);
+        // Inflate the outer SEQUENCE length and pad the tail so the length
+        // mismatch surfaces before the trailing-bytes check.
+        der[1] = der[1].wrapping_add(10);
+        der.extend_from_slice(&[0u8; 10]);
+        let err = ecdsa_der_to_raw(&der, 32).unwrap_err();
+        assert!(
+            matches!(err, SignerError::DerLengthMismatch { .. }),
+            "err={err}",
+        );
+    }
+
+    #[test]
+    fn ecdsa_der_rejects_scalar_too_large() {
+        let r = (1u8..=60).collect::<Vec<u8>>();
+        let s = (61u8..=120).collect::<Vec<u8>>();
+        let der = build_ecdsa_der(&r, &s);
+        let err = ecdsa_der_to_raw(&der, 48).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SignerError::ScalarTooLarge {
+                    r: 60,
+                    s: 60,
+                    expected: 48,
+                }
+            ),
+            "err={err}",
+        );
+    }
+
+    #[test]
+    fn ecdsa_der_pads_short_scalars() {
+        let r = vec![0x05];
+        let s = vec![0x06];
+        let der = build_ecdsa_der(&r, &s);
+        let raw = ecdsa_der_to_raw(&der, 48).unwrap();
+        assert_eq!(raw[47], 0x05);
+        assert_eq!(raw[95], 0x06);
+        assert!(raw[..47].iter().all(|&b| b == 0));
+        assert!(raw[48..95].iter().all(|&b| b == 0));
+    }
+
+    /// Build a DER ECDSA signature envelope from raw scalars.
+    fn build_ecdsa_der(r: &[u8], s: &[u8]) -> Vec<u8> {
+        fn uint(v: &[u8]) -> Vec<u8> {
+            let mut trimmed = v;
+            while trimmed.len() > 1 && trimmed[0] == 0 {
+                trimmed = &trimmed[1..];
+            }
+            let mut body = Vec::new();
+            if trimmed[0] & 0x80 != 0 {
+                body.push(0);
+            }
+            body.extend_from_slice(trimmed);
+            let mut out = vec![0x02, body.len() as u8];
+            out.extend_from_slice(&body);
+            out
+        }
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&uint(r));
+        inner.extend_from_slice(&uint(s));
+        let mut out = vec![0x30, inner.len() as u8];
+        out.extend_from_slice(&inner);
+        out
+    }
+
+    #[test]
+    fn rejects_rsa_pem_key() {
+        // Both the stub cert and the RSA label are rejected paths; either
+        // typed error is acceptable.
+        let cert_pem = pem::encode(&pem::Pem::new("CERTIFICATE", vec![0u8; 8]));
+        let key_pem = pem::encode(&pem::Pem::new("RSA PRIVATE KEY", vec![0u8; 8]));
+        let result = LocalSigner::from_pem(cert_pem.as_bytes(), key_pem.as_bytes());
+        assert!(matches!(
+            result.err(),
+            Some(SignerError::KeyPemLabel { .. } | SignerError::ParseCert { .. }),
+        ));
+    }
+
+    #[test]
+    fn rejects_sec1_ec_private_key_with_actionable_error() {
+        // SEC1 (`EC PRIVATE KEY`) input must surface a typed error, not an
+        // opaque aws-lc-rs failure.
+        use crate::der_helpers::wrap_der;
+        use aws_lc_rs::signature::{EcdsaKeyPair, KeyPair, ECDSA_P384_SHA384_ASN1_SIGNING};
+        let rng = aws_lc_rs::rand::SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, &rng).unwrap();
+        let key_pair =
+            EcdsaKeyPair::from_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8.as_ref()).unwrap();
+        let sec1_pub = key_pair.public_key().as_ref().to_vec();
+        let spki = spki_der_for_ecdsa(&sec1_pub, SignAlg::Es384);
+        let cert = wrap_der(0x30, &spki);
+        let cert_pem = pem::encode(&pem::Pem::new("CERTIFICATE", cert));
+        let sec1 = pem::encode(&pem::Pem::new("EC PRIVATE KEY", vec![0u8; 8]));
+        let err = LocalSigner::from_pem(cert_pem.as_bytes(), sec1.as_bytes())
+            .err()
+            .expect("should reject");
+        // Either typed error is acceptable; both prove we don't panic.
+        assert!(
+            matches!(
+                err,
+                SignerError::Sec1PrivateKeyUnsupported | SignerError::ParseCert { .. },
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn region_from_kms_arn_extracts_region_from_key_arn() {
+        assert_eq!(
+            region_from_kms_arn(
+                "arn:aws:kms:us-east-1:123456789012:key/abcdef01-2345-6789-abcd-ef0123456789"
+            ),
+            Some("us-east-1".to_string()),
+        );
+    }
+
+    #[test]
+    fn region_from_kms_arn_extracts_region_from_alias_arn() {
+        assert_eq!(
+            region_from_kms_arn("arn:aws:kms:eu-west-2:123456789012:alias/eif-signing-key"),
+            Some("eu-west-2".to_string()),
+        );
+    }
+
+    #[test]
+    fn region_from_kms_arn_accepts_partitions() {
+        assert_eq!(
+            region_from_kms_arn(
+                "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/abcdef01-2345-6789-abcd-ef0123456789"
+            ),
+            Some("us-gov-west-1".to_string()),
+        );
+        assert_eq!(
+            region_from_kms_arn(
+                "arn:aws-cn:kms:cn-north-1:123456789012:key/abcdef01-2345-6789-abcd-ef0123456789"
+            ),
+            Some("cn-north-1".to_string()),
+        );
+    }
+
+    #[test]
+    fn region_from_kms_arn_rejects_non_arn_ids() {
+        assert_eq!(region_from_kms_arn("alias/eif-signing-key"), None);
+        assert_eq!(
+            region_from_kms_arn("abcdef01-2345-6789-abcd-ef0123456789"),
+            None,
+        );
+    }
+
+    #[test]
+    fn region_from_kms_arn_rejects_wrong_service() {
+        assert_eq!(
+            region_from_kms_arn("arn:aws:iam::123456789012:role/example"),
+            None,
+        );
+        assert_eq!(region_from_kms_arn("arn:aws:s3:::my-bucket"), None,);
+    }
+
+    #[test]
+    fn region_from_kms_arn_rejects_empty_region_field() {
+        assert_eq!(
+            region_from_kms_arn("arn:aws:kms::123456789012:key/abcdef01"),
+            None,
+        );
+    }
+}


### PR DESCRIPTION
Extend eif-builder library with EifSectionSignature (0x04) covering PCR0
via COSE_Sign1 ECDSA (ES256/ES384). Introduces a Signer trait with two
implementations:

* LocalSigner (aws-lc-rs) — reads a PEM ECDSA key from disk.
* KmsSigner (aws-sdk-kms) — calls KMS Sign on P-256/P-384 keys with
  typed errors for KmsAccessDenied / KmsKeyDisabled / KmsInvalidKeyState.

Wire format matches aws-nitro-enclaves-image-format: CBOR Array(1) of
Map { signing_certificate: PEM, signature: COSE_Sign1 } with a PcrInfo
payload for PCR0 = SHA-384(48 zero bytes || SHA-384(kernel || cmdline
|| ramdisks)). This makes `nitro-cli describe-eif` populate PCR8.

Also adds byte-preserving resign_eif() and describe_eif() library
entry points for the CLI subcommands landing in the next commit.

New deps: aws-lc-rs, coset, ciborium, pem, x509-cert.

Tests: PCR0 spec conformance, COSE payload shape, end-to-end signature
verification, DER parser edge cases (SEQUENCE length + trailing byte
rejection), resign round-trips.