### PR TITLE
feat(eif): expose EIF header PCIE flags as variant metadata

### DIFF
--- a/tools/buildsys/src/builder.rs
+++ b/tools/buildsys/src/builder.rs
@@ -214,6 +214,12 @@ impl crate::builder::PackageBuildArgs {
     }
 }
 
+/// Bare lowercase hex for the Docker build-arg; `None` → empty string
+/// (Dockerfile omits `--pcie-flags`, so `eif-builder`'s default applies).
+fn format_eif_pcie_flags(flags: Option<u16>) -> String {
+    flags.map(|v| format!("{v:x}")).unwrap_or_default()
+}
+
 struct VariantBuildArgs {
     package_dependencies: Vec<String>,
     kit_dependencies: Vec<String>,
@@ -224,6 +230,9 @@ struct VariantBuildArgs {
     image_features: HashSet<ImageFeature>,
     image_format: String,
     kernel_parameters: String,
+    /// EIF header PCIE flags override from `[package.metadata.build-variant]
+    /// eif-pcie-flags`.
+    eif_pcie_flags: String,
     name: String,
     os_image_publish_size_gib: String,
     os_image_size_gib: String,
@@ -262,6 +271,7 @@ impl VariantBuildArgs {
         args.build_arg("IMAGE_FORMAT", &self.image_format);
         args.build_arg("IMAGE_NAME", &self.name);
         args.build_arg("KERNEL_PARAMETERS", &self.kernel_parameters);
+        args.build_arg("EIF_PCIE_FLAGS", &self.eif_pcie_flags);
         args.build_arg("KIT_DEPENDENCIES", self.kit_dependencies.join(" "));
         args.build_arg(
             "EXTERNAL_KIT_DEPENDENCIES",
@@ -315,6 +325,7 @@ struct RepackVariantBuildArgs {
     data_image_size_gib: String,
     image_features: HashSet<ImageFeature>,
     image_format: String,
+    eif_pcie_flags: String,
     name: String,
     os_image_publish_size_gib: String,
     os_image_size_gib: String,
@@ -350,6 +361,7 @@ impl RepackVariantBuildArgs {
         args.build_arg("VARIANT_PLATFORM", &self.variant_platform);
         args.build_arg("BUILD_ID", &self.version_build);
         args.build_arg("VERSION_ID", &self.version_image);
+        args.build_arg("EIF_PCIE_FLAGS", &self.eif_pcie_flags);
         args.build_arg("GUEST_IMAGES", &self.guest_images);
 
         // TWOLITER_VERSION mirrors what VariantBuildArgs plumbs through so
@@ -568,6 +580,7 @@ impl DockerBuild {
                     .cloned()
                     .unwrap_or_default()
                     .join(" "),
+                eif_pcie_flags: format_eif_pcie_flags(manifest.info().eif_pcie_flags()),
                 name: args.name,
                 os_image_publish_size_gib: os_image_publish_size_gib.to_string(),
                 os_image_size_gib: os_image_size_gib.to_string(),
@@ -689,6 +702,7 @@ impl DockerBuild {
                     Some(ImageFormat::Vmdk) => "vmdk",
                 }
                 .to_string(),
+                eif_pcie_flags: format_eif_pcie_flags(manifest.info().eif_pcie_flags()),
                 name: args.name,
                 os_image_publish_size_gib: os_image_publish_size_gib.to_string(),
                 os_image_size_gib: os_image_size_gib.to_string(),

--- a/tools/buildsys/src/manifest.rs
+++ b/tools/buildsys/src/manifest.rs
@@ -183,6 +183,18 @@ The given parameters are inserted at the start of the command line.
 kernel-parameters = [
    "console=ttyS42",
 ]
+```
+
+`eif-pcie-flags` overrides the PCIE flag word written into the EIF header for
+`image-format = "eif"` variants. Accepted as a TOML integer literal (decimal)
+or a `0x`/`0X`-prefixed hex string. Unprefixed strings are rejected to avoid
+ambiguity with the `eif-builder --pcie-flags` CLI (hex-only). When absent,
+`eif-builder`'s built-in default is used. Non-EIF variants ignore this field.
+```ignore
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = 0x340
+```
 
 `image-features` is a map of image feature flags, which can be enabled or disabled. This allows us
 to conditionally use or exclude certain image-level features in variants.
@@ -306,7 +318,7 @@ use crate::BuildType;
 use buildsys_config::EXTERNAL_KIT_METADATA;
 use guppy::graph::{DependencyDirection, PackageGraph, PackageLink, PackageMetadata};
 use guppy::{CargoMetadata, PackageId};
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use std::cmp::max;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -629,6 +641,13 @@ impl ManifestInfo {
             .and_then(|b| b.kernel_parameters.as_ref())
     }
 
+    /// Convenience method to return the EIF header PCIE flags override for
+    /// this variant. Only meaningful when `image-format = "eif"`; ignored
+    /// otherwise.
+    pub fn eif_pcie_flags(&self) -> Option<u16> {
+        self.build_variant().and_then(|b| b.eif_pcie_flags)
+    }
+
     /// Convenience method to return the enabled image features for this variant.
     pub fn image_features(&self) -> Option<HashSet<ImageFeature>> {
         let variant = self.build_variant()?;
@@ -937,6 +956,43 @@ pub enum SensitivityType {
     Flavor,
 }
 
+/// Deserialize `Option<u16>` from a TOML integer (decimal) or a `0x`/`0X`-prefixed
+/// hex string. Unprefixed strings are rejected; see `BuildVariant::eif_pcie_flags`.
+fn deserialize_u16_hex_or_int<'de, D>(deserializer: D) -> std::result::Result<Option<u16>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        Int(u64),
+        Str(String),
+    }
+
+    let Some(value) = Option::<Repr>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    match value {
+        Repr::Int(n) => u16::try_from(n).map(Some).map_err(|_| {
+            <D::Error as de::Error>::custom(format!("value {n} does not fit in a u16"))
+        }),
+        Repr::Str(s) => {
+            let trimmed = s.trim();
+            let hex_body = trimmed
+                .strip_prefix("0x")
+                .or_else(|| trimmed.strip_prefix("0X"))
+                .ok_or_else(|| {
+                    <D::Error as de::Error>::custom(format!(
+                        "invalid `eif-pcie-flags` value {s:?}: string form requires a `0x` prefix or an integer literal"
+                    ))
+                })?;
+            u16::from_str_radix(hex_body, 16)
+                .map(Some)
+                .map_err(|e| <D::Error as de::Error>::custom(format!("Invalid hex u16 {s:?}: {e}")))
+        }
+    }
+}
+
 /// Metadata for a `build-variant`.
 ///
 /// `guest-images` is a map from a guest variant's crate name to an absolute install path in
@@ -964,6 +1020,8 @@ pub struct BuildVariant {
     pub supported_arches: Option<HashSet<SupportedArch>>,
     pub kernel_parameters: Option<Vec<String>>,
     pub image_features: Option<HashMap<ImageFeature, bool>>,
+    #[serde(default, deserialize_with = "deserialize_u16_hex_or_int")]
+    pub eif_pcie_flags: Option<u16>,
     /// Map of guest variant crate name -> absolute install path in this variant's root
     /// filesystem.
     pub guest_images: Option<BTreeMap<String, PathBuf>>,
@@ -1873,6 +1931,98 @@ name = "test-variant"
         let msg = format!("{err}");
         assert!(msg.contains("ephemeral-encryption-keys"));
         assert!(msg.contains("encrypted-storage"));
+    }
+
+    #[test]
+    fn eif_pcie_flags_omitted_is_none() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_pcie_flags(), None);
+    }
+
+    #[test]
+    fn eif_pcie_flags_hex_string_parses() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = "0x340"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_pcie_flags(), Some(0x340));
+    }
+
+    #[test]
+    fn eif_pcie_flags_unprefixed_string_is_rejected() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = "340"
+"#;
+        let err = toml::from_str::<ManifestInfo>(toml)
+            .expect_err("unprefixed hex string should be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("0x"),
+            "error should mention the `0x` prefix requirement, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn eif_pcie_flags_uppercase_prefix_parses() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = "0X340"
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_pcie_flags(), Some(0x340));
+    }
+
+    #[test]
+    fn eif_pcie_flags_integer_parses() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = 576
+"#;
+        let info = manifest_info_from_toml(toml);
+        assert_eq!(info.eif_pcie_flags(), Some(576));
+    }
+
+    #[test]
+    fn eif_pcie_flags_rejects_overflow() {
+        let toml = r#"
+[package]
+name = "test-variant"
+
+[package.metadata.build-variant]
+image-format = "eif"
+eif-pcie-flags = "0x10000"
+"#;
+        let err = toml::from_str::<ManifestInfo>(toml).expect_err("0x10000 should not fit in u16");
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("u16"),
+            "expected u16 mention in error, got: {msg}"
+        );
     }
 
     #[test]

--- a/tools/eif-builder/src/lib.rs
+++ b/tools/eif-builder/src/lib.rs
@@ -59,7 +59,9 @@ pub const SIGNATURE_MAX_SIZE: usize = 32768;
 pub const EIF_HDR_FLAG_PCIE: u16 = 1 << 6;
 pub const EIF_HDR_FLAG_PCIE_VIRTIO: u16 = 1 << 9;
 
-/// Default PCIE flags for sidecar mode.
+/// Default PCIE flags written into the EIF header when no `--pcie-flags`
+/// override is supplied. Override per-variant via
+/// `[package.metadata.build-variant] eif-pcie-flags`.
 pub const DEFAULT_PCIE_FLAGS: u16 = EIF_HDR_FLAG_PCIE | EIF_HDR_FLAG_PCIE_VIRTIO;
 
 /// Default kernel command line for block device boot.

--- a/tools/eif-builder/src/main.rs
+++ b/tools/eif-builder/src/main.rs
@@ -41,7 +41,8 @@ struct Args {
     #[arg(long, default_value_t = 2)]
     cpus: u64,
 
-    /// PCIE flags (hex; `0x` / `0X` prefix optional)
+    /// PCIE flags written into the EIF header (hex; `0x`/`0X` prefix optional).
+    /// See `lib.rs::DEFAULT_PCIE_FLAGS` for the header==launch-flags contract.
     #[arg(long, default_value_t = DEFAULT_PCIE_FLAGS, value_parser = parse_hex_u16)]
     pcie_flags: u16,
 

--- a/twoliter/embedded/eif2eif
+++ b/twoliter/embedded/eif2eif
@@ -301,6 +301,13 @@ if ! discover_eif_signer_args sign_args; then
   exit 1
 fi
 
+# EIF header PCIE flags; unset → omit `--pcie-flags` so the repacked header
+# matches the first-build default. See tools/eif-builder/src/lib.rs.
+pcie_flags_args=()
+if [[ -n "${EIF_PCIE_FLAGS:-}" ]]; then
+  pcie_flags_args=(--pcie-flags "${EIF_PCIE_FLAGS}")
+fi
+
 EIF_OUT="${WORKDIR}/out.eif"
 
 # Carry METADATA identity fields forward from the input EIF.
@@ -379,6 +386,7 @@ KERNEL_CMDLINE="${CMDLINE_PREFIX}${DM_CREATE}${CMDLINE_SUFFIX}"
   --kernel-version "${INPUT_KERNEL_VERSION}" \
   --image-version "${INPUT_IMAGE_VERSION}" \
   --build-time "${INPUT_BUILD_TIME}" \
+  "${pcie_flags_args[@]}" \
   "${sign_args[@]}"
 
 # ---------- Emit artifacts ----------

--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -536,6 +536,13 @@ if ! discover_eif_signer_args sign_args; then
     exit 1
 fi
 
+# EIF header PCIE flags; unset → omit `--pcie-flags` so `eif-builder`'s
+# default applies. See tools/eif-builder/src/lib.rs::DEFAULT_PCIE_FLAGS.
+pcie_flags_args=()
+if [[ -n "${EIF_PCIE_FLAGS:-}" ]]; then
+    pcie_flags_args=(--pcie-flags "${EIF_PCIE_FLAGS}")
+fi
+
 /host/build/tools/eif-builder \
     --kernel "${KERNEL_LOCAL}" \
     --cmdline "${KERNEL_CMDLINE}" \
@@ -546,6 +553,7 @@ fi
     --image-version "${VERSION_ID}" \
     --build-time "${BUILD_TIME_RFC3339}" \
     --out-prepared-kernel "${PREPARED_KERNEL_TMP}" \
+    "${pcie_flags_args[@]}" \
     "${sign_args[@]}"
 
 echo "=== Generating SBOMs ==="


### PR DESCRIPTION
Add `[package.metadata.build-variant] eif-pcie-flags` so `image-format =
"eif"` variants can author the PCIE flag word written into the EIF
header. The value flows buildsys -> Docker ARG (`EIF_PCIE_FLAGS`) ->
rpm2eif / eif2eif -> `eif-builder --pcie-flags <hex>`; when unset,
`eif-builder`'s built-in `DEFAULT_PCIE_FLAGS` (0x240) is applied, so
existing variants are unaffected.

The header value must match the PCIE flags the sidecar shim passes to
the hypervisor at launch (`header == launch-flags`, hypervisor-enforced);
today the shim's launch flags are authored independently, so a
per-variant knob is what lets a build keep the two sides in sync. Once
the shim derives its launch flags from the header directly (host echoes,
hypervisor enforces), the coupling goes away — but this knob is still
the authoring surface for the header value itself.

Accepted forms: TOML integer literal (decimal, per TOML spec, e.g. `832`)
or a `0x`-prefixed hex string (e.g. `"0x340"`). Unprefixed string forms
like `"340"` are rejected at parse time: eif-builder's --pcie-flags CLI
treats `340` as hex, so silently reading the unprefixed string as
decimal would produce exactly the header/launch-flags mismatch this
knob exists to prevent.

The header==launch-flags contract is documented on
`DEFAULT_PCIE_FLAGS` in eif-builder, on the new `BuildVariant`
field, and briefly in the eif-builder `--pcie-flags` CLI help.

Tests: 6 new unit tests in tools/buildsys covering omitted field,
integer literal, hex string (`0x` and `0X`), unprefixed-string
rejection, and u16 overflow.