### PR TITLE
feat(eif): embed os-release into rpm2eif rootfs

### DIFF
--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -366,6 +366,24 @@ ENCRYPTED_STORAGE=false
 STANDALONE_IMAGE=true
 EOF
 
+echo "=== Embedding os-release ==="
+# Mirrors the os-release append in rpm2img. INSTALL_ROOT here is the merged
+# sysroot, so no ${ARCH}-bottlerocket-linux-gnu/sys-root prefix is needed.
+VERSION="${VERSION_ID} (${VARIANT})"
+# shellcheck disable=SC2154 # PROJECT_VENDOR/PRETTY_NAME come from the build env.
+cat <<EOF >>"${INSTALL_ROOT}/usr/lib/os-release"
+VERSION="${VERSION}"
+PRETTY_NAME="${PRETTY_NAME} ${VERSION}"
+VARIANT_ID=${VARIANT}
+VERSION_ID=${VERSION_ID}
+BUILD_ID=${BUILD_ID}
+VENDOR_NAME="${PROJECT_VENDOR}"
+HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
+SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
+BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
+DOCUMENTATION_URL="https://bottlerocket.dev"
+EOF
+
 echo "=== Creating rootfs.erofs ==="
 # Remove only the top-level /boot from rootfs (kernel is shipped separately).
 [[ -d "${INSTALL_ROOT}/boot" ]] && rm -rf "${INSTALL_ROOT}/boot"


### PR DESCRIPTION
Mirror the os-release append that rpm2img performs, so EIF-built rootfs
images expose the same identifying fields (VERSION, PRETTY_NAME,
VARIANT_ID, VERSION_ID, BUILD_ID, VENDOR_NAME, and the canonical URLs)
to userspace. Unlike rpm2img, INSTALL_ROOT already points at the merged
sysroot, so the append writes directly to ${INSTALL_ROOT}/usr/lib/os-release
without the ${ARCH}-bottlerocket-linux-gnu/sys-root prefix.