### PR TITLE
feat(eif): add in-tree EIF repack path (eif2eif)

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -324,6 +324,10 @@ struct RepackVariantBuildArgs {
     variant_platform: String,
     version_build: String,
     version_image: String,
+    /// Newline-delimited list of `<guest>:<install_path>:<host_image_dir>` triples for host
+    /// variants that embed guest images and, on repack, need to resign the guest EIFs found
+    /// under those install paths. Mirrors `VariantBuildArgs::guest_images`.
+    guest_images: String,
 }
 
 impl RepackVariantBuildArgs {
@@ -346,6 +350,14 @@ impl RepackVariantBuildArgs {
         args.build_arg("VARIANT_PLATFORM", &self.variant_platform);
         args.build_arg("BUILD_ID", &self.version_build);
         args.build_arg("VERSION_ID", &self.version_image);
+        args.build_arg("GUEST_IMAGES", &self.guest_images);
+
+        // TWOLITER_VERSION mirrors what VariantBuildArgs plumbs through so
+        // `eif2eif` can embed it into EIF metadata (BuildMetadata.BuildToolVersion).
+        args.build_arg(
+            "TWOLITER_VERSION",
+            std::env::var("TWOLITER_VERSION").unwrap_or_default(),
+        );
 
         for image_feature in self.image_features.iter() {
             let value = if matches!(image_feature, ImageFeature::StandaloneImage) {
@@ -598,29 +610,31 @@ impl DockerBuild {
     }
 
     /// Create a new `DockerBuild` that can repackage a variant image.
-    pub(crate) fn repack_variant(args: RepackVariantArgs, manifest: &Manifest) -> Result<Self> {
+    ///
+    /// `guest_images` is the resolved list of guest variants declared by the
+    /// host under `[package.metadata.build-variant.guest-images]`, whose
+    /// `*.eif` files `img2img` must resign before rebuilding host verity.
+    /// Empty for an EIF variant or a host that declares no guests.
+    pub(crate) fn repack_variant(
+        args: RepackVariantArgs,
+        manifest: &Manifest,
+        guest_images: Vec<(String, std::path::PathBuf)>,
+    ) -> Result<Self> {
         let raw_layout = manifest.info().image_layout().cloned().unwrap_or_default();
         let features = manifest.info().image_features().unwrap_or_default();
-        // Repack is implemented by `img2img`. Handle every format explicitly so
-        // that a newly added one cannot reach the repack path without someone
-        // deciding whether `img2img` can actually handle it.
+        // Exhaustive match so a newly added image format cannot reach the
+        // repack path without being explicitly routed to `img2img` or `eif2eif`.
         match manifest.info().image_format() {
-            // `img2img` has no EIF support. Fail fast here so users get a clear
-            // error instead of a cryptic failure deep inside the Dockerfile
-            // build.
-            Some(ImageFormat::Eif) => return error::EifRepackUnsupportedSnafu.fail(),
-            // UKI repack is supported (along with the other listed formats).
-            // `img2img` extracts the FAT boot partition with mtools, rebuilds
-            // `EFI/Linux/bottlerocket.efi` from the sections of the existing
-            // UKI so that the kernel command line carries the new dm-verity
-            // root hash, and recreates the partition. See `repack_uki` in
-            // `twoliter/embedded/img2img`.
-            Some(ImageFormat::Raw | ImageFormat::Qcow2 | ImageFormat::Vmdk | ImageFormat::Uki)
+            Some(
+                ImageFormat::Eif
+                | ImageFormat::Raw
+                | ImageFormat::Qcow2
+                | ImageFormat::Vmdk
+                | ImageFormat::Uki,
+            )
             | None => {}
         }
 
-        // Repack has already rejected EIF above, so `image_format` is always
-        // non-EIF here; pass it through anyway for defense-in-depth.
         let image_format = manifest.info().image_format();
         let image_layout = resolved_image_layout(&raw_layout, &features, image_format);
         // Defense in depth: re-run the image feature validator here so that
@@ -688,6 +702,18 @@ impl DockerBuild {
                 variant_platform,
                 version_build: args.version_build,
                 version_image: args.version_image,
+                guest_images: guest_images
+                    .iter()
+                    .map(|(guest, install_path)| {
+                        format!(
+                            "{guest}:{install_path}:build/images/{arch}-{guest}/{version_full}",
+                            install_path = install_path.display(),
+                            arch = args.common.arch,
+                            version_full = args.common.version_full,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n"),
             }),
             secrets_args: secrets_args()?,
         })

--- a/tools/buildsys/src/builder/error.rs
+++ b/tools/buildsys/src/builder/error.rs
@@ -139,9 +139,6 @@ pub(crate) enum Error {
         source: semver::Error,
         version_str: String,
     },
-
-    #[snafu(display("Repacking is not supported for image-format = \"eif\""))]
-    EifRepackUnsupported,
 }
 
 pub(super) type Result<T> = std::result::Result<T, Error>;

--- a/tools/buildsys/src/main.rs
+++ b/tools/buildsys/src/main.rs
@@ -306,11 +306,15 @@ fn repack_variant(args: RepackVariantArgs) -> Result<()> {
     check_arch_support(manifest.info(), args.common.arch);
     validate_standalone_image_or_warn(manifest.info())?;
 
+    let guest_images = manifest
+        .guest_image_variant_deps()
+        .context(error::ManifestParseSnafu)?;
+
     if args.common.cicd_hack {
         return Ok(());
     }
 
-    DockerBuild::repack_variant(args, &manifest)
+    DockerBuild::repack_variant(args, &manifest, guest_images)
         .context(error::BuilderInstantiationSnafu)?
         .build()
         .context(error::BuildAttemptSnafu)

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -1296,7 +1296,7 @@ pub fn validate_image_features(
         "`standalone-image = true`"
     };
     let reason_secure_boot: String = if is_eif {
-        "secure boot is not supported by the EIF pipeline; `rpm2eif` does not sign shim/grub/vmlinuz".to_string()
+        "secure boot is not supported by the EIF pipeline; `rpm2eif` does not sign shim/grub/vmlinuz (EIF signing over PCR0 is orthogonal and driven by Infra.toml [eif])".to_string()
     } else {
         "secure boot relies on signed first-party artifacts that are not present when `standalone-image = true`".to_string()
     };

--- a/twoliter/embedded/build.Dockerfile
+++ b/twoliter/embedded/build.Dockerfile
@@ -580,8 +580,13 @@ ARG UEFI_SECURE_BOOT
 ARG EROFS_ROOT_PARTITION
 ARG IN_PLACE_UPDATES
 ARG STANDALONE_IMAGE
+ARG GUEST_IMAGES=""
+ARG TWOLITER_VERSION=""
+
 ENV VARIANT=${VARIANT_NAME} VARIANT_PLATFORM=${VARIANT_PLATFORM} \
-    VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID}
+    VERSION_ID=${VERSION_ID} BUILD_ID=${BUILD_ID} \
+    TWOLITER_VERSION=${TWOLITER_VERSION} \
+    IMAGE_NAME=${IMAGE_NAME} VARIANT_NAME=${VARIANT_NAME} ARCH=${ARCH}
 WORKDIR /root
 
 USER root
@@ -599,12 +604,24 @@ RUN --mount=target=/host \
     --mount=type=secret,id=config-sign.key,target=/root/sbkeys/config-sign.key \
     --mount=type=secret,id=efi-vars.json,target=/root/sbkeys/efi-vars.json \
     --mount=type=secret,id=kms-sign.json,target=/root/.config/aws-kms-pkcs11/config.json \
+    --mount=type=secret,id=eif-signing.crt,target=/root/eif/signing.crt \
+    --mount=type=secret,id=eif-signing.key,target=/root/eif/signing.key \
+    --mount=type=secret,id=eif-kms-key-id.env,target=/root/eif/kms-key-id \
+    --mount=type=secret,id=eif-kms-region.env,target=/root/eif/kms-region \
     --mount=type=secret,id=aws-access-key-id.env,target=/root/.aws/aws-access-key-id.env \
     --mount=type=secret,id=aws-secret-access-key.env,target=/root/.aws/aws-secret-access-key.env \
     --mount=type=secret,id=aws-session-token.env,target=/root/.aws/aws-session-token.env \
     /host/build/tools/pipesys link --fd-socket "${BYPASS_SOCKET}" --target /bypass && \
     /host/build/tools/pipesys link --fd-socket "${OUTPUT_SOCKET}" --target /output && \
     rm -rf /output/* && \
+    if [[ "${IMAGE_FORMAT}" == "eif" ]]; then \
+      /host/build/tools/eif2eif \
+        --input-dir="/bypass/build/images/${ARCH}-${VARIANT_NAME}/${VERSION_ID}-${BUILD_ID}" \
+        --output-dir=/output \
+        --os-image-size-gib="${OS_IMAGE_SIZE_GIB}" \
+        ${EROFS_ROOT_PARTITION:+--with-erofs-root-partition=yes} \
+        --with-standalone-image="${STANDALONE_IMAGE:-no}" ; \
+    else \
     /host/build/tools/img2img \
       --input-dir="/bypass/build/images/${ARCH}-${VARIANT_NAME}/${VERSION_ID}-${BUILD_ID}" \
       --output-dir=/output \
@@ -619,7 +636,9 @@ RUN --mount=target=/host \
       ${UEFI_SECURE_BOOT:+--with-uefi-secure-boot=yes} \
       ${IN_PLACE_UPDATES:+--with-in-place-updates=yes} \
       $([ "${IMAGE_FORMAT}" = "uki" ] && echo "--with-uki-image=yes") \
-      --with-standalone-image="${STANDALONE_IMAGE:-no}" && \
+      --with-standalone-image="${STANDALONE_IMAGE:-no}" \
+      --guest-images="${GUEST_IMAGES}" ; \
+    fi && \
     chown -R "${BUILDER_UID}:${BUILDER_UID}" /output/ && \
     rm /output && \
     rm /bypass && \

--- a/twoliter/embedded/eif2eif
+++ b/twoliter/embedded/eif2eif
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# eif2eif - repack an EIF variant's disk image + EIF sidecar with fresh
+# rootfs edits (CA bundle, root.json), new erofs ROOT-A, new dm-verity
+# HASH-A, and a re-signed EIF whose kernel cmdline pins the new verity
+# root hash.
+#
+# Produces (mirroring rpm2eif's output shape):
+#   - {prefix}.eif        newly rebuilt, signed if Infra.toml [eif] is configured
+#   - {prefix}-disk.img   GPT disk with new ROOT-A + HASH-A
+#   - {prefix}-kernel     copied byte-for-byte from the input (unchanged)
+#   - latest.eif, latest-disk.img, latest-kernel symlinks
+#
+# Contract vs. `img2img`:
+#   - Same CLI shape (input-dir, output-dir, feature flags). `--guest-images`
+#     is accepted for parity but ignored (an EIF variant has no rootfs to
+#     resign guests inside — its rootfs is the enclave's own).
+#   - IMAGE_FORMAT/OUTPUT_FMT is not "raw"/"qcow2"/"vmdk"; we ignore whatever
+#     is passed and produce the EIF-native artifact set.
+#   - Because the kernel cmdline changes (new dm-verity root hash), PCR0
+#     changes, and we cannot use `eif-builder resign`: we do a full
+#     `eif-builder build` here. `resign` is used only for guest EIFs inside
+#     a *host* repack (see img2img).
+
+set -eux -o pipefail
+shopt -qs failglob
+
+# ---------- CLI parse ----------
+
+INPUT_DIR=""
+OUTPUT_DIR=""
+OS_IMAGE_SIZE_GIB="0"
+EROFS_ROOT_PARTITION="yes"
+UEFI_SECURE_BOOT="no"
+IN_PLACE_UPDATES="no"
+ENCRYPTED_STORAGE="no"
+STANDALONE_IMAGE="yes"
+
+# shellcheck disable=SC2034 # feature flags are read indirectly via `${!flag}`
+for opt in "$@"; do
+  optarg="$(expr "${opt}" : '[^=]*=\(.*\)' || echo '')"
+  case "${opt}" in
+    --input-dir=*)                    INPUT_DIR="${optarg}" ;;
+    --output-dir=*)                   OUTPUT_DIR="${optarg}" ;;
+    --output-fmt=*)                   : ;;   # accepted, ignored (EIF is EIF)
+    --os-image-size-gib=*)            OS_IMAGE_SIZE_GIB="${optarg}" ;;
+    --data-image-size-gib=*)          : ;;
+    --os-image-publish-size-gib=*)    : ;;
+    --data-image-publish-size-gib=*)  : ;;
+    --partition-plan=*)               : ;;
+    --ovf-template=*)                 : ;;
+    --with-erofs-root-partition=*)    EROFS_ROOT_PARTITION="${optarg}" ;;
+    --with-uefi-secure-boot=*)        UEFI_SECURE_BOOT="${optarg}" ;;
+    --with-in-place-updates=*)        IN_PLACE_UPDATES="${optarg}" ;;
+    --with-encrypted-storage=*)       ENCRYPTED_STORAGE="${optarg}" ;;
+    --with-standalone-image=*)        STANDALONE_IMAGE="${optarg}" ;;
+    --guest-images=*)                 : ;;   # accepted, ignored (leaf variant)
+    *)
+      echo "eif2eif: unexpected arg: ${opt}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${INPUT_DIR}" || -z "${OUTPUT_DIR}" ]]; then
+  echo "eif2eif: --input-dir and --output-dir are required" >&2
+  exit 1
+fi
+
+# Same EIF-only feature-profile enforcement as rpm2eif. Keep in sync with
+# `validate_image_features` in tools/buildsys/src/manifest.rs.
+declare -A eif_flag_allowlist=(
+  [EROFS_ROOT_PARTITION]="yes"
+  [UEFI_SECURE_BOOT]="no"
+  [IN_PLACE_UPDATES]="no"
+  [ENCRYPTED_STORAGE]="no"
+  [STANDALONE_IMAGE]="yes"
+)
+eif_flag_errors=0
+for flag in "${!eif_flag_allowlist[@]}"; do
+  want="${eif_flag_allowlist[${flag}]}"
+  have="${!flag}"
+  if [[ "${have}" != "${want}" ]]; then
+    echo "eif2eif: image-format='eif' requires ${flag}='${want}' (got '${have}')" >&2
+    eif_flag_errors=$((eif_flag_errors + 1))
+  fi
+done
+(( eif_flag_errors == 0 )) || exit 1
+
+if ! [[ "${OS_IMAGE_SIZE_GIB}" =~ ^[0-9]+$ ]]; then
+  echo "eif2eif: --os-image-size-gib='${OS_IMAGE_SIZE_GIB}' is not a non-negative integer" >&2
+  exit 1
+fi
+
+# Required env vars (provided by buildsys / the Dockerfile).
+: "${VERSION_ID:?VERSION_ID must be set}"
+: "${BUILD_ID:?BUILD_ID must be set}"
+: "${IMAGE_NAME:?IMAGE_NAME must be set}"
+: "${VARIANT_NAME:?VARIANT_NAME must be set}"
+: "${ARCH:?ARCH must be set}"
+
+# ---------- Helpers ----------
+
+# shellcheck source=imghelper
+. "${0%/*}/imghelper"          # install_ca_certs, install_root_json, mkfs_root_erofs,
+                               # generate_verity_root, check_image_size, ...
+# shellcheck source=partyplanner
+. "${0%/*}/partyplanner"       # BOTTLEROCKET_{ROOT,HASH}_TYPECODE, set_eif_partition_sizes
+# shellcheck source=eif-sign-helper
+. "${0%/*}/eif-sign-helper"    # discover_eif_signer_args
+
+# ---------- Working environment ----------
+
+WORKDIR="$(mktemp -d)"
+trap '[[ -d "${WORKDIR}" ]] && rm -rf "${WORKDIR}"' EXIT
+pushd "${WORKDIR}" >/dev/null
+
+OUTPUT_DIR="${OUTPUT_DIR}/${VERSION_ID}-${BUILD_ID}"
+mkdir -p "${OUTPUT_DIR}"
+
+# ---------- Locate input artifacts ----------
+
+# rpm2eif writes its outputs into a versioned subdirectory. Whatever
+# directory was passed in via --input-dir is expected to be that
+# versioned dir (buildsys resolves the path).
+#
+# Use `nullglob` so an empty match returns an empty array rather than the
+# literal pattern (bash's default). That makes the `${#a[@]}` check below
+# meaningful — without it, `${#a[@]}` is always >= 1 because the unexpanded
+# pattern occupies the array.
+shopt -u failglob
+shopt -s nullglob
+# Referenced indirectly via `declare -n a="${arr}"` below.
+# shellcheck disable=SC2034
+disk_imgs=( "${INPUT_DIR}"/*-disk.img )
+# shellcheck disable=SC2034
+eif_files=( "${INPUT_DIR}"/*.eif )
+# shellcheck disable=SC2034
+kernels=(   "${INPUT_DIR}"/*-kernel )
+shopt -u nullglob
+shopt -s failglob
+
+for arr in disk_imgs eif_files kernels; do
+  declare -n a="${arr}"
+  if (( ${#a[@]} == 0 )); then
+    echo "eif2eif: no matching input in ${INPUT_DIR} for ${arr}" >&2
+    exit 1
+  fi
+  unset -n a
+done
+
+# Skip stable-name symlinks (`latest.eif`, `latest-disk.img`, ...) so we
+# operate on the versioned artifacts and avoid clobbering by editing
+# through a symlink.
+pick_versioned() {
+  local -n src="$1"
+  local -n dst="$2"
+  dst=()
+  local f
+  for f in "${src[@]}"; do
+    [[ -L "${f}" ]] && continue
+    dst+=("${f}")
+  done
+}
+declare -a INPUT_DISKS INPUT_EIFS INPUT_KERNELS
+pick_versioned disk_imgs INPUT_DISKS
+pick_versioned eif_files INPUT_EIFS
+pick_versioned kernels   INPUT_KERNELS
+
+if (( ${#INPUT_DISKS[@]} != 1 )); then
+  echo "eif2eif: expected exactly one -disk.img in ${INPUT_DIR}, found ${#INPUT_DISKS[@]}" >&2
+  exit 1
+fi
+if (( ${#INPUT_EIFS[@]} != 1 )); then
+  echo "eif2eif: expected exactly one .eif in ${INPUT_DIR}, found ${#INPUT_EIFS[@]}" >&2
+  exit 1
+fi
+if (( ${#INPUT_KERNELS[@]} != 1 )); then
+  echo "eif2eif: expected exactly one -kernel in ${INPUT_DIR}, found ${#INPUT_KERNELS[@]}" >&2
+  exit 1
+fi
+
+INPUT_DISK="${INPUT_DISKS[0]}"
+INPUT_EIF="${INPUT_EIFS[0]}"
+INPUT_KERNEL="${INPUT_KERNELS[0]}"
+
+# ---------- Extract ROOT-A from input disk ----------
+
+# rpm2eif produced a 2-partition GPT: ROOT-A (erofs) at partition 1,
+# HASH-A (dm-verity) at partition 2. Read the current geometry.
+declare -A imgsize imgoff
+get_partition_sizes "${INPUT_DISK}" "" imgsize imgoff
+
+for part in ROOT-A HASH-A; do
+  if [[ -z "${imgsize[${part}]:-}" || -z "${imgoff[${part}]:-}" ]]; then
+    echo "eif2eif: input disk is missing ${part} partition" >&2
+    exit 1
+  fi
+done
+
+ROOT_MOUNT="${WORKDIR}/rootfs"
+mkdir -p "${ROOT_MOUNT}"
+ROOTFS_IN="${WORKDIR}/root-in.erofs"
+dd if="${INPUT_DISK}" of="${ROOTFS_IN}" \
+  count="${imgsize[ROOT-A]}" bs=1M skip="${imgoff[ROOT-A]}" status=none
+
+# Validate the filesystem type before we try to extract.
+fs_type="$(blkid -c /dev/null -o value -s TYPE "${ROOTFS_IN}")"
+if [[ "${fs_type}" != "erofs" ]]; then
+  echo "eif2eif: input ROOT-A is '${fs_type}', expected 'erofs'" >&2
+  exit 1
+fi
+
+fsck.erofs --extract="${ROOT_MOUNT}" "${ROOTFS_IN}"
+touch -r "${ROOTFS_IN}" "${ROOT_MOUNT}"
+rm -f "${ROOTFS_IN}"
+
+# ---------- Replace CA bundle and root.json ----------
+
+install_ca_certs "${ROOT_MOUNT}"
+install_root_json "${ROOT_MOUNT}"
+
+# ---------- Rebuild ROOT-A (erofs) ----------
+
+SELINUX_FILE_CONTEXTS="${ROOT_MOUNT}/etc/selinux/fortified/contexts/files/file_contexts"
+ROOTFS_OUT="${WORKDIR}/root-out.erofs"
+mkfs_root_erofs "${ROOT_MOUNT}" "${ROOTFS_OUT}" "${SELINUX_FILE_CONTEXTS}"
+
+# ---------- Generate new dm-verity HASH-A ----------
+
+ROOTFS_SIZE="$(stat -c %s "${ROOTFS_OUT}")"
+ROOTFS_MIB="$(( (ROOTFS_SIZE + 1048575) / 1048576 ))"
+VERITY_MIB="$(( (ROOTFS_MIB / 64) + 4 ))"
+
+VERITY_OUT="${WORKDIR}/hash-out.verity"
+declare -a DM_VERITY_ROOT
+generate_verity_root "${ROOTFS_OUT}" "${VERITY_OUT}" "${VERITY_MIB}" DM_VERITY_ROOT
+
+# Sanity-check the four fields we splice into the cmdline below. Everything
+# else in the dm-verity table is fixed by our build (block sizes, algorithm,
+# device paths) or hardcoded here, so validating these four is sufficient.
+[[ "${DM_VERITY_ROOT[11]}" =~ ^[0-9a-f]{64}$ ]] \
+  || { echo "eif2eif: bad verity root hash: ${DM_VERITY_ROOT[11]}" >&2; exit 1; }
+[[ "${DM_VERITY_ROOT[12]}" =~ ^[0-9a-f]+$ ]] \
+  || { echo "eif2eif: bad verity salt: ${DM_VERITY_ROOT[12]}" >&2; exit 1; }
+[[ "${DM_VERITY_ROOT[1]}" =~ ^[0-9]+$ ]] \
+  || { echo "eif2eif: bad verity data sectors" >&2; exit 1; }
+[[ "${DM_VERITY_ROOT[8]}" =~ ^[0-9]+$ ]] \
+  || { echo "eif2eif: bad verity data blocks" >&2; exit 1; }
+
+VERITY_DATA_SECTORS="${DM_VERITY_ROOT[1]}"
+VERITY_DATA_BLOCKS="${DM_VERITY_ROOT[8]}"
+VERITY_ROOT_HASH="${DM_VERITY_ROOT[11]}"
+VERITY_SALT="${DM_VERITY_ROOT[12]}"
+
+# ---------- Build fresh GPT ----------
+
+target_mib=0
+if (( OS_IMAGE_SIZE_GIB > 0 )); then
+  target_mib=$(( OS_IMAGE_SIZE_GIB * 1024 ))
+fi
+declare -A eif_partsize eif_partoff
+set_eif_partition_sizes "${ROOTFS_MIB}" "${VERITY_MIB}" \
+  eif_partsize eif_partoff "${target_mib}"
+
+ROOT_OFF_MIB="${eif_partoff[ROOT-A]}"
+ROOT_SIZE_MIB="${eif_partsize[ROOT-A]}"
+HASH_OFF_MIB="${eif_partoff[HASH-A]}"
+HASH_SIZE_MIB="${eif_partsize[HASH-A]}"
+DISK_SIZE_MIB="$(( HASH_OFF_MIB + HASH_SIZE_MIB + 1 ))"
+
+DISK_OUT="${WORKDIR}/disk-out.img"
+truncate -s "${DISK_SIZE_MIB}M" "${DISK_OUT}"
+sgdisk -Z "${DISK_OUT}" >/dev/null
+
+check_image_size "${ROOTFS_OUT}" "${ROOT_SIZE_MIB}"
+check_image_size "${VERITY_OUT}" "${HASH_SIZE_MIB}"
+
+ROOT_START="$(( ROOT_OFF_MIB * 2048 ))"
+ROOT_END="$(( (ROOT_OFF_MIB + ROOT_SIZE_MIB) * 2048 - 1 ))"
+HASH_START="$(( HASH_OFF_MIB * 2048 ))"
+HASH_END="$(( (HASH_OFF_MIB + HASH_SIZE_MIB) * 2048 - 1 ))"
+
+sgdisk \
+  --new=1:${ROOT_START}:${ROOT_END} --typecode=1:"${BOTTLEROCKET_ROOT_TYPECODE}" --change-name=1:ROOT-A \
+  --new=2:${HASH_START}:${HASH_END} --typecode=2:"${BOTTLEROCKET_HASH_TYPECODE}" --change-name=2:HASH-A \
+  "${DISK_OUT}"
+
+dd if="${ROOTFS_OUT}" of="${DISK_OUT}" conv=notrunc bs=1M seek="${ROOT_OFF_MIB}" status=none
+dd if="${VERITY_OUT}" of="${DISK_OUT}" conv=notrunc bs=1M seek="${HASH_OFF_MIB}" status=none
+sgdisk -v "${DISK_OUT}"
+
+# ---------- Build new EIF ----------
+
+# The kernel cmdline changes (new verity root hash), so PCR0 changes, so a
+# `resign` is not enough — we must run a full `eif-builder build`. We feed
+# it the *already-prepared* kernel from the input `-kernel` sidecar: those
+# bytes are exactly what the input EIF embedded, so the new EIF has the
+# same kernel section as the input.
+sign_args=()
+if ! discover_eif_signer_args sign_args; then
+  exit 1
+fi
+
+EIF_OUT="${WORKDIR}/out.eif"
+
+# Carry METADATA identity fields forward from the input EIF.
+#
+# rpm2eif populates KernelVersion / ImageVersion / BuildTime from the source
+# build's own inputs (RPM db, VERSION_ID, BUILD_ID_TIMESTAMP). eif2eif has
+# none of those to query at this point — the rootfs has been extracted and
+# rebuilt, but the RPM db lookup happens well before this script runs, and
+# we can't derive the original build's timestamp from any current-run state.
+# So we read them out of the input EIF's METADATA section via
+# `eif-builder describe` and forward them verbatim. This makes a repacked
+# EIF's provenance identify the *original* build, not the repack run —
+# which is what a consumer inspecting `ImageVersion` / `BuildTime` would
+# reasonably expect: a repack changes the disk layout (dm-verity), not the
+# release identity.
+#
+# `jq -r` prints "null" for a missing key and the literal string for
+# present-but-empty. Both map to "unknown" via the sentinel logic below,
+# matching rpm2eif's fallback for missing information.
+#
+# `describe` prints a single JSON blob to stdout with no stderr output on
+# success, so it is safe to consume directly. We also read the original
+# CMDLINE out of the same blob (see kernel-cmdline construction below).
+INPUT_EIF_JSON="$(/host/build/tools/eif-builder describe --input "${INPUT_EIF}" --compact)"
+
+read_metadata_field() {
+  local path="${1:?}"
+  local fallback="${2:?}"
+  local value
+  value="$(jq -r "${path} // \"${fallback}\"" <<<"${INPUT_EIF_JSON}")"
+  if [[ -z "${value}" || "${value}" == "null" ]]; then
+    value="${fallback}"
+  fi
+  printf '%s' "${value}"
+}
+
+INPUT_KERNEL_VERSION="$(read_metadata_field '.metadata.BuildMetadata.KernelVersion' 'unknown')"
+INPUT_IMAGE_VERSION="$(read_metadata_field '.metadata.ImageVersion' '')"
+INPUT_BUILD_TIME="$(read_metadata_field '.metadata.BuildMetadata.BuildTime' '')"
+
+OLD_CMDLINE="$(jq -r '.cmdline // ""' <<<"${INPUT_EIF_JSON}")"
+if [[ -z "${OLD_CMDLINE}" || "${OLD_CMDLINE}" == "null" ]]; then
+  echo "eif2eif: input EIF '${INPUT_EIF}' has no CMDLINE section" >&2
+  exit 1
+fi
+if [[ "${OLD_CMDLINE}" != *'dm-mod.create="'* ]]; then
+  echo "eif2eif: no 'dm-mod.create=' in the kernel command line of '${INPUT_EIF}'" >&2
+  exit 1
+fi
+CMDLINE_PREFIX="${OLD_CMDLINE%%dm-mod.create=\"*}"
+CMDLINE_SUFFIX="${OLD_CMDLINE#*dm-mod.create=\"}"
+CMDLINE_SUFFIX="${CMDLINE_SUFFIX#*\"}"
+# Hardcode /dev/vda1 /dev/vda2, matching rpm2eif. The enclave has no GRUB to
+# expand `generate_verity_root`'s default `PARTUUID=$boot_uuid` placeholder.
+DM_CREATE="dm-mod.create=\"root,,,ro,0 ${VERITY_DATA_SECTORS} verity 1 /dev/vda1 /dev/vda2 4096 4096 ${VERITY_DATA_BLOCKS} 1 sha256 ${VERITY_ROOT_HASH} ${VERITY_SALT} 2 restart_on_corruption ignore_zero_blocks\""
+KERNEL_CMDLINE="${CMDLINE_PREFIX}${DM_CREATE}${CMDLINE_SUFFIX}"
+
+# `eif-builder build` runs `prepare_kernel` on --kernel unconditionally.
+# ${INPUT_KERNEL} here is the already-prepared kernel (rpm2eif emitted the
+# post-zboot-unwrap flat Image on arm64 / vmlinux on x86_64), so
+# `prepare_kernel` must be idempotent on this input for the resulting
+# EIF's KERNEL section to match what the original build embedded:
+#   - x86_64: pass-through (identity).
+#   - arm64: `prepare_kernel` sees a flat PE Image (MZ + ARM\x64), which
+#     is already the target format; the zboot-unwrap path does not fire.
+# See `tools/eif-builder/src/kernel.rs` for the branches. If a future
+# change makes `prepare_kernel` non-idempotent (e.g. inserting padding),
+# the -kernel sidecar this script emits and the KERNEL section embedded
+# in the new .eif will drift — audit this call site accordingly.
+/host/build/tools/eif-builder \
+  --kernel "${INPUT_KERNEL}" \
+  --cmdline "${KERNEL_CMDLINE}" \
+  --output "${EIF_OUT}" \
+  --arch "${ARCH}" \
+  --build-tool-version "${TWOLITER_VERSION:-}" \
+  --kernel-version "${INPUT_KERNEL_VERSION}" \
+  --image-version "${INPUT_IMAGE_VERSION}" \
+  --build-time "${INPUT_BUILD_TIME}" \
+  "${sign_args[@]}"
+
+# ---------- Emit artifacts ----------
+
+ARTIFACT_PREFIX="${IMAGE_NAME}-${VARIANT_NAME}-${ARCH}-${VERSION_ID}-${BUILD_ID}"
+cp "${INPUT_KERNEL}" "${OUTPUT_DIR}/${ARTIFACT_PREFIX}-kernel"
+cp "${EIF_OUT}"      "${OUTPUT_DIR}/${ARTIFACT_PREFIX}.eif"
+cp "${DISK_OUT}"     "${OUTPUT_DIR}/${ARTIFACT_PREFIX}-disk.img"
+
+ln -snf "${ARTIFACT_PREFIX}.eif"      "${OUTPUT_DIR}/latest.eif"
+ln -snf "${ARTIFACT_PREFIX}-disk.img" "${OUTPUT_DIR}/latest-disk.img"
+ln -snf "${ARTIFACT_PREFIX}-kernel"   "${OUTPUT_DIR}/latest-kernel"
+
+popd >/dev/null
+
+echo "=== eif2eif complete ==="
+ls -lh "${OUTPUT_DIR}/"

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -14,13 +14,16 @@ IN_PLACE_UPDATES="no"
 # standalone-image validation below treats it consistently with rpm2img.
 # If a future change adds a flag for it, the validation below will already
 # enforce mutual exclusion when `standalone-image = true`.
+# Referenced indirectly via `${!f}` in the standalone-image conflict loop.
+# shellcheck disable=SC2034
 ENCRYPTED_STORAGE="no"
+# shellcheck disable=SC2034
 EPHEMERAL_ENCRYPTION_KEYS="no"
 STANDALONE_IMAGE="no"
 UKI_IMAGE="no"
 
 for opt in "$@"; do
-  optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
+  optarg="$(expr "${opt}" : '[^=]*=\(.*\)' || echo '')"
   case "${opt}" in
   --input-dir=*) INPUT_DIR="${optarg}" ;;
   --output-dir=*) OUTPUT_DIR="${optarg}" ;;
@@ -36,6 +39,7 @@ for opt in "$@"; do
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   --with-standalone-image=*) STANDALONE_IMAGE="${optarg}" ;;
   --with-uki-image=*) UKI_IMAGE="${optarg}" ;;
+  --guest-images=*) ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1

--- a/twoliter/src/tool-crates/embedded-bundle/build.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/build.rs
@@ -29,6 +29,7 @@ fn main() {
     paths.copy_file("build.Dockerfile.dockerignore");
     paths.copy_file("docker-cargo");
     paths.copy_file("docker-go");
+    paths.copy_file("eif2eif");
     paths.copy_file("eif-sign-helper");
     paths.copy_file("guest-images-helper");
     paths.copy_file("img2img");

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -150,6 +150,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("build.Dockerfile").is_file());
     assert!(toolsdir.join("build.Dockerfile.dockerignore").is_file());
     assert!(toolsdir.join("docker-go").is_file());
+    assert!(toolsdir.join("eif2eif").is_file());
     assert!(toolsdir.join("eif-sign-helper").is_file());
     assert!(toolsdir.join("guest-images-helper").is_file());
     assert!(toolsdir.join("img2img").is_file());


### PR DESCRIPTION
Add `eif2eif`, a new Dockerfile-invoked tool that repackages an existing
EIF: rewrites the CA bundle / root.json inside the EIF's rootfs, rebuilds
erofs + dm-verity, pins the cmdline to the new verity root hash, and
produces a freshly signed .eif using the [eif] signing profile from the
prior commit.

Wires the imgrepack Dockerfile stage to dispatch to `eif2eif` when
IMAGE_FORMAT=eif and `img2img` otherwise. Plumbs KERNEL_PARAMETERS and
TWOLITER_VERSION as build args so the rebuilt EIF's cmdline and
BuildToolVersion metadata match what rpm2eif emitted at first build.

Removes the `EifRepackUnsupported` early-fail in `buildsys::repack_variant`
now that a real repack path exists.