### PR TITLE
feat(buildsys): plumb [eif] signing profile into rpm2eif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "lazy_static",
  "nonzero_ext",
  "pipesys",
+ "pubsys-config",
  "rand 0.9.5",
  "regex",
  "reqwest",

--- a/tools/buildsys/Cargo.toml
+++ b/tools/buildsys/Cargo.toml
@@ -18,6 +18,7 @@ guppy.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
 pipesys.workspace = true
+pubsys-config.workspace = true
 rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 regex.workspace = true
 reqwest = { workspace = true, features = ["blocking", "rustls"] }

--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -19,6 +19,7 @@ use error::Result;
 use lazy_static::lazy_static;
 use nonzero_ext::nonzero;
 use pipesys::server::Server as PipesysServer;
+use pubsys_config::{EifSigningKey, InfraConfig};
 use rand::Rng;
 use regex::Regex;
 use semver::{Comparator, Op, Prerelease, Version, VersionReq};
@@ -971,7 +972,104 @@ fn secrets_args() -> Result<Vec<String>> {
         args.build_secret("env", &id, var);
     }
 
+    args.extend(eif_signing_args()?);
+
     Ok(args)
+}
+
+/// Docker-build `--secret` flags carrying the EIF signing profile from
+/// `Infra.toml [eif]`. Absent config (no `PUBLISH_INFRA_CONFIG_PATH`, no
+/// `[eif]`, or no Infra.toml) is not an error: the in-container helper
+/// treats missing mounts as "unsigned". Empty cert/key files are rejected
+/// here to keep this gate in lockstep with the helper's `[[ -s ]]` check.
+fn eif_signing_args() -> Result<Vec<String>> {
+    let infra_path = match env::var("PUBLISH_INFRA_CONFIG_PATH") {
+        Ok(p) if !p.is_empty() => PathBuf::from(p),
+        _ => return Ok(Vec::new()),
+    };
+
+    let infra = InfraConfig::from_path_or_lock(&infra_path, true)
+        .context(error::InfraConfigLoadSnafu { path: &infra_path })?;
+    let Some(eif) = infra.eif else {
+        // Guard against a stale Infra.lock that predates the `[eif]` schema
+        // shadowing an `[eif]` section in Infra.toml.
+        detect_stale_infra_lock(&infra_path)?;
+        return Ok(Vec::new());
+    };
+
+    if !is_non_empty_file(&eif.signing_cert) {
+        return error::EifSigningCertMissingSnafu {
+            path: eif.signing_cert,
+        }
+        .fail();
+    }
+
+    let mut args = Vec::new();
+    args.build_secret(
+        "file",
+        "eif-signing.crt",
+        &eif.signing_cert.to_string_lossy(),
+    );
+
+    match eif.signing_key {
+        EifSigningKey::file { path } => {
+            if !is_non_empty_file(&path) {
+                return error::EifSigningKeyMissingSnafu { path }.fail();
+            }
+            args.build_secret("file", "eif-signing.key", &path.to_string_lossy());
+        }
+        EifSigningKey::kms { key_id, region } => {
+            env::set_var("EIF_KMS_KEY_ID", &key_id);
+            args.build_secret("env", "eif-kms-key-id.env", "EIF_KMS_KEY_ID");
+            if let Some(region) = region {
+                env::set_var("EIF_KMS_REGION", &region);
+                args.build_secret("env", "eif-kms-region.env", "EIF_KMS_REGION");
+            }
+        }
+    }
+
+    Ok(args)
+}
+
+/// True if `path` names a regular file with size > 0.
+fn is_non_empty_file(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|m| m.is_file() && m.len() > 0)
+        .unwrap_or(false)
+}
+
+/// Fail if `Infra.lock` was loaded with no `[eif]` section while the
+/// sibling `Infra.toml` declares one — this indicates a lock predating
+/// the `[eif]` schema and would otherwise silently strip EIF signing.
+/// Returns `Ok(())` when there is no lock, no Infra.toml, or Infra.toml
+/// has no `[eif]` — those are legitimate "no signing" configurations.
+fn detect_stale_infra_lock(infra_path: &Path) -> Result<()> {
+    let Ok(lock_path) = InfraConfig::compute_lock_path(infra_path) else {
+        return Ok(());
+    };
+    // Only relevant when the lock is what actually got loaded.
+    if !lock_path.exists() {
+        return Ok(());
+    }
+    // If Infra.toml is missing or unreadable, there is nothing to compare
+    // against — the lock is authoritative by design.
+    let Ok(toml_str) = fs::read_to_string(infra_path) else {
+        return Ok(());
+    };
+    // Use version-tolerant `toml::Value` so unrelated schema additions in
+    // Infra.toml do not trip this guard.
+    let has_eif = toml::from_str::<toml::Value>(&toml_str)
+        .ok()
+        .and_then(|v| v.get("eif").cloned())
+        .is_some();
+    if has_eif {
+        return error::EifStaleInfraLockSnafu {
+            lock_path,
+            toml_path: infra_path.to_path_buf(),
+        }
+        .fail();
+    }
+    Ok(())
 }
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
@@ -1238,6 +1336,8 @@ fn filename(p: impl AsRef<Path>) -> String {
 mod test {
     use super::*;
     use semver::Version;
+    use std::io::Write;
+    use tempfile::TempDir;
 
     #[test]
     fn test_docker_version_req_25_0_5_passes() {
@@ -1261,5 +1361,103 @@ mod test {
     fn test_docker_version_req_20_10_27_fails() {
         let version = Version::parse("20.10.27").unwrap();
         assert!(!MINIMUM_DOCKER_VERSION.matches(&version))
+    }
+
+    /// A regular file with content is accepted.
+    #[test]
+    fn is_non_empty_file_accepts_nonempty() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("cert.pem");
+        let mut f = File::create(&p).unwrap();
+        f.write_all(b"-----BEGIN CERTIFICATE-----\n").unwrap();
+        assert!(is_non_empty_file(&p));
+    }
+
+    /// A 0-byte file must be treated the same as `[[ -s ]]` in the helper: not present.
+    #[test]
+    fn is_non_empty_file_rejects_zero_byte() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("cert.pem");
+        File::create(&p).unwrap();
+        assert!(p.exists(), "precondition: file exists on disk");
+        assert!(
+            !is_non_empty_file(&p),
+            "a 0-byte file must be treated the same as `[[ -s ]]` in the helper: not present",
+        );
+    }
+
+    #[test]
+    fn is_non_empty_file_rejects_missing() {
+        let dir = TempDir::new().unwrap();
+        assert!(!is_non_empty_file(&dir.path().join("nope")));
+    }
+
+    /// A directory must not satisfy the "file with signing material" check.
+    #[test]
+    fn is_non_empty_file_rejects_directory() {
+        let dir = TempDir::new().unwrap();
+        assert!(!is_non_empty_file(dir.path()));
+    }
+
+    /// No `Infra.lock` on disk → nothing to detect; must be Ok(()).
+    #[test]
+    fn detect_stale_infra_lock_returns_ok_when_no_lock() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("Infra.toml");
+        fs::write(
+            &toml_path,
+            r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { file = { path = "/opt/eif/signing.key" } }
+"#,
+        )
+        .unwrap();
+        // No Infra.lock next to it.
+        assert!(detect_stale_infra_lock(&toml_path).is_ok());
+    }
+
+    /// Lock present with `eif = None` while Infra.toml declares `[eif]` → error.
+    #[test]
+    fn detect_stale_infra_lock_errors_when_lock_shadows_eif_toml() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("Infra.toml");
+        let lock_path = dir.path().join("Infra.lock");
+        fs::write(
+            &toml_path,
+            r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { file = { path = "/opt/eif/signing.key" } }
+"#,
+        )
+        .unwrap();
+        fs::write(&lock_path, "aws: null\n").unwrap();
+
+        let err = detect_stale_infra_lock(&toml_path)
+            .expect_err("stale lock shadowing Infra.toml [eif] must error");
+        assert!(matches!(err, error::Error::EifStaleInfraLock { .. }));
+    }
+
+    /// Lock present and Infra.toml has no `[eif]` → legitimate no-signing project, Ok(()).
+    #[test]
+    fn detect_stale_infra_lock_ok_when_toml_has_no_eif() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("Infra.toml");
+        let lock_path = dir.path().join("Infra.lock");
+        fs::write(&toml_path, "[aws]\nregions = []\n").unwrap();
+        fs::write(&lock_path, "aws: null\n").unwrap();
+        assert!(detect_stale_infra_lock(&toml_path).is_ok());
+    }
+
+    /// Malformed Infra.toml is not this guard's concern; must be Ok(()).
+    #[test]
+    fn detect_stale_infra_lock_ok_when_toml_unparseable() {
+        let dir = TempDir::new().unwrap();
+        let toml_path = dir.path().join("Infra.toml");
+        let lock_path = dir.path().join("Infra.lock");
+        fs::write(&toml_path, "this is not = valid = toml [[[").unwrap();
+        fs::write(&lock_path, "aws: null\n").unwrap();
+        assert!(detect_stale_infra_lock(&toml_path).is_ok());
     }
 }

--- a/tools/buildsys/src/builder/error.rs
+++ b/tools/buildsys/src/builder/error.rs
@@ -84,6 +84,38 @@ pub(crate) enum Error {
     #[snafu(display("Failed to create build arguments due to a dependency error: {source}"))]
     Graph { source: buildsys::manifest::Error },
 
+    #[snafu(display("Failed to load Infra.toml at '{}': {}", path.display(), source))]
+    InfraConfigLoad {
+        path: PathBuf,
+        #[snafu(source(from(pubsys_config::Error, Box::new)))]
+        source: Box<pubsys_config::Error>,
+    },
+
+    #[snafu(display(
+        "EIF signing cert '{}' does not exist or is empty (from Infra.toml [eif].signing_cert).",
+        path.display()
+    ))]
+    EifSigningCertMissing { path: PathBuf },
+
+    #[snafu(display(
+        "EIF signing key '{}' does not exist or is empty (from Infra.toml [eif].signing_key).",
+        path.display()
+    ))]
+    EifSigningKeyMissing { path: PathBuf },
+
+    #[snafu(display(
+        "Infra.lock at '{}' was loaded and has no [eif] section, but the sibling Infra.toml at \
+         '{}' does declare one. This usually means Infra.lock predates the [eif] field and would \
+         silently strip EIF signing. Delete Infra.lock (it will be regenerated) or regenerate it \
+         from the current Infra.toml.",
+        lock_path.display(),
+        toml_path.display()
+    ))]
+    EifStaleInfraLock {
+        lock_path: PathBuf,
+        toml_path: PathBuf,
+    },
+
     #[snafu(display("Missing environment variable '{}'", var))]
     Environment {
         var: String,

--- a/tools/pubsys-config/src/lib.rs
+++ b/tools/pubsys-config/src/lib.rs
@@ -231,8 +231,14 @@ pub struct EifConfig {
 
 /// Backend for the EIF signing key. Only `file` and `kms` are supported;
 /// these map to `eif-builder`'s `--signing-key` and `--kms-key-id` flags.
+///
+/// The `kms` variant is validated on deserialization: when `key_id` is not
+/// a full KMS ARN (which carries a region), `region` must be set explicitly.
+/// Bare key IDs and `alias/...` names have no embedded region, and the
+/// BuildKit sandbox used by `buildsys` has no ambient AWS region source,
+/// so we reject the config here rather than fail deep inside a KMS call.
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub enum EifSigningKey {
     file {
@@ -240,8 +246,9 @@ pub enum EifSigningKey {
     },
     kms {
         key_id: String,
-        /// AWS region for the KMS `Sign` call. When `None`, the KMS backend
-        /// resolves the region from the ambient AWS SDK chain (env, profile, IMDS).
+        /// AWS region for the KMS `Sign` call. Required unless `key_id` is
+        /// a full ARN (`arn:<partition>:kms:<region>:...`), in which case
+        /// the region is taken from the ARN.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         region: Option<String>,
     },
@@ -254,6 +261,66 @@ impl Default for EifSigningKey {
             path: PathBuf::new(),
         }
     }
+}
+
+impl<'de> Deserialize<'de> for EifSigningKey {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Mirror of `EifSigningKey` used solely to derive the raw parse; the
+        // outer impl then runs semantic validation before returning.
+        #[allow(non_camel_case_types)]
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        enum Raw {
+            file {
+                path: PathBuf,
+            },
+            kms {
+                key_id: String,
+                #[serde(default)]
+                region: Option<String>,
+            },
+        }
+
+        match Raw::deserialize(deserializer)? {
+            Raw::file { path } => Ok(EifSigningKey::file { path }),
+            Raw::kms { key_id, region } => {
+                if region.is_none() && !key_id_has_embedded_region(&key_id) {
+                    return Err(serde::de::Error::custom(format!(
+                        "EIF signing key `kms.key_id = {key_id:?}` has no embedded region \
+                         and no `region` was set. `region` is required unless `key_id` is \
+                         a full KMS ARN (`arn:<partition>:kms:<region>:...`), because the \
+                         BuildKit sandbox used to sign EIFs has no ambient AWS region \
+                         source (no AWS_REGION, AWS_DEFAULT_REGION, or AWS config file)."
+                    )));
+                }
+                Ok(EifSigningKey::kms { key_id, region })
+            }
+        }
+    }
+}
+
+/// True when `key_id` is a full KMS ARN with a non-empty region field
+/// (`arn:<partition>:kms:<region>:...`). Bare key IDs, UUIDs, and
+/// `alias/...` names return `false`.
+///
+/// Kept in sync with `eif-builder`'s `region_from_kms_arn`; the two must
+/// agree on what counts as "carries its own region".
+fn key_id_has_embedded_region(key_id: &str) -> bool {
+    let mut parts = key_id.splitn(6, ':');
+    if parts.next() != Some("arn") {
+        return false;
+    }
+    // partition (e.g. `aws`, `aws-us-gov`, `aws-cn`)
+    if parts.next().is_none() {
+        return false;
+    }
+    if parts.next() != Some("kms") {
+        return false;
+    }
+    matches!(parts.next(), Some(region) if !region.is_empty())
 }
 
 /// Represents a Bottlerocket repo's location and the metadata needed to update the repo
@@ -356,25 +423,7 @@ signing_key = { file = { path = "/opt/eif/signing.key" } }
 }
 
 #[test]
-fn eif_config_kms_backend_parses() {
-    let toml_str = r#"
-[eif]
-signing_cert = "/opt/eif/signing.crt"
-signing_key = { kms = { key_id = "alias/my-eif-key" } }
-"#;
-    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
-    let eif = cfg.eif.expect("eif section missing");
-    match eif.signing_key {
-        EifSigningKey::kms { key_id, region } => {
-            assert_eq!(key_id, "alias/my-eif-key");
-            assert_eq!(region, None);
-        }
-        _ => panic!("expected kms backend"),
-    }
-}
-
-#[test]
-fn eif_config_kms_with_region_parses() {
+fn eif_config_kms_alias_with_region_parses() {
     let toml_str = r#"
 [eif]
 signing_cert = "/opt/eif/signing.crt"
@@ -389,6 +438,118 @@ signing_key = { kms = { key_id = "alias/my-eif-key", region = "us-west-2" } }
         }
         _ => panic!("expected kms backend"),
     }
+}
+
+#[test]
+fn eif_config_kms_full_arn_without_region_parses() {
+    // A full KMS ARN carries its own region; no explicit `region` needed.
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "arn:aws:kms:us-east-1:123456789012:key/abcdef01-2345-6789-abcd-ef0123456789" } }
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    let eif = cfg.eif.expect("eif section missing");
+    match eif.signing_key {
+        EifSigningKey::kms { key_id, region } => {
+            assert!(key_id.starts_with("arn:aws:kms:us-east-1:"));
+            assert_eq!(region, None);
+        }
+        _ => panic!("expected kms backend"),
+    }
+}
+
+#[test]
+fn eif_config_kms_alias_without_region_is_rejected() {
+    // Bare alias with no region must be rejected: the BuildKit sandbox
+    // has no ambient region source, so this would fail at KMS-call time.
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "alias/my-eif-key" } }
+"#;
+    let err = toml::from_str::<InfraConfig>(toml_str)
+        .expect_err("kms alias without region must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("region"),
+        "error should mention the missing region, got: {msg}"
+    );
+}
+
+#[test]
+fn eif_config_kms_bare_key_id_without_region_is_rejected() {
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "abcdef01-2345-6789-abcd-ef0123456789" } }
+"#;
+    let err = toml::from_str::<InfraConfig>(toml_str)
+        .expect_err("bare kms key id without region must be rejected");
+    assert!(err.to_string().contains("region"));
+}
+
+#[test]
+fn eif_config_kms_arn_with_empty_region_is_rejected() {
+    // `arn:aws:kms::...` has no region field; treated the same as an alias.
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "arn:aws:kms::123456789012:key/abcdef01" } }
+"#;
+    let err = toml::from_str::<InfraConfig>(toml_str)
+        .expect_err("arn with empty region field must be rejected");
+    assert!(err.to_string().contains("region"));
+}
+
+#[test]
+fn eif_config_kms_partitioned_arn_without_region_parses() {
+    // Non-`aws` partitions (gov, cn) also carry a region in the ARN.
+    let toml_str = r#"
+[eif]
+signing_cert = "/opt/eif/signing.crt"
+signing_key = { kms = { key_id = "arn:aws-us-gov:kms:us-gov-west-1:123456789012:alias/eif" } }
+"#;
+    let cfg: InfraConfig = toml::from_str(toml_str).unwrap();
+    let eif = cfg.eif.expect("eif section missing");
+    match eif.signing_key {
+        EifSigningKey::kms { key_id, region } => {
+            assert!(key_id.contains(":us-gov-west-1:"));
+            assert_eq!(region, None);
+        }
+        _ => panic!("expected kms backend"),
+    }
+}
+
+#[test]
+fn key_id_has_embedded_region_classifier() {
+    // Positive cases: full ARNs across partitions and resource shapes.
+    assert!(key_id_has_embedded_region(
+        "arn:aws:kms:us-east-1:123456789012:key/abcdef01-2345-6789-abcd-ef0123456789"
+    ));
+    assert!(key_id_has_embedded_region(
+        "arn:aws:kms:eu-west-2:123456789012:alias/eif-signing-key"
+    ));
+    assert!(key_id_has_embedded_region(
+        "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/abcdef01"
+    ));
+    assert!(key_id_has_embedded_region(
+        "arn:aws-cn:kms:cn-north-1:123456789012:key/abcdef01"
+    ));
+
+    // Negative cases: bare IDs, aliases, non-KMS ARNs, empty region.
+    assert!(!key_id_has_embedded_region("alias/eif-signing-key"));
+    assert!(!key_id_has_embedded_region(
+        "abcdef01-2345-6789-abcd-ef0123456789"
+    ));
+    assert!(!key_id_has_embedded_region(
+        "arn:aws:iam::123456789012:role/example"
+    ));
+    assert!(!key_id_has_embedded_region("arn:aws:s3:::my-bucket"));
+    assert!(!key_id_has_embedded_region(
+        "arn:aws:kms::123456789012:key/abcdef01"
+    ));
+    assert!(!key_id_has_embedded_region(""));
 }
 
 #[test]

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -406,6 +406,10 @@ RUN --mount=target=/host \
     --mount=type=secret,id=config-sign.key,target=/root/sbkeys/config-sign.key \
     --mount=type=secret,id=efi-vars.json,target=/root/sbkeys/efi-vars.json \
     --mount=type=secret,id=kms-sign.json,target=/root/.config/aws-kms-pkcs11/config.json \
+    --mount=type=secret,id=eif-signing.crt,target=/root/eif/signing.crt \
+    --mount=type=secret,id=eif-signing.key,target=/root/eif/signing.key \
+    --mount=type=secret,id=eif-kms-key-id.env,target=/root/eif/kms-key-id \
+    --mount=type=secret,id=eif-kms-region.env,target=/root/eif/kms-region \
     --mount=type=secret,id=aws-access-key-id.env,target=/root/.aws/aws-access-key-id.env \
     --mount=type=secret,id=aws-secret-access-key.env,target=/root/.aws/aws-secret-access-key.env \
     --mount=type=secret,id=aws-session-token.env,target=/root/.aws/aws-session-token.env \

--- a/twoliter/embedded/eif-sign-helper
+++ b/twoliter/embedded/eif-sign-helper
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# eif-sign-helper — translate the EIF signing profile mounted from
+# Infra.toml [eif] into `eif-builder` signing flags.
+#
+# Sourced by rpm2eif / eif2eif / img2img.
+#
+# Contract:
+#   discover_eif_signer_args OUT_ARRAY_NAME
+#     Fills OUT_ARRAY_NAME with `--signing-cert / --signing-key`
+#     (local) or `--kms-key-id / --signing-cert [/ --region]` (KMS).
+#     rc 0: profile detected (may be empty ⇒ unsigned).
+#     rc 1: cert mounted but no backend ⇒ broken build plumbing.
+#
+# Env:
+#   EIF_SIGNING_DIR   Mount dir for signing artifacts (default /root/eif).
+#   EIF_AWS_DIR       Mount dir for AWS credential .env files
+#                     (default "${HOME:-/root}/.aws"; KMS backend only).
+
+discover_eif_signer_args() {
+  local -n _out=${1:?discover_eif_signer_args: OUT_ARRAY_NAME required}
+  # Reset to empty in case the caller passed a pre-populated array.
+  _out=()
+
+  local dir="${EIF_SIGNING_DIR:-/root/eif}"
+  local cert="${dir}/signing.crt"
+  local key="${dir}/signing.key"
+  local kms_key_id_file="${dir}/kms-key-id"
+  local kms_region_file="${dir}/kms-region"
+
+  # Case 1: no cert → no signing profile.
+  if [[ ! -s "${cert}" ]]; then
+    return 0
+  fi
+
+  # Case 2: local key backend.
+  if [[ -s "${key}" ]]; then
+    echo "eif-sign-helper: local backend, cert=${cert}" >&2
+    _out=(
+      --signing-cert "${cert}"
+      --signing-key  "${key}"
+    )
+    return 0
+  fi
+
+  # Case 3: KMS backend. Strip whitespace defensively (env-source mounts
+  # sometimes include a trailing newline).
+  if [[ -s "${kms_key_id_file}" ]]; then
+    local key_id
+    key_id="$(tr -d '[:space:]' <"${kms_key_id_file}")"
+    if [[ -z "${key_id}" ]]; then
+      echo "eif-sign-helper: ${kms_key_id_file} is empty after stripping whitespace" >&2
+      return 1
+    fi
+    _out=(
+      --kms-key-id   "${key_id}"
+      --signing-cert "${cert}"
+    )
+    # --region is optional; if unset, defer to the AWS SDK's ambient region chain.
+    local region=""
+    if [[ -s "${kms_region_file}" ]]; then
+      region="$(tr -d '[:space:]' <"${kms_region_file}")"
+    fi
+    if [[ -n "${region}" ]]; then
+      _out+=(--region "${region}")
+    fi
+
+    # Load AWS creds from mounted .env files into env to propagate down the call chain.
+    local aws_dir="${EIF_AWS_DIR:-${HOME:-/root}/.aws}"
+    local var val
+    for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN; do
+      # Skip absent/empty files silently (session token is optional).
+      val="${var,,}"
+      val="${aws_dir}/${val//_/-}.env"
+      [[ -s "${val}" ]] || continue
+      export "${var}=$(<"${val}")"
+    done
+
+    echo "eif-sign-helper: KMS backend, key=${key_id}, region=${region:-<ambient>}" >&2
+    return 0
+  fi
+
+  # Case 4: cert without a backend — refuse rather than silently downgrade to unsigned.
+  echo "eif-sign-helper: Refusing to build an unsigned EIF since ${cert} is present but neither ${key} nor ${kms_key_id_file} is. Check Infra.toml [eif].signing_key" >&2
+  return 1
+}

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -16,8 +16,11 @@ shopt -qs failglob
 # Source imghelper for generate_verity_root and related functions.
 # Source partyplanner for the Bottlerocket-standard partition type GUIDs; this
 # keeps the sidecar disk-image layout in sync with rpm2img and img2img.
+# Source eif-sign-helper for the shared Infra.toml [eif] → eif-builder CLI
+# arg discovery (see the helper's header for the mount-path contract).
 . "${0%/*}/imghelper"
 . "${0%/*}/partyplanner"
+. "${0%/*}/eif-sign-helper"
 
 usage() {
     cat <<EOF
@@ -505,6 +508,16 @@ if [[ "${BUILD_ID_TIMESTAMP:-}" =~ ^[0-9]+$ ]]; then
     BUILD_TIME_RFC3339="$(date -u -d "@${BUILD_ID_TIMESTAMP}" +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
+# Discover the EIF signing profile mounted by buildsys from Infra.toml [eif]
+# and pass the appropriate signing flags to eif-builder. Delegated to
+# `eif-sign-helper::discover_eif_signer_args` so the eif2eif / img2img
+# resign paths share the exact same behavior. See the helper's header for
+# the mount-path contract and the four possible profile shapes.
+sign_args=()
+if ! discover_eif_signer_args sign_args; then
+    exit 1
+fi
+
 /host/build/tools/eif-builder \
     --kernel "${KERNEL_LOCAL}" \
     --cmdline "${KERNEL_CMDLINE}" \
@@ -514,7 +527,8 @@ fi
     --kernel-version "${KERNEL_VERSION}" \
     --image-version "${VERSION_ID}" \
     --build-time "${BUILD_TIME_RFC3339}" \
-    --out-prepared-kernel "${PREPARED_KERNEL_TMP}"
+    --out-prepared-kernel "${PREPARED_KERNEL_TMP}" \
+    "${sign_args[@]}"
 
 echo "=== Generating SBOMs ==="
 # Mirror rpm2img: generate SBOMs over the variant RPMs and merge with the

--- a/twoliter/embedded/tests/test_eif_sign_helper.sh
+++ b/twoliter/embedded/tests/test_eif_sign_helper.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+#
+# Test `discover_eif_signer_args` across the four EIF-signing-profile shapes
+# that Infra.toml's [eif] section (via buildsys and build.Dockerfile) can
+# produce inside the build container:
+#
+#   1. Local:      signing.crt + signing.key
+#   2. KMS:        signing.crt + kms-key-id (a non-empty file whose contents
+#                                            are the KMS key id/ARN/alias)
+#   3. Cert-only:  signing.crt but neither backend (error path — indicates
+#                                                   broken build plumbing)
+#   4. None:       no signing.crt at all (no [eif] section in Infra.toml, or
+#                                         no Infra.toml passed to buildsys)
+#
+# Run from the repo root:
+#   bash twoliter/embedded/tests/test_eif_sign_helper.sh
+#
+# Complements `test_rpm2eif_args.sh` (flag validation) and pins the exact
+# tuple that rpm2eif, eif2eif, and img2img all rely on.
+
+set -eu -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../eif-sign-helper"
+
+if [[ ! -f "${HELPER}" ]]; then
+  echo "test_eif_sign_helper: helper not found at ${HELPER}" >&2
+  exit 1
+fi
+
+pass_count=0
+fail_count=0
+
+pass() { pass_count=$((pass_count + 1)); echo "  ok: $1"; }
+fail() { fail_count=$((fail_count + 1)); echo "  FAIL: $1" >&2; }
+
+# Run `discover_eif_signer_args` in a fresh subshell against a synthesized
+# signing directory and print the resulting argv (one entry per line).
+# Args: $1 scenario name, $2 EIF_SIGNING_DIR fixture, $3 optional EIF_AWS_DIR fixture.
+run_helper() {
+  local dir="$2"
+  local aws_dir="${3:-${tmp}/no-aws-creds}"
+  mkdir -p "${aws_dir}"
+  (
+    # Clean AWS env so the KMS-path export can be observed precisely.
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    export EIF_SIGNING_DIR="${dir}"
+    export EIF_AWS_DIR="${aws_dir}"
+    # shellcheck disable=SC1090
+    . "${HELPER}"
+    declare -a out
+    if discover_eif_signer_args out; then
+      printf '%s\n' "${out[@]}"
+      echo "__RC=0"
+      # Dump the AWS_* env so tests can assert on credential export.
+      echo "__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID-<unset>}"
+      echo "__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-<unset>}"
+      echo "__AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN-<unset>}"
+    else
+      printf '%s\n' "${out[@]-}"
+      echo "__RC=1"
+    fi
+  ) 2>&1
+}
+
+# Extract the `__RC=` line's value from run_helper's output.
+extract_rc() {
+  local out="$1"
+  local rc
+  rc=$(printf '%s\n' "${out}" | grep -E '^__RC=' | tail -1 | cut -d= -f2)
+  echo "${rc:-?}"
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+# --------------------------------------------------------------------------
+# Scenario 1: local backend (signing.crt + signing.key both present)
+# --------------------------------------------------------------------------
+dir1="${tmp}/local"
+mkdir -p "${dir1}"
+echo "cert-a" >"${dir1}/signing.crt"
+echo "key-a"  >"${dir1}/signing.key"
+
+out=$(run_helper "local" "${dir1}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--signing-cert$"        <<<"${out}" \
+   && grep -q "^${dir1}/signing.crt$"   <<<"${out}" \
+   && grep -q "^--signing-key$"         <<<"${out}" \
+   && grep -q "^${dir1}/signing.key$"   <<<"${out}" \
+   && ! grep -q "^--kms-key-id$"        <<<"${out}"; then
+  pass "local backend → --signing-cert + --signing-key"
+else
+  fail "local backend args wrong. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2: KMS backend (signing.crt + kms-key-id file)
+# --------------------------------------------------------------------------
+dir2="${tmp}/kms"
+mkdir -p "${dir2}"
+echo "cert-b" >"${dir2}/signing.crt"
+echo -n "alias/my-eif-key" >"${dir2}/kms-key-id"
+
+out=$(run_helper "kms" "${dir2}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--kms-key-id$"          <<<"${out}" \
+   && grep -q "^alias/my-eif-key$"      <<<"${out}" \
+   && grep -q "^--signing-cert$"        <<<"${out}" \
+   && grep -q "^${dir2}/signing.crt$"   <<<"${out}" \
+   && ! grep -q "^--signing-key$"       <<<"${out}"; then
+  pass "KMS backend → --kms-key-id + --signing-cert"
+else
+  fail "KMS backend args wrong. rc=${rc} out=${out}"
+fi
+
+# Scenario 2b: KMS ARN with trailing newline (helper must strip whitespace).
+dir2b="${tmp}/kms-arn"
+mkdir -p "${dir2b}"
+echo "cert-c" >"${dir2b}/signing.crt"
+printf 'arn:aws:kms:us-east-1:0:key/00000000\n' >"${dir2b}/kms-key-id"
+
+out=$(run_helper "kms-arn" "${dir2b}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--kms-key-id$"                                <<<"${out}" \
+   && grep -q "^arn:aws:kms:us-east-1:0:key/00000000$"        <<<"${out}"; then
+  pass "KMS backend accepts a full ARN with trailing newline"
+else
+  fail "KMS ARN wrong. rc=${rc} out=${out}"
+fi
+
+# Scenario 2c: KMS backend with explicit region → appends `--region <r>`.
+dir2c="${tmp}/kms-region"
+mkdir -p "${dir2c}"
+echo "cert-region" >"${dir2c}/signing.crt"
+echo -n "alias/my-eif-key" >"${dir2c}/kms-key-id"
+echo -n "us-west-2"        >"${dir2c}/kms-region"
+
+out=$(run_helper "kms-region" "${dir2c}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--kms-key-id$"    <<<"${out}" \
+   && grep -q "^--region$"        <<<"${out}" \
+   && grep -q "^us-west-2$"       <<<"${out}"; then
+  pass "KMS backend with region → --region us-west-2"
+else
+  fail "KMS region wrong. rc=${rc} out=${out}"
+fi
+
+# Scenario 2d: empty kms-region file must NOT emit `--region`.
+dir2d="${tmp}/kms-empty-region"
+mkdir -p "${dir2d}"
+echo "cert-empty-region" >"${dir2d}/signing.crt"
+echo -n "alias/x"        >"${dir2d}/kms-key-id"
+: >"${dir2d}/kms-region"
+
+out=$(run_helper "kms-empty-region" "${dir2d}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--kms-key-id$"    <<<"${out}" \
+   && ! grep -q "^--region$"      <<<"${out}"; then
+  pass "KMS backend with empty region file → no --region flag"
+else
+  fail "empty kms-region should not emit --region. rc=${rc} out=${out}"
+fi
+
+# Scenario 2e: KMS backend exports AWS creds from mounted .env files.
+dir2e="${tmp}/kms-with-creds"
+mkdir -p "${dir2e}"
+echo "cert-creds"       >"${dir2e}/signing.crt"
+echo -n "alias/y"       >"${dir2e}/kms-key-id"
+aws_e="${tmp}/aws-creds-2e"
+mkdir -p "${aws_e}"
+echo -n "AKIAEXAMPLE"                          >"${aws_e}/aws-access-key-id.env"
+echo -n "secret-example-1234"                  >"${aws_e}/aws-secret-access-key.env"
+echo -n "session-token-example"                >"${aws_e}/aws-session-token.env"
+
+out=$(run_helper "kms-with-creds" "${dir2e}" "${aws_e}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q '^__AWS_ACCESS_KEY_ID=AKIAEXAMPLE$'          <<<"${out}" \
+   && grep -q '^__AWS_SECRET_ACCESS_KEY=secret-example-1234$' <<<"${out}" \
+   && grep -q '^__AWS_SESSION_TOKEN=session-token-example$'   <<<"${out}"; then
+  pass "KMS backend exports AWS credential env from mounted files"
+else
+  fail "KMS creds not exported. rc=${rc} out=${out}"
+fi
+
+# Scenario 2f: local backend must not touch AWS env.
+dir2f="${tmp}/local-with-aws-mount"
+mkdir -p "${dir2f}"
+echo "cert-l"  >"${dir2f}/signing.crt"
+echo "key-l"   >"${dir2f}/signing.key"
+aws_f="${tmp}/aws-creds-2f"
+mkdir -p "${aws_f}"
+echo -n "SHOULD_NOT_BE_EXPORTED" >"${aws_f}/aws-access-key-id.env"
+
+out=$(run_helper "local-with-aws-mount" "${dir2f}" "${aws_f}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "0" ]] \
+   && grep -q "^--signing-key$"   <<<"${out}" \
+   && ! grep -q "^__AWS_ACCESS_KEY_ID=SHOULD_NOT_BE_EXPORTED$" <<<"${out}"; then
+  pass "local backend leaves AWS env untouched"
+else
+  fail "local backend must not export AWS creds. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 3: cert-only (error path — no backend at all)
+# --------------------------------------------------------------------------
+dir3="${tmp}/cert-only"
+mkdir -p "${dir3}"
+echo "cert-d" >"${dir3}/signing.crt"
+
+out=$(run_helper "cert-only" "${dir3}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "1" ]] && grep -qi "refusing to build an unsigned EIF" <<<"${out}"; then
+  pass "cert-only fails hard (no backend files)"
+else
+  fail "cert-only should have failed. rc=${rc} out=${out}"
+fi
+
+# Scenario 3b: cert-only with empty kms-key-id file must fail (`-s` requires size >0).
+dir3b="${tmp}/cert-only-empty-kms"
+mkdir -p "${dir3b}"
+echo "cert-e" >"${dir3b}/signing.crt"
+: >"${dir3b}/kms-key-id"
+
+out=$(run_helper "cert-only-empty-kms" "${dir3b}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "1" ]] && grep -qi "refusing to build an unsigned EIF" <<<"${out}"; then
+  pass "cert + empty kms-key-id file fails hard"
+else
+  fail "cert + empty kms-key-id should fail. rc=${rc} out=${out}"
+fi
+
+# Scenario 3c: whitespace-only kms-key-id must fail with a distinct diagnostic.
+dir3c="${tmp}/cert-kms-whitespace"
+mkdir -p "${dir3c}"
+echo "cert-f" >"${dir3c}/signing.crt"
+printf '   \n\t\n' >"${dir3c}/kms-key-id"
+
+out=$(run_helper "cert-kms-whitespace" "${dir3c}")
+rc=$(extract_rc "${out}")
+if [[ "${rc}" == "1" ]] && grep -q "empty after stripping whitespace" <<<"${out}"; then
+  pass "cert + whitespace-only kms-key-id fails with a specific diagnostic"
+else
+  fail "whitespace-only kms-key-id should fail. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 4: no profile at all (no signing.crt on disk)
+# --------------------------------------------------------------------------
+dir4="${tmp}/nothing"
+mkdir -p "${dir4}"
+
+out=$(run_helper "no-profile" "${dir4}")
+rc=$(extract_rc "${out}")
+non_meta=$(grep -Ev '^__RC=|^__AWS_|^eif-sign-helper' <<<"${out}" | grep -vE '^$' || true)
+if [[ "${rc}" == "0" ]] && [[ -z "${non_meta}" ]]; then
+  pass "no profile → empty args, rc 0"
+else
+  fail "no profile args wrong. rc=${rc} out=${out}"
+fi
+
+# Scenario 5: empty signing.crt treated as no profile; a stray key file must
+# not flip us into the local-backend branch.
+dir5="${tmp}/empty-cert"
+mkdir -p "${dir5}"
+: >"${dir5}/signing.crt"
+echo "key-only" >"${dir5}/signing.key"
+
+out=$(run_helper "empty-cert" "${dir5}")
+rc=$(extract_rc "${out}")
+non_meta=$(grep -Ev '^__RC=|^__AWS_|^eif-sign-helper' <<<"${out}" | grep -vE '^$' || true)
+if [[ "${rc}" == "0" ]] && [[ -z "${non_meta}" ]]; then
+  pass "empty signing.crt treated as no profile (unsigned)"
+else
+  fail "empty signing.crt should produce unsigned. rc=${rc} out=${out}"
+fi
+
+# --------------------------------------------------------------------------
+echo
+echo "test_eif_sign_helper: ${pass_count} passed, ${fail_count} failed"
+[[ "${fail_count}" -eq 0 ]]

--- a/twoliter/src/tool-crates/embedded-bundle/build.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/build.rs
@@ -29,6 +29,7 @@ fn main() {
     paths.copy_file("build.Dockerfile.dockerignore");
     paths.copy_file("docker-cargo");
     paths.copy_file("docker-go");
+    paths.copy_file("eif-sign-helper");
     paths.copy_file("guest-images-helper");
     paths.copy_file("img2img");
     paths.copy_file("imghelper");

--- a/twoliter/src/tool-crates/embedded-bundle/tests/eif_sign_helper.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/tests/eif_sign_helper.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn eif_sign_helper_bash_tests() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = manifest_dir.join("embedded/tests/test_eif_sign_helper.sh");
+
+    assert!(
+        script.is_file(),
+        "test_eif_sign_helper.sh not found at {}",
+        script.display(),
+    );
+
+    let output = Command::new("bash")
+        .arg(&script)
+        .output()
+        .expect("failed to invoke bash");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    println!("--- test_eif_sign_helper.sh stdout ---\n{stdout}");
+    if !stderr.is_empty() {
+        println!("--- test_eif_sign_helper.sh stderr ---\n{stderr}");
+    }
+
+    assert!(
+        output.status.success(),
+        "test_eif_sign_helper.sh failed with status {:?}",
+        output.status,
+    );
+}

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -150,6 +150,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("build.Dockerfile").is_file());
     assert!(toolsdir.join("build.Dockerfile.dockerignore").is_file());
     assert!(toolsdir.join("docker-go").is_file());
+    assert!(toolsdir.join("eif-sign-helper").is_file());
     assert!(toolsdir.join("guest-images-helper").is_file());
     assert!(toolsdir.join("img2img").is_file());
     assert!(toolsdir.join("imghelper").is_file());


### PR DESCRIPTION
Wire the Infra.toml [eif] section from pubsys-config through buildsys
into the rpm2eif Docker build stage. Adds:

* `eif_signing_args()` in buildsys: reads Infra.toml [eif] and emits
  Docker `--secret` flags for signing.crt + (signing.key | KMS key id
  + optional region). Silent absence produces an unsigned EIF; a stale
  Infra.lock that shadows [eif] hard-fails, and a 0-byte cert/key is
  rejected in lockstep with the in-container helper.
* `eif-sign-helper`: bash helper sourced by rpm2eif that translates the
  mounted profile into the `eif-builder` flag tuple (local backend →
  --signing-cert + --signing-key, KMS backend → --kms-key-id +
  --signing-cert + optional --region + AWS creds env-source).
* rpm2eif sourcing of the helper + passthrough of `sign_args` to
  `eif-builder`.
* Dockerfile: mounts for eif-signing.crt, eif-signing.key,
  eif-kms-key-id.env, eif-kms-region.env in the rpm2eif stage.
* Unit tests for the buildsys stale-lock detector and file gate.
* Discovery-matrix bash test for eif-sign-helper.

Guest EIF resign during host repack and the in-tree EIF repack path
(eif2eif) land in follow-up commits in this stack.