### PR TITLE
Re-pack support for UKIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5076,6 +5076,7 @@ dependencies = [
  "twoliter-tool-pubsys",
  "twoliter-tool-pubsys-setup",
  "twoliter-tool-tuftool",
+ "twoliter-tool-ukisys",
  "twoliter-tool-unplug",
  "uuid",
  "which",
@@ -5156,6 +5157,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "twoliter-tool-ukisys"
+version = "0.1.0"
+dependencies = [
+ "include-env-compressed",
+ "ukisys",
+]
+
+[[package]]
 name = "twoliter-tool-unplug"
 version = "0.1.0"
 dependencies = [
@@ -5195,6 +5204,14 @@ checksum = "885c31f06fce836457fe3ef09a59f83fe8db95d270b11cd78f40a4666c4d1661"
 dependencies = [
  "libc",
  "tokio",
+]
+
+[[package]]
+name = "ukisys"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "snafu 0.8.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "tools/pubsys-setup",
     "tools/serde-templated",
     "tools/serde-templated-derive",
+    "tools/ukisys",
     "tools/unplug",
 
     "tools/update-metadata",
@@ -33,6 +34,7 @@ members = [
     "twoliter/src/tool-crates/pubsys",
     "twoliter/src/tool-crates/pubsys-setup",
     "twoliter/src/tool-crates/tuftool",
+    "twoliter/src/tool-crates/ukisys",
     "twoliter/src/tool-crates/unplug",
     "twoliter/src/tool-crates/eif-builder",
 
@@ -87,8 +89,10 @@ twoliter-tool-pipesys = { version = "0.1", path = "twoliter/src/tool-crates/pipe
 twoliter-tool-pubsys = { version = "0.1", path = "twoliter/src/tool-crates/pubsys" }
 twoliter-tool-pubsys-setup = { version = "0.1", path = "twoliter/src/tool-crates/pubsys-setup" }
 twoliter-tool-tuftool = { version = "0.1", path = "twoliter/src/tool-crates/tuftool" }
+twoliter-tool-ukisys = { version = "0.1", path = "twoliter/src/tool-crates/ukisys" }
 twoliter-tool-unplug = { version = "0.1", path = "twoliter/src/tool-crates/unplug" }
 
+ukisys = { version = "0.1", path = "tools/ukisys", artifact = [ "bin:ukisys" ] }
 unplug = { version = "0.1", path = "tools/unplug", artifact = [ "bin:unplug" ] }
 update-metadata = { version = "0.1", path = "tools/update-metadata" }
 

--- a/tools/ukisys/Cargo.toml
+++ b/tools/ukisys/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ukisys"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+snafu.workspace = true

--- a/tools/ukisys/README.md
+++ b/tools/ukisys/README.md
@@ -1,0 +1,13 @@
+# ukisys
+
+Native PE section-removal tool for Bottlerocket Unified Kernel Images (UKIs).
+
+`derive-stub` recovers the unsigned systemd-stub a signed UKI was built from: it strips the Authenticode signature and truncates the trailing `.osrel`/`.cmdline`/`.uname`/`.linux` sections, patching `NumberOfSections`, `SizeOfInitializedData`, and `SizeOfImage`, and zeroing `CheckSum`.
+
+All four trailing sections are removed together, not just the three payload sections, because `ukify build` overwrites any same-named section already present in the stub in place rather than skipping it.
+
+## Usage
+
+```bash
+ukisys derive-stub <input-uki> <output-stub>
+```

--- a/tools/ukisys/src/error.rs
+++ b/tools/ukisys/src/error.rs
@@ -1,0 +1,6 @@
+//! Common error handling for ukisys.
+
+use snafu::Whatever;
+
+/// Result type for ukisys CLI-level operations.
+pub type Result<T> = std::result::Result<T, Whatever>;

--- a/tools/ukisys/src/main.rs
+++ b/tools/ukisys/src/main.rs
@@ -1,0 +1,78 @@
+//! ukisys: derives the unsigned systemd-stub PE a Bottlerocket UKI was
+//! built from, by stripping its Authenticode signature and truncating the
+//! trailing payload sections. Those sections are `.osrel`, `.cmdline`,
+//! `.uname`, and `.linux`.
+
+mod error;
+mod pe;
+
+use clap::{Parser, Subcommand};
+use pe::PeImage;
+use snafu::ResultExt;
+use std::path::{Path, PathBuf};
+
+use crate::error::Result;
+
+/// All four sections must be removed, not just the three payload sections:
+/// `ukify build` overwrites any same-named section already in the stub in
+/// place instead of appending fresh content, rather than skipping it.
+const TRAILING_SECTIONS_TO_REMOVE: &[&str] = &[".osrel", ".cmdline", ".uname", ".linux"];
+
+/// Command-line arguments for ukisys.
+#[derive(Parser)]
+#[command(
+    version,
+    about = "PE section removal for Bottlerocket Unified Kernel Images"
+)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+/// Subcommands for UKI repack section removal.
+#[derive(Subcommand)]
+enum Command {
+    /// Derive an unsigned systemd-stub PE from a finished, signed UKI.
+    DeriveStub {
+        /// Path to the finished, signed UKI to strip.
+        uki: PathBuf,
+
+        /// Path to write the derived, unsigned stub to.
+        stub: PathBuf,
+    },
+}
+
+#[snafu::report]
+fn main() -> Result<()> {
+    let args = Args::parse();
+    match &args.command {
+        Command::DeriveStub { uki, stub } => derive_stub(uki, stub),
+    }
+}
+
+fn derive_stub(uki_path: &Path, stub_path: &Path) -> Result<()> {
+    let mut image = PeImage::load(uki_path)
+        .with_whatever_context(|_| format!("Failed to parse UKI '{}'", uki_path.display()))?;
+
+    image
+        .remove_signature()
+        .with_whatever_context(|_| "Failed to remove signature".to_string())?;
+
+    image
+        .derive_stub_by_truncating_trailing_sections(TRAILING_SECTIONS_TO_REMOVE)
+        .with_whatever_context(|_| "Failed to derive stub".to_string())?;
+
+    image
+        .write_to(stub_path)
+        .with_whatever_context(|_| format!("Failed to write stub '{}'", stub_path.display()))?;
+
+    eprintln!(
+        "ukisys: stripped signature and trailing sections {:?} from '{}', wrote {} bytes to '{}'",
+        TRAILING_SECTIONS_TO_REMOVE,
+        uki_path.display(),
+        image.bytes.len(),
+        stub_path.display(),
+    );
+
+    Ok(())
+}

--- a/tools/ukisys/src/pe.rs
+++ b/tools/ukisys/src/pe.rs
@@ -1,0 +1,791 @@
+//! Parses and patches the PE32+ COFF image structures of a Unified
+//! Kernel Image: the DOS/PE headers, COFF file header, PE32+ optional
+//! header including the Certificate Table data directory, and section
+//! table, per the Microsoft PE Format specification
+//! (<https://learn.microsoft.com/en-us/windows/win32/debug/pe-format>).
+//!
+//! The UKI section names this module truncates are `.osrel`, `.cmdline`,
+//! `.uname`, and `.linux`. They are defined by the UAPI Group's Unified
+//! Kernel Images specification
+//! (<https://uapi-group.org/specifications/specs/unified_kernel_image/>).
+//!
+//! # Layout reference, PE32+, i.e. `PE32+` optional header magic 0x20B
+//!
+//! ```text
+//! 0x3C                      e_lfanew: u32 LE -- file offset of "PE\0\0"
+//! e_lfanew + 0              "PE\0\0" signature (4 bytes)
+//! e_lfanew + 4              COFF File Header begins
+//!   +4 (=coff+0)            Machine (u16)
+//!   +6  (=coff+2)           NumberOfSections (u16)
+//!   +20 (=coff+16)          SizeOfOptionalHeader (u16)
+//!   +22 (=coff+18)          Characteristics (u16)
+//! e_lfanew + 24             Optional Header begins ("opt")
+//!   opt+0                   Magic (u16) -- must be 0x20B for PE32+
+//!   opt+4                   SizeOfCode (u32)
+//!   opt+8                   SizeOfInitializedData (u32)
+//!   opt+32                  SectionAlignment (u32)
+//!   opt+36                  FileAlignment (u32)
+//!   opt+56                  SizeOfImage (u32)
+//!   opt+60                  SizeOfHeaders (u32)
+//!   opt+64                  CheckSum (u32)
+//!   opt+108                 NumberOfRvaAndSizes (u32)
+//!   opt+112                 DataDirectory[0] begins, 8 bytes/entry:
+//!                             +0 VirtualAddress (u32), +4 Size (u32)
+//!   opt+112 + 4*8           DataDirectory[4] (SECURITY): opt+144 / opt+148
+//! opt + SizeOfOptionalHeader  Section table begins, 40 bytes/entry:
+//!   +0   Name (8 bytes, not necessarily NUL-terminated if 8 chars long)
+//!   +8   VirtualSize (u32)
+//!   +12  VirtualAddress (u32)
+//!   +16  SizeOfRawData (u32)
+//!   +20  PointerToRawData (u32)
+//!   +24  PointerToRelocations (u32)
+//!   +28  PointerToLinenumbers (u32)
+//!   +32  NumberOfRelocations (u16)
+//!   +34  NumberOfLinenumbers (u16)
+//!   +36  Characteristics (u32)
+//! ```
+
+use snafu::{OptionExt, Snafu};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Snafu)]
+pub enum PeError {
+    #[snafu(display("Failed I/O on '{path}': {source}"))]
+    Io {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Bad optional header magic 0x{magic:04x}, expected PE32+ (0x020b)"))]
+    NotPe32Plus { magic: u16 },
+
+    #[snafu(display(
+        "Failed to access {context}: file too short, needed at least {needed} bytes, have {have}"
+    ))]
+    TruncatedFile {
+        needed: usize,
+        have: usize,
+        context: &'static str,
+    },
+
+    #[snafu(display(
+        "Failed to access {context}: offset overflows usize (max valid offset {max}), file is {have} bytes"
+    ))]
+    FileTooLarge {
+        context: &'static str,
+        max: usize,
+        have: usize,
+    },
+
+    #[snafu(display("Failed to set {context}: computed value {value} does not fit in a u32"))]
+    ValueOverflow { context: &'static str, value: u64 },
+
+    #[snafu(display("Missing 'MZ' DOS signature"))]
+    BadDosSignature,
+
+    #[snafu(display("Missing 'PE\\0\\0' signature at e_lfanew"))]
+    BadPeSignature,
+
+    #[snafu(display("Expected trailing sections {expected:?}, found {found:?}"))]
+    UnexpectedTrailingSections {
+        expected: Vec<String>,
+        found: Vec<String>,
+    },
+}
+
+/// One entry from the PE section table, plus its own index and byte offset
+/// within the file, so callers can locate or patch the raw table entry.
+#[derive(Debug, Clone)]
+pub struct Section {
+    pub name: String,
+    pub virtual_size: u32,
+    pub virtual_address: u32,
+    pub pointer_to_raw_data: u32,
+    pub table_entry_offset: usize,
+}
+
+/// A parsed view over an in-memory PE32+ image.
+///
+/// Holds the raw bytes plus the header offsets needed to read or patch
+/// fields in place.
+pub struct PeImage {
+    pub bytes: Vec<u8>,
+    /// Offset of the "PE\0\0" signature.
+    pub pe_offset: usize,
+    /// Offset of the COFF File Header, i.e. `pe_offset + 4`.
+    pub coff_offset: usize,
+    /// Offset of the Optional Header, i.e. `pe_offset + 24`.
+    pub opt_offset: usize,
+    pub size_of_optional_header: u16,
+    pub sections: Vec<Section>,
+}
+
+impl PeImage {
+    /// Loads and parses a PE32+ image from disk.
+    pub fn load(path: &Path) -> Result<Self, PeError> {
+        let bytes = fs::read(path).map_err(|e| PeError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+        Self::parse(bytes)
+    }
+
+    /// Parses a PE32+ image already resident in memory.
+    pub fn parse(bytes: Vec<u8>) -> Result<Self, PeError> {
+        if bytes.len() < 0x40 || &bytes[0..2] != b"MZ" {
+            return Err(PeError::BadDosSignature);
+        }
+
+        let pe_offset = read_u32(&bytes, OFF_E_LFANEW, "e_lfanew")? as usize;
+        let pe_offset_end = pe_offset.checked_add(4).context(FileTooLargeSnafu {
+            context: "PE signature",
+            max: bytes.len().saturating_sub(4),
+            have: bytes.len(),
+        })?;
+        if bytes.len() < pe_offset_end || &bytes[pe_offset..pe_offset_end] != b"PE\0\0" {
+            // Either the file is too short to reach pe_offset_end, which
+            // only a bogus e_lfanew or a genuinely truncated file can
+            // cause, or the file is long enough but those 4 bytes simply
+            // aren't "PE\0\0".
+            return Err(PeError::BadPeSignature);
+        }
+
+        let coff_offset = pe_offset + 4;
+        let num_sections = read_u16(&bytes, coff_offset + COFF_NUM_SECTIONS, "NumberOfSections")?;
+        let size_of_optional_header = read_u16(
+            &bytes,
+            coff_offset + COFF_SIZE_OPT_HDR,
+            "SizeOfOptionalHeader",
+        )?;
+
+        let opt_offset = pe_offset + 24;
+        let magic = read_u16(&bytes, opt_offset + OPT_MAGIC, "OptionalHeader.Magic")?;
+        if magic != PE32_PLUS_MAGIC {
+            return Err(PeError::NotPe32Plus { magic });
+        }
+
+        let section_table_offset = opt_offset + size_of_optional_header as usize;
+        let mut sections = Vec::with_capacity(num_sections as usize);
+        for i in 0..num_sections as usize {
+            // Guard against offset overflow.
+            let entry_offset = i
+                .checked_mul(SECTION_ENTRY_SIZE)
+                .and_then(|span| section_table_offset.checked_add(span))
+                .context(FileTooLargeSnafu {
+                    context: "section table entry",
+                    max: bytes.len().saturating_sub(SECTION_ENTRY_SIZE),
+                    have: bytes.len(),
+                })?;
+            let entry_end =
+                entry_offset
+                    .checked_add(SECTION_ENTRY_SIZE)
+                    .context(FileTooLargeSnafu {
+                        context: "section table entry",
+                        max: bytes.len().saturating_sub(SECTION_ENTRY_SIZE),
+                        have: bytes.len(),
+                    })?;
+            // This entry's offset is larger than the file itself.
+            if entry_end > bytes.len() {
+                return Err(PeError::TruncatedFile {
+                    needed: entry_end,
+                    have: bytes.len(),
+                    context: "section table entry",
+                });
+            }
+            let mut raw_name = [0u8; 8];
+            raw_name.copy_from_slice(&bytes[entry_offset..entry_offset + 8]);
+            let name = decode_section_name(&raw_name);
+            let virtual_size = read_u32(&bytes, entry_offset + 8, "Section.VirtualSize")?;
+            let virtual_address = read_u32(&bytes, entry_offset + 12, "Section.VirtualAddress")?;
+            let pointer_to_raw_data =
+                read_u32(&bytes, entry_offset + 20, "Section.PointerToRawData")?;
+
+            sections.push(Section {
+                name,
+                virtual_size,
+                virtual_address,
+                pointer_to_raw_data,
+                table_entry_offset: entry_offset,
+            });
+        }
+
+        Ok(PeImage {
+            bytes,
+            pe_offset,
+            coff_offset,
+            opt_offset,
+            size_of_optional_header,
+            sections,
+        })
+    }
+
+    /// Reads the Security Directory, which is Data Directory entry 4.
+    pub fn security_directory(&self) -> Result<(u32, u32), PeError> {
+        let dir_offset = self.opt_offset + OPT_DATA_DIRECTORY + SECURITY_DIRECTORY_INDEX * 8;
+        let rva = read_u32(&self.bytes, dir_offset, "SecurityDirectory.VirtualAddress")?;
+        let size = read_u32(&self.bytes, dir_offset + 4, "SecurityDirectory.Size")?;
+        Ok((rva, size))
+    }
+
+    /// Reads `NumberOfSections` from the COFF File Header.
+    pub fn number_of_sections(&self) -> Result<u16, PeError> {
+        read_u16(
+            &self.bytes,
+            self.coff_offset + COFF_NUM_SECTIONS,
+            "NumberOfSections",
+        )
+    }
+
+    /// Reads `SizeOfInitializedData` from the Optional Header.
+    pub fn size_of_initialized_data(&self) -> Result<u32, PeError> {
+        read_u32(
+            &self.bytes,
+            self.opt_offset + OPT_SIZE_OF_INIT_DATA,
+            "SizeOfInitializedData",
+        )
+    }
+
+    /// Reads `SectionAlignment` from the Optional Header.
+    pub fn section_alignment(&self) -> Result<u32, PeError> {
+        read_u32(
+            &self.bytes,
+            self.opt_offset + OPT_SECTION_ALIGNMENT,
+            "SectionAlignment",
+        )
+    }
+
+    /// Removes the Authenticode signature from the image, if present.
+    ///
+    /// An Authenticode signature is not a PE section: it is a certificate
+    /// blob appended after all section data, referenced only by Data
+    /// Directory entry 4, the "Security Directory". Removing it means:
+    ///   1. Clear that directory entry's VirtualAddress and Size to 0.
+    ///   2. Truncate the file so the trailing certificate blob is dropped.
+    pub fn remove_signature(&mut self) -> Result<(), PeError> {
+        let (rva, size) = self.security_directory()?;
+        if size == 0 {
+            return Ok(());
+        }
+        let cert_start = rva as usize;
+        if cert_start > 0 && cert_start < self.bytes.len() {
+            self.bytes.truncate(cert_start);
+        }
+        self.set_security_directory(0, 0)?;
+        Ok(())
+    }
+
+    /// Removes a contiguous run of *trailing* sections from the image,
+    /// which turns removal into a pure truncation rather than a general
+    /// splice, since no kept section's file offset needs to move.
+    ///
+    /// `trailing_names` must exactly match, in order, the last
+    /// `trailing_names.len()` entries of the section table.
+    ///
+    /// On success, patches in place:
+    ///   - `NumberOfSections`: decremented by `trailing_names.len()`
+    ///   - `SizeOfInitializedData`: decremented by the sum of the removed
+    ///     sections' VirtualSize
+    ///   - `SizeOfImage`: set to the last remaining section's
+    ///     VirtualAddress + VirtualSize, rounded up to SectionAlignment
+    ///   - `CheckSum`: set to 0
+    ///
+    /// and removes/zeroes the freed section-table entries.
+    pub fn derive_stub_by_truncating_trailing_sections(
+        &mut self,
+        trailing_names: &[&str],
+    ) -> Result<(), PeError> {
+        let n = trailing_names.len();
+        let total = self.sections.len();
+        if n == 0 || n > total {
+            return Err(PeError::UnexpectedTrailingSections {
+                expected: trailing_names.iter().map(|s| s.to_string()).collect(),
+                found: self.sections.iter().map(|s| s.name.clone()).collect(),
+            });
+        }
+
+        let first_trailing_idx = total - n;
+        let actual_tail: Vec<String> = self.sections[first_trailing_idx..]
+            .iter()
+            .map(|s| s.name.clone())
+            .collect();
+        let expected_tail: Vec<String> = trailing_names.iter().map(|s| s.to_string()).collect();
+        if actual_tail != expected_tail {
+            return Err(PeError::UnexpectedTrailingSections {
+                expected: expected_tail,
+                found: actual_tail,
+            });
+        }
+
+        let truncation_point = self.sections[first_trailing_idx].pointer_to_raw_data as usize;
+
+        let removed_vsize_sum: u64 = self.sections[first_trailing_idx..]
+            .iter()
+            .map(|s| s.virtual_size as u64)
+            .sum();
+
+        self.bytes.truncate(truncation_point);
+
+        // Zeroed for hygiene/determinism even though NumberOfSections will
+        // no longer claim these entries exist. Some trailing entries may
+        // already be gone if their table offset fell within the truncated
+        // region, so skip rather than index out of the shorter buffer.
+        for sec in &self.sections[first_trailing_idx..] {
+            let off = sec.table_entry_offset;
+            if off + SECTION_ENTRY_SIZE > self.bytes.len() {
+                continue;
+            }
+            for b in &mut self.bytes[off..off + SECTION_ENTRY_SIZE] {
+                *b = 0;
+            }
+        }
+
+        let old_num_sections = self.number_of_sections()?;
+        let new_num_sections = old_num_sections - n as u16;
+        self.set_number_of_sections(new_num_sections)?;
+
+        let old_init_data = self.size_of_initialized_data()?;
+        let new_init_data = (old_init_data as u64).saturating_sub(removed_vsize_sum) as u32;
+        self.set_size_of_initialized_data(new_init_data)?;
+
+        let last_remaining = &self.sections[first_trailing_idx - 1];
+        let raw_end = last_remaining.virtual_address as u64 + last_remaining.virtual_size as u64;
+        let section_alignment = self.section_alignment()? as u64;
+        let new_size_of_image = if section_alignment > 0 {
+            raw_end.div_ceil(section_alignment) * section_alignment
+        } else {
+            raw_end
+        };
+        let new_size_of_image =
+            u32::try_from(new_size_of_image).map_err(|_| PeError::ValueOverflow {
+                context: "SizeOfImage",
+                value: new_size_of_image,
+            })?;
+        self.set_size_of_image(new_size_of_image)?;
+
+        // CheckSum is zeroed rather than recomputed, matching `ukify
+        // build`'s own behavior.
+        self.set_checksum(0)?;
+
+        self.sections.truncate(first_trailing_idx);
+
+        Ok(())
+    }
+
+    /// Writes the image's current bytes to disk at `path`.
+    pub fn write_to(&self, path: &Path) -> Result<(), PeError> {
+        fs::write(path, &self.bytes).map_err(|e| PeError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })
+    }
+
+    fn set_security_directory(&mut self, rva: u32, size: u32) -> Result<(), PeError> {
+        let dir_offset = self.opt_offset + OPT_DATA_DIRECTORY + SECURITY_DIRECTORY_INDEX * 8;
+        write_u32(
+            &mut self.bytes,
+            dir_offset,
+            rva,
+            "SecurityDirectory.VirtualAddress",
+        )?;
+        write_u32(
+            &mut self.bytes,
+            dir_offset + 4,
+            size,
+            "SecurityDirectory.Size",
+        )?;
+        Ok(())
+    }
+
+    fn set_number_of_sections(&mut self, value: u16) -> Result<(), PeError> {
+        write_u16(
+            &mut self.bytes,
+            self.coff_offset + COFF_NUM_SECTIONS,
+            value,
+            "NumberOfSections",
+        )
+    }
+
+    fn set_size_of_initialized_data(&mut self, value: u32) -> Result<(), PeError> {
+        write_u32(
+            &mut self.bytes,
+            self.opt_offset + OPT_SIZE_OF_INIT_DATA,
+            value,
+            "SizeOfInitializedData",
+        )
+    }
+
+    fn set_size_of_image(&mut self, value: u32) -> Result<(), PeError> {
+        write_u32(
+            &mut self.bytes,
+            self.opt_offset + OPT_SIZE_OF_IMAGE,
+            value,
+            "SizeOfImage",
+        )
+    }
+
+    fn set_checksum(&mut self, value: u32) -> Result<(), PeError> {
+        write_u32(
+            &mut self.bytes,
+            self.opt_offset + OPT_CHECKSUM,
+            value,
+            "CheckSum",
+        )
+    }
+}
+
+impl std::fmt::Debug for PeImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PeImage")
+            .field("size_bytes", &self.bytes.len())
+            .field("pe_offset", &self.pe_offset)
+            .field("coff_offset", &self.coff_offset)
+            .field("opt_offset", &self.opt_offset)
+            .field("size_of_optional_header", &self.size_of_optional_header)
+            .field("sections", &self.sections)
+            .finish()
+    }
+}
+
+/// Offset of `e_lfanew`, the file offset of the "PE\0\0" signature, in the DOS header.
+const OFF_E_LFANEW: usize = 0x3C;
+/// Offset of `NumberOfSections`, relative to `coff_offset`.
+const COFF_NUM_SECTIONS: usize = 2;
+/// Offset of `SizeOfOptionalHeader`, relative to `coff_offset`.
+const COFF_SIZE_OPT_HDR: usize = 16;
+/// Offset of `Magic`, relative to `opt_offset`.
+const OPT_MAGIC: usize = 0;
+/// Offset of `SizeOfInitializedData`, relative to `opt_offset`.
+const OPT_SIZE_OF_INIT_DATA: usize = 8;
+/// Offset of `SectionAlignment`, relative to `opt_offset`.
+const OPT_SECTION_ALIGNMENT: usize = 32;
+/// Offset of `SizeOfImage`, relative to `opt_offset`.
+const OPT_SIZE_OF_IMAGE: usize = 56;
+/// Offset of `CheckSum`, relative to `opt_offset`.
+const OPT_CHECKSUM: usize = 64;
+/// Offset of `DataDirectory[0]`, relative to `opt_offset`.
+const OPT_DATA_DIRECTORY: usize = 112;
+/// Index of the Security Directory entry within the Data Directory table.
+const SECURITY_DIRECTORY_INDEX: usize = 4;
+/// Size in bytes of one section table entry.
+const SECTION_ENTRY_SIZE: usize = 40;
+/// Optional header `Magic` value identifying a PE32+, 64-bit, image.
+const PE32_PLUS_MAGIC: u16 = 0x020B;
+
+/// Reads a little-endian u16 out of `buf` at `offset`, bounds-checked.
+fn read_u16(buf: &[u8], offset: usize, context: &'static str) -> Result<u16, PeError> {
+    let end = offset.checked_add(2).context(FileTooLargeSnafu {
+        context,
+        max: buf.len().saturating_sub(2),
+        have: buf.len(),
+    })?;
+    if end > buf.len() {
+        return Err(PeError::TruncatedFile {
+            needed: end,
+            have: buf.len(),
+            context,
+        });
+    }
+    Ok(u16::from_le_bytes([buf[offset], buf[offset + 1]]))
+}
+
+/// Reads a little-endian u32 out of `buf` at `offset`, bounds-checked.
+fn read_u32(buf: &[u8], offset: usize, context: &'static str) -> Result<u32, PeError> {
+    let end = offset.checked_add(4).context(FileTooLargeSnafu {
+        context,
+        max: buf.len().saturating_sub(4),
+        have: buf.len(),
+    })?;
+    if end > buf.len() {
+        return Err(PeError::TruncatedFile {
+            needed: end,
+            have: buf.len(),
+            context,
+        });
+    }
+    Ok(u32::from_le_bytes([
+        buf[offset],
+        buf[offset + 1],
+        buf[offset + 2],
+        buf[offset + 3],
+    ]))
+}
+
+/// Writes a little-endian u16 into `buf` at `offset` in place, bounds-checked.
+fn write_u16(
+    buf: &mut [u8],
+    offset: usize,
+    value: u16,
+    context: &'static str,
+) -> Result<(), PeError> {
+    let end = offset.checked_add(2).context(FileTooLargeSnafu {
+        context,
+        max: buf.len().saturating_sub(2),
+        have: buf.len(),
+    })?;
+    if end > buf.len() {
+        return Err(PeError::TruncatedFile {
+            needed: end,
+            have: buf.len(),
+            context,
+        });
+    }
+    buf[offset..end].copy_from_slice(&value.to_le_bytes());
+    Ok(())
+}
+
+/// Writes a little-endian u32 into `buf` at `offset` in place, bounds-checked.
+fn write_u32(
+    buf: &mut [u8],
+    offset: usize,
+    value: u32,
+    context: &'static str,
+) -> Result<(), PeError> {
+    let end = offset.checked_add(4).context(FileTooLargeSnafu {
+        context,
+        max: buf.len().saturating_sub(4),
+        have: buf.len(),
+    })?;
+    if end > buf.len() {
+        return Err(PeError::TruncatedFile {
+            needed: end,
+            have: buf.len(),
+            context,
+        });
+    }
+    buf[offset..end].copy_from_slice(&value.to_le_bytes());
+    Ok(())
+}
+
+/// Decodes an 8-byte PE section name field into a `String`, stopping at the
+/// first NUL.
+fn decode_section_name(raw: &[u8; 8]) -> String {
+    let end = raw.iter().position(|&b| b == 0).unwrap_or(8);
+    String::from_utf8_lossy(&raw[..end]).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a minimal synthetic PE32+ image in memory with the given
+    /// section names/sizes, for testing header arithmetic without needing
+    /// a real UKI on disk. Not a faithful PE, since it has no real code or
+    /// data, just enough structure for the header/section-table logic under
+    /// test.
+    ///
+    /// `section_specs` entries are `(name, virtual_size, virtual_address,
+    /// size_of_raw_data, pointer_to_raw_data)`.
+    fn build_synthetic_pe(section_specs: &[(&str, u32, u32, u32, u32)]) -> Vec<u8> {
+        let num_sections = section_specs.len();
+        let opt_header_size: u16 = 240;
+        let e_lfanew: u32 = 0x80;
+        let coff_offset = e_lfanew as usize + 4;
+        let opt_offset = e_lfanew as usize + 24;
+        let section_table_offset = opt_offset + opt_header_size as usize;
+        let total_size = section_table_offset + num_sections * SECTION_ENTRY_SIZE + 0x2000;
+
+        let mut buf = vec![0u8; total_size];
+        buf[0] = b'M';
+        buf[1] = b'Z';
+        write_u32(&mut buf, OFF_E_LFANEW, e_lfanew, "test").unwrap();
+        buf[e_lfanew as usize..e_lfanew as usize + 4].copy_from_slice(b"PE\0\0");
+        write_u16(
+            &mut buf,
+            coff_offset + COFF_NUM_SECTIONS,
+            num_sections as u16,
+            "test",
+        )
+        .unwrap();
+        write_u16(
+            &mut buf,
+            coff_offset + COFF_SIZE_OPT_HDR,
+            opt_header_size,
+            "test",
+        )
+        .unwrap();
+        write_u16(&mut buf, opt_offset + OPT_MAGIC, PE32_PLUS_MAGIC, "test").unwrap();
+        write_u32(&mut buf, opt_offset + OPT_SECTION_ALIGNMENT, 0x1000, "test").unwrap();
+        write_u32(&mut buf, opt_offset + OPT_SIZE_OF_INIT_DATA, 0, "test").unwrap();
+        write_u32(&mut buf, opt_offset + OPT_CHECKSUM, 0xdead_beef, "test").unwrap();
+
+        let mut total_vsize: u64 = 0;
+        for (i, (name, vsize, vaddr, rawsize, ptr)) in section_specs.iter().enumerate() {
+            let off = section_table_offset + i * SECTION_ENTRY_SIZE;
+            let name_bytes = name.as_bytes();
+            buf[off..off + name_bytes.len().min(8)]
+                .copy_from_slice(&name_bytes[..name_bytes.len().min(8)]);
+            write_u32(&mut buf, off + 8, *vsize, "test").unwrap();
+            write_u32(&mut buf, off + 12, *vaddr, "test").unwrap();
+            write_u32(&mut buf, off + 16, *rawsize, "test").unwrap();
+            write_u32(&mut buf, off + 20, *ptr, "test").unwrap();
+            total_vsize += *vsize as u64;
+        }
+        write_u32(
+            &mut buf,
+            opt_offset + OPT_SIZE_OF_INIT_DATA,
+            total_vsize as u32,
+            "test",
+        )
+        .unwrap();
+
+        buf
+    }
+
+    #[test]
+    fn parses_synthetic_section_table() {
+        // A basic three-section layout should parse into Sections in file order,
+        // with each section's real PointerToRawData preserved.
+        let bytes = build_synthetic_pe(&[
+            (".text", 0x1000, 0x1000, 0x1000, 0x400),
+            (".data", 0x800, 0x2000, 0x800, 0x1400),
+            (".linux", 0x9000, 0x3000, 0x9000, 0x1c00),
+        ]);
+        let img = PeImage::parse(bytes).expect("parse should succeed");
+        let names: Vec<&str> = img.sections.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec![".text", ".data", ".linux"]);
+        let linux_section = img
+            .sections
+            .iter()
+            .find(|s| s.name == ".linux")
+            .expect(".linux section should be present");
+        assert_eq!(linux_section.pointer_to_raw_data, 0x1c00);
+    }
+
+    #[test]
+    fn rejects_non_pe32_plus() {
+        // Overwrite the Magic field with the plain PE32 value 0x010B and
+        // confirm parsing rejects it instead of misreading it as PE32+.
+        let mut bytes = build_synthetic_pe(&[(".text", 0x1000, 0x1000, 0x1000, 0x400)]);
+        let e_lfanew = 0x80usize;
+        let opt_offset = e_lfanew + 24;
+        write_u16(&mut bytes, opt_offset + OPT_MAGIC, 0x010B, "test").unwrap();
+        let err = PeImage::parse(bytes).unwrap_err();
+        assert!(matches!(err, PeError::NotPe32Plus { magic: 0x010B }));
+    }
+
+    #[test]
+    fn truncates_trailing_sections_and_patches_headers() {
+        // Two payload sections, .text and .data, followed by the four UKI
+        // trailing sections that derive-stub is expected to strip.
+        let bytes = build_synthetic_pe(&[
+            (".text", 0x1000, 0x1000, 0x1000, 0x400),
+            (".data", 0x800, 0x2000, 0x800, 0x1400),
+            (".osrel", 0x100, 0x3000, 0x200, 0x1c00),
+            (".cmdline", 0x80, 0x3200, 0x200, 0x1e00),
+            (".uname", 0x40, 0x3400, 0x200, 0x2000),
+            (".linux", 0x9000, 0x3600, 0x9000, 0x2200),
+        ]);
+        let mut img = PeImage::parse(bytes).unwrap();
+        let before_init_data = img.size_of_initialized_data().unwrap();
+
+        img.derive_stub_by_truncating_trailing_sections(&[
+            ".osrel", ".cmdline", ".uname", ".linux",
+        ])
+        .expect("truncation should succeed");
+
+        let names: Vec<&str> = img.sections.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec![".text", ".data"]);
+        assert_eq!(img.number_of_sections().unwrap(), 2);
+        // File is truncated at the first trailing section's raw data pointer.
+        assert_eq!(img.bytes.len(), 0x1c00);
+
+        // SizeOfInitializedData should drop by exactly the sum of the four
+        // removed sections' VirtualSize.
+        let removed_vsize = 0x100 + 0x80 + 0x40 + 0x9000;
+        assert_eq!(
+            img.size_of_initialized_data().unwrap(),
+            before_init_data - removed_vsize
+        );
+
+        let size_of_image = read_u32(&img.bytes, img.opt_offset + OPT_SIZE_OF_IMAGE, "test");
+        assert_eq!(size_of_image.unwrap(), 0x3000);
+        let checksum = read_u32(&img.bytes, img.opt_offset + OPT_CHECKSUM, "test");
+        assert_eq!(checksum.unwrap(), 0);
+    }
+
+    #[test]
+    fn rejects_wrong_trailing_sections() {
+        // Requesting removal of sections that don't match the actual tail
+        // of the section table must fail rather than truncate blindly.
+        let bytes = build_synthetic_pe(&[
+            (".text", 0x1000, 0x1000, 0x1000, 0x400),
+            (".linux", 0x9000, 0x2000, 0x9000, 0x1400),
+        ]);
+        let mut img = PeImage::parse(bytes).unwrap();
+        let err = img
+            .derive_stub_by_truncating_trailing_sections(&[".cmdline", ".uname", ".linux"])
+            .unwrap_err();
+        assert!(matches!(err, PeError::UnexpectedTrailingSections { .. }));
+    }
+
+    #[test]
+    fn security_directory_roundtrip() {
+        // Setting a Security Directory entry and then removing the
+        // signature should truncate the file back to the certificate's
+        // start and clear the directory entry.
+        let bytes = build_synthetic_pe(&[(".text", 0x1000, 0x1000, 0x1000, 0x400)]);
+        let mut img = PeImage::parse(bytes).unwrap();
+        let cert_offset = img.bytes.len() as u32 - 0x400;
+        img.set_security_directory(cert_offset, 0x400).unwrap();
+        let (rva, size) = img.security_directory().unwrap();
+        assert_eq!((rva, size), (cert_offset, 0x400));
+
+        img.remove_signature().unwrap();
+        let (rva2, size2) = img.security_directory().unwrap();
+        assert_eq!((rva2, size2), (0, 0));
+        assert_eq!(img.bytes.len(), cert_offset as usize);
+    }
+
+    #[test]
+    fn read_reports_truncated_file_not_file_too_large() {
+        // An offset that is in-bounds for `usize` but past the end of a
+        // short buffer is a truncated file, not an overflowing offset.
+        let buf = [0u8; 4];
+        let err = read_u32(&buf, 2, "test").unwrap_err();
+        assert!(matches!(
+            err,
+            PeError::TruncatedFile {
+                needed: 6,
+                have: 4,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn read_reports_file_too_large_on_offset_overflow() {
+        // An offset within `checked_add`'s addend of `usize::MAX` cannot be
+        // a valid location in any buffer that fits in memory, so this must
+        // be reported as FileTooLarge rather than reusing TruncatedFile.
+        let buf = [0u8; 4];
+        let err = read_u32(&buf, usize::MAX - 1, "test").unwrap_err();
+        assert!(matches!(
+            err,
+            PeError::FileTooLarge {
+                max: 0,
+                have: 4,
+                ..
+            }
+        ));
+        assert_eq!(
+            err.to_string(),
+            "Failed to access test: offset overflows usize (max valid offset 0), \
+             file is 4 bytes"
+        );
+    }
+
+    #[test]
+    fn write_reports_file_too_large_on_offset_overflow() {
+        let mut buf = [0u8; 4];
+        let err = write_u16(&mut buf, usize::MAX, 0, "test").unwrap_err();
+        assert!(matches!(
+            err,
+            PeError::FileTooLarge {
+                max: 2,
+                have: 4,
+                ..
+            }
+        ));
+    }
+}

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -52,6 +52,7 @@ twoliter-tool-pipesys.workspace = true
 twoliter-tool-pubsys.workspace = true
 twoliter-tool-pubsys-setup.workspace = true
 twoliter-tool-tuftool.workspace = true
+twoliter-tool-ukisys.workspace = true
 twoliter-tool-unplug.workspace = true
 
 [build-dependencies]

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -17,6 +17,7 @@ IN_PLACE_UPDATES="no"
 ENCRYPTED_STORAGE="no"
 EPHEMERAL_ENCRYPTION_KEYS="no"
 STANDALONE_IMAGE="no"
+UKI_IMAGE="no"
 
 for opt in "$@"; do
   optarg="$(expr "${opt}" : '[^=]*=\(.*\)')"
@@ -34,6 +35,7 @@ for opt in "$@"; do
   --with-uefi-secure-boot=*) UEFI_SECURE_BOOT="${optarg}" ;;
   --with-in-place-updates=*) IN_PLACE_UPDATES="${optarg}" ;;
   --with-standalone-image=*) STANDALONE_IMAGE="${optarg}" ;;
+  --with-uki-image=*) UKI_IMAGE="${optarg}" ;;
   *)
     echo "unexpected arg: ${opt}" >&2
     exit 1
@@ -109,6 +111,168 @@ write_partition() {
   fi
 }
 
+# Reassemble the Unified Kernel Image for a UKI-format image.
+#
+# The UKI is the only EFI input for the rebuild. The root filesystem is not
+# consulted. The only thing that comes from outside the UKI is the new
+# dm-verity table.
+#
+# Must be called after the new root verity has been generated.
+#
+# Args:
+#   $1: path to the extracted boot filesystem tree
+#   $2: the new dm-verity table, as a single space-separated string
+repack_uki() {
+  local boot_mount dm_verity_table
+  boot_mount="${1:?}"
+  dm_verity_table="${2:?}"
+
+  local uki
+  uki="${boot_mount}/EFI/Linux/bottlerocket.efi"
+  if [[ ! -s "${uki}" ]]; then
+    echo "no UKI found at '${uki}'" >&2
+    exit 1
+  fi
+
+  local stage
+  stage="$(mktemp -p "${WORKDIR}" -d uki.XXXXXXXXXX)"
+
+  # Recover the build inputs from the sections of the existing UKI. The
+  # recovered kernel replaces the loose copy on the boot partition.
+  local kernel old_cmdline_file os_release uname_file old_sbat_file
+  kernel="${boot_mount}/vmlinuz"
+  old_cmdline_file="${stage}/cmdline"
+  os_release="${stage}/os-release"
+  uname_file="${stage}/uname"
+  old_sbat_file="${stage}/sbat"
+  ukify inspect "${uki}" --section=".linux:binary@${kernel}"
+  ukify inspect "${uki}" --section=".cmdline:binary@${old_cmdline_file}"
+  ukify inspect "${uki}" --section=".osrel:binary@${os_release}"
+  ukify inspect "${uki}" --section=".uname:binary@${uname_file}"
+  ukify inspect "${uki}" --section=".sbat:binary@${old_sbat_file}"
+
+  # `ukify build` refuses a signed stub, so derive one from the UKI.
+  local stub
+  stub="${stage}/linux.efi.stub"
+  "${0%/*}/ukisys" derive-stub "${uki}" "${stub}"
+
+  # Resign the recovered kernel. `sign_vmlinuz` runs `undo_sign` first to strip
+  # the signature applied when the image was built, so repacking does not
+  # append another one and grow the kernel.
+  if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
+    sign_vmlinuz "${kernel}"
+  fi
+
+  # Substitute the new verity table into the recovered command line. img2img is
+  # not given the variant's kernel parameters, so everything other than
+  # `dm-mod.create=` is carried over from the UKI unchanged. Matching on the
+  # literal quote characters is deliberate: the table contains spaces, so the
+  # quotes are part of the command line itself.
+  local old_cmdline
+  old_cmdline="$(tr -d '\0' <"${old_cmdline_file}")"
+  if [[ "${old_cmdline}" != *'dm-mod.create="'* ]]; then
+    echo "no 'dm-mod.create=' in the kernel command line of '${uki}'" >&2
+    exit 1
+  fi
+  local cmdline_prefix cmdline_suffix new_cmdline
+  cmdline_prefix="${old_cmdline%%dm-mod.create=\"*}"
+  cmdline_suffix="${old_cmdline#*dm-mod.create=\"}"
+  cmdline_suffix="${cmdline_suffix#*\"}"
+  new_cmdline="${cmdline_prefix}dm-mod.create=\"${dm_verity_table}\"${cmdline_suffix}"
+
+  local kernel_version
+  kernel_version="$(tr -d '\0' <"${uname_file}")"
+  if [[ -z "${kernel_version}" ]]; then
+    echo "no kernel version in the '.uname' section of '${uki}'" >&2
+    exit 1
+  fi
+
+  # Reassemble. No measured-boot options are passed: predicted PCR values are
+  # not supported for these images.
+  #
+  # --sbat: a single-line placeholder, not new SBAT content. ukify merges in
+  # the stub's carried-over `.sbat` regardless. Omitting this flag lets ukify
+  # inject its own extra default entry instead, failing the cmp below.
+  local new_uki
+  new_uki="${stage}/bottlerocket.efi"
+  ukify build \
+    --stub "${stub}" \
+    --linux "${kernel}" \
+    --cmdline "${new_cmdline}" \
+    --uname "${kernel_version}" \
+    --os-release @"${os_release}" \
+    --sbat 'sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md' \
+    --output "${new_uki}"
+
+  # Sign the assembled UKI, keeping the existing pesign and NSS plumbing in
+  # charge of the keys.
+  if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
+    sign_systemd_boot "${new_uki}"
+  fi
+
+  # Validate before the new UKI replaces the old one. A UKI that lost a section,
+  # or that still carries the previous verity table, would boot a kernel that
+  # cannot find its root filesystem, so treat either as fatal.
+  local section extracted
+  for section in .linux .cmdline .uname .osrel .sbat; do
+    extracted="${stage}/verify${section}"
+    if ! ukify inspect "${new_uki}" --section="${section}:binary@${extracted}" ||
+      [[ ! -s "${extracted}" ]]; then
+      echo "assembled UKI has no '${section}' section" >&2
+      exit 1
+    fi
+  done
+  if [[ "$(tr -d '\0' <"${stage}/verify.cmdline")" != "${new_cmdline}" ]]; then
+    echo "assembled UKI does not carry the new kernel command line" >&2
+    exit 1
+  fi
+
+  # Confirm the rebuilt `.sbat` matches the original, rather than assuming it.
+  if ! cmp -s "${old_sbat_file}" "${stage}/verify.sbat"; then
+    echo "assembled UKI's '.sbat' section does not match the original" >&2
+    exit 1
+  fi
+
+  mv "${new_uki}" "${uki}"
+
+  # The HMAC has to cover the final signed bytes of the repacked UKI, so
+  # generate it after the UKI is in its final place. The token is relative to
+  # check-kernel-integrity.service's WorkingDirectory=/boot.
+  generate_hmac "${uki}" "EFI/Linux/bottlerocket.efi"
+
+  # The kernel is now embedded in the UKI's .linux PE section, so the
+  # standalone kernel image is no longer needed and must not be shipped.
+  # The .bottlerocket.efi.hmac file generated above is left in place, as it
+  # is still copied into the boot partition below.
+  rm -f "${kernel}"
+}
+
+# Rebuild the FAT boot partition image for a UKI-format image.
+#
+# The image is rebuilt from scratch: only the files copied in below are
+# carried over, so leftover files from the original filesystem are not.
+#
+# Args:
+#   $1: path to the extracted boot filesystem tree
+#   $2: path of the boot partition image to create
+#   $3: size of the boot partition, in MiB
+mkfs_boot_uki() {
+  local boot_mount boot_image bootpart_mib
+  boot_mount="${1:?}"
+  boot_image="${2:?}"
+  bootpart_mib="${3:?}"
+
+  rm -f "${boot_image}"
+  dd if=/dev/zero of="${boot_image}" bs=1M count="${bootpart_mib}"
+  mkfs.vfat -I -S 512 "${boot_image}" $((bootpart_mib * 1024))
+  mmd -i "${boot_image}" ::/EFI
+  mmd -i "${boot_image}" ::/EFI/Linux
+  mcopy -i "${boot_image}" "${boot_mount}/EFI/Linux/bottlerocket.efi" ::/EFI/Linux/
+  if [[ -f "${boot_mount}/EFI/Linux/.bottlerocket.efi.hmac" ]]; then
+    mcopy -i "${boot_image}" "${boot_mount}/EFI/Linux/.bottlerocket.efi.hmac" ::/EFI/Linux/
+  fi
+}
+
 # Import the partition helper functions.
 # shellcheck source=partyplanner
 . "${0%/*}/partyplanner"
@@ -144,6 +308,11 @@ if [[ "${STANDALONE_IMAGE}" == "yes" ]]; then
   fi
 fi
 
+if [[ "${UKI_IMAGE}" == "yes" && "${IN_PLACE_UPDATES}" == "yes" ]]; then
+  echo "\`image-format = \"uki\"\` is incompatible with 'in-place-updates'" >&2
+  exit 1
+fi
+
 ###############################################################################
 # Section 1: prepare working environment
 
@@ -166,14 +335,19 @@ SELINUX_FILE_CONTEXTS="${ROOT_MOUNT}/${SELINUX_ROOT}/${SELINUX_POLICY}/contexts/
 
 # Collect partition sizes and offsets from the partition plan.
 # The caller is responsible for resolving any feature-dependent default
-# for OS_IMAGE_SIZE_GIB (e.g., 1 GiB when `standalone-image = true`) before invoking
-# this script; we use the value as-is. See `resolved_image_layout` in
+# for OS_IMAGE_SIZE_GIB, e.g. 1 GiB when `standalone-image = true`, before invoking
+# this script. We use the value as-is. See `resolved_image_layout` in
 # `tools/buildsys/src/manifest.rs` for the canonical resolver.
 declare -A partsize partoff
 set_partition_sizes \
   "${OS_IMAGE_SIZE_GIB}" "${DATA_IMAGE_SIZE_GIB}" \
   "${PARTITION_PLAN}" "${IN_PLACE_UPDATES}" \
   partsize partoff "${STANDALONE_IMAGE}"
+
+# Collect the partition labels, which are needed to look a partition up in the
+# GPT of the image we were given.
+declare -A partlabel
+set_partition_labels partlabel
 
 # Process and stage the input images to the working directory.
 declare OS_IMAGE DATA_IMAGE
@@ -226,7 +400,12 @@ fi
 # Extract the boot partition from the OS image, and dump the contents.
 dd if="${OS_IMAGE}" of="${BOOT_IMAGE}" \
   count="${partsize["BOOT-A"]}" bs=1M skip="${partoff["BOOT-A"]}"
-debugfs -R "rdump / ${BOOT_MOUNT}" "${BOOT_IMAGE}"
+if [[ "${UKI_IMAGE}" == "yes" ]]; then
+  # UKI images have a FAT boot partition, which `debugfs` cannot read.
+  mcopy -i "${BOOT_IMAGE}" -sv "::/" "${BOOT_MOUNT}/"
+else
+  debugfs -R "rdump / ${BOOT_MOUNT}" "${BOOT_IMAGE}"
+fi
 
 # Extract the EFI partition from the OS image and dump the contents, if needed.
 if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
@@ -280,10 +459,23 @@ else
   root_usage=$(get_ext4_usage "${ROOT_IMAGE}" "ROOT-A")
 fi
 
+# For UKI images, BOOT-A's PARTUUID is fixed for the life of
+# the image, and the repacked image keeps the partition table it came with.
+# Capture it so it can be baked into the .cmdline PE section.
+BOOT_PARTUUID=""
+if [[ "${UKI_IMAGE}" == "yes" ]]; then
+  BOOT_PARTUUID="$(get_partition_uuid "${OS_IMAGE}" "${partlabel["BOOT-A"]}")"
+fi
+
 # Generate a new root verity.
 declare -a DM_VERITY_ROOT
-generate_verity_root "${ROOT_IMAGE}" "${VERITY_IMAGE}" \
-  "${partsize["HASH-A"]}" DM_VERITY_ROOT
+if [[ "${UKI_IMAGE}" == "yes" ]]; then
+  generate_verity_root "${ROOT_IMAGE}" "${VERITY_IMAGE}" \
+    "${partsize["HASH-A"]}" DM_VERITY_ROOT "${BOOT_PARTUUID}"
+else
+  generate_verity_root "${ROOT_IMAGE}" "${VERITY_IMAGE}" \
+    "${partsize["HASH-A"]}" DM_VERITY_ROOT
+fi
 
 # Validate and write root verity back to the OS image. The image size check
 # isn't needed here as it's already done in `generate_verity_root`.
@@ -294,10 +486,11 @@ write_partition "${VERITY_IMAGE}" "${OS_IMAGE}" "${partoff["HASH-A"]}"
 
 if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
   pushd "${EFI_MOUNT}/EFI/BOOT" >/dev/null
+  # The shim was renamed to the platform-defined default boot path,
+  # `boot*.efi`, by `rpm2img`, regardless of which bootloader it
+  # chain-loads.
   shims=(boot*.efi)
   shim="${shims[0]}"
-  grubs=(grub*.efi)
-  grub="${grubs[0]}"
   mokms=(mm*.efi)
   mokm="${mokms[0]}"
 
@@ -309,7 +502,16 @@ if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
   # Resign the EFI artifacts.
   sign_shim "${shim}"
   sign_mokm "${mokm}"
-  sign_grub "${grub}"
+  if [[ "${UKI_IMAGE}" == "yes" ]]; then
+    # UKI images carry systemd-boot next to the shim instead of grub.
+    systemd_boots=(systemd-boot*.efi)
+    systemd_boot="${systemd_boots[0]}"
+    sign_systemd_boot "${systemd_boot}"
+  else
+    grubs=(grub*.efi)
+    grub="${grubs[0]}"
+    sign_grub "${grub}"
+  fi
 
   # Write the resigned artifacts back to the EFI image.
   mcopy -i "${EFI_IMAGE}" -ov "${EFI_MOUNT}/EFI/BOOT"/*.efi ::/EFI/BOOT
@@ -323,32 +525,43 @@ if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
   check_image_size "${EFI_IMAGE}" "${partsize["EFI-A"]}"
   write_partition "${EFI_IMAGE}" "${OS_IMAGE}" "${partoff["EFI-A"]}"
 
-  # Resign the kernel and write to boot image.
-  sign_vmlinuz "${BOOT_MOUNT}/vmlinuz"
-  debugfs_replace "${BOOT_IMAGE}" "${BOOT_MOUNT}/vmlinuz" vmlinuz
+  # Resign the kernel and write to boot image. UKI images are handled in
+  # section 6 instead: there the kernel is a payload section of the UKI, which
+  # has to be taken apart and reassembled anyway, and BOOT-A is FAT so
+  # `debugfs_replace` does not apply.
+  if [[ "${UKI_IMAGE}" != "yes" ]]; then
+    sign_vmlinuz "${BOOT_MOUNT}/vmlinuz"
+    debugfs_replace "${BOOT_IMAGE}" "${BOOT_MOUNT}/vmlinuz" vmlinuz
 
-  # Generate a new HMAC for the kernel after signing and write to boot image.
-  generate_hmac "${BOOT_MOUNT}/vmlinuz"
-  debugfs_replace "${BOOT_IMAGE}" "${BOOT_MOUNT}/.vmlinuz.hmac" .vmlinuz.hmac
+    # Generate a new HMAC for the kernel after signing and write to boot image.
+    generate_hmac "${BOOT_MOUNT}/vmlinuz"
+    debugfs_replace "${BOOT_IMAGE}" "${BOOT_MOUNT}/.vmlinuz.hmac" .vmlinuz.hmac
+  fi
 fi
 
 ###############################################################################
 # Section 6: update boot partition
 
-GRUB_CONFIG="${BOOT_MOUNT}/grub/grub.cfg"
+if [[ "${UKI_IMAGE}" == "yes" ]]; then
+  # No GRUB or grub.cfg to patch: rebuild the UKI and boot partition instead.
+  repack_uki "${BOOT_MOUNT}" "${DM_VERITY_ROOT[*]}"
+  mkfs_boot_uki "${BOOT_MOUNT}" "${BOOT_IMAGE}" "${partsize["BOOT-A"]}"
+else
+  GRUB_CONFIG="${BOOT_MOUNT}/grub/grub.cfg"
 
-# Replace the dm-verity root with the new verity.
-sed -i \
-  "s:^set dm_verity_root=.*:set dm_verity_root=\"${DM_VERITY_ROOT[*]}\":g" \
-  "${GRUB_CONFIG}"
+  # Replace the dm-verity root with the new verity.
+  sed -i \
+    "s:^set dm_verity_root=.*:set dm_verity_root=\"${DM_VERITY_ROOT[*]}\":g" \
+    "${GRUB_CONFIG}"
 
-# Replace grub.cfg on the boot image.
-debugfs_replace "${BOOT_IMAGE}" "${GRUB_CONFIG}" /grub/grub.cfg
+  # Replace grub.cfg on the boot image.
+  debugfs_replace "${BOOT_IMAGE}" "${GRUB_CONFIG}" /grub/grub.cfg
 
-# Sign the grub.cfg and replace the signature on the boot image, if needed.
-if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
-  sign_grubcfg "${GRUB_CONFIG}"
-  debugfs_replace "${BOOT_IMAGE}" "${GRUB_CONFIG}.sig" /grub/grub.cfg.sig
+  # Sign the grub.cfg and replace the signature on the boot image, if needed.
+  if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
+    sign_grubcfg "${GRUB_CONFIG}"
+    debugfs_replace "${BOOT_IMAGE}" "${GRUB_CONFIG}.sig" /grub/grub.cfg.sig
+  fi
 fi
 
 # Write the boot image back to the OS image.
@@ -356,13 +569,18 @@ check_image_size "${BOOT_IMAGE}" "${partsize["BOOT-A"]}"
 write_partition "${BOOT_IMAGE}" "${OS_IMAGE}" "${partoff["BOOT-A"]}"
 
 # Report BOOT partition usage
-boot_usage=$(get_ext4_usage "${BOOT_IMAGE}" "BOOT-A")
+if [[ "${UKI_IMAGE}" == "yes" ]]; then
+  boot_usage=$(get_fat_usage "${BOOT_IMAGE}" "BOOT-A" "${partsize["BOOT-A"]}")
+else
+  boot_usage=$(get_ext4_usage "${BOOT_IMAGE}" "BOOT-A")
+fi
 
 # Combine usage data into final JSON
 echo "${root_usage}" "${boot_usage}" | jq -s 'add | {disk_usage: .}' > "${OUTPUT_DIR}/artifact-metadata.json"
 
 # Predict PCR values after all signing is complete.
-if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
+# Skipped for UKI images, matching `rpm2img`.
+if [[ "${UEFI_SECURE_BOOT}" == "yes" && "${UKI_IMAGE}" == "no" ]]; then
   "${0%/*}/pcrsys" disk \
     --image "${OS_IMAGE}" \
     --efi-vars "${SBKEYS}/efi-vars.json" \
@@ -399,6 +617,13 @@ elif [[ "${OUTPUT_FMT}" == "vmdk" ]]; then
   if [[ -s "${DATA_IMAGE}" ]]; then
     symlink_image "vmdk" "data_image" "${OUTPUT_DIR}"
   fi
+elif [[ "${OUTPUT_FMT}" == "uki" ]]; then
+  # UKI uses raw disk format. "uki" here refers to boot layout, not disk format.
+  compress_image "img.lz4" "os_image" "${OUTPUT_DIR}"
+  symlink_image "img.lz4" "os_image" "${OUTPUT_DIR}"
+  if [[ -s "${DATA_IMAGE}" ]]; then
+    symlink_image "img.lz4" "data_image" "${OUTPUT_DIR}"
+  fi
 fi
 
 # Create the OVA if needed.
@@ -415,11 +640,20 @@ if [[ "${OUTPUT_FMT}" == "vmdk" ]]; then
 fi
 
 # Compress and symlink the rest.
-compress_image "ext4.lz4" "boot_image" "${OUTPUT_DIR}"
+# BOOT-A is FAT for UKI images, see mkfs_boot_uki above, and ext4 otherwise.
+if [[ "${UKI_IMAGE}" == "yes" ]]; then
+  compress_image "fat.lz4" "boot_image" "${OUTPUT_DIR}"
+else
+  compress_image "ext4.lz4" "boot_image" "${OUTPUT_DIR}"
+fi
 compress_image "verity.lz4" "verity_image" "${OUTPUT_DIR}"
 compress_image "ext4.lz4" "root_image" "${OUTPUT_DIR}"
 
-symlink_image "ext4.lz4" "boot_image" "${OUTPUT_DIR}"
+if [[ "${UKI_IMAGE}" == "yes" ]]; then
+  symlink_image "fat.lz4" "boot_image" "${OUTPUT_DIR}"
+else
+  symlink_image "ext4.lz4" "boot_image" "${OUTPUT_DIR}"
+fi
 symlink_image "verity.lz4" "verity_image" "${OUTPUT_DIR}"
 symlink_image "ext4.lz4" "root_image" "${OUTPUT_DIR}"
 

--- a/twoliter/embedded/imghelper
+++ b/twoliter/embedded/imghelper
@@ -464,6 +464,30 @@ get_erofs_usage() {
     '{($partition): {bytes_total: $bytes_total, bytes_used: $bytes_used, bytes_remaining: $bytes_remaining, percentage_bytes: $percentage_bytes}}'
 }
 
+# FAT has no dumpe2fs equivalent, so this measures usage from mtools' real
+# free cluster accounting via `mdir -s` instead of summing file sizes.
+get_fat_usage() {
+  local image_file partition_name partition_size_mib
+  local free_bytes total_bytes used_bytes bytes_remaining percentage_bytes
+  image_file="${1:?}"
+  partition_name="${2:?}"
+  partition_size_mib="${3:?}"
+
+  free_bytes="$(mdir -i "${image_file}" -s ::/ | grep "bytes free" | tr -d ' ' | grep -oE '^[0-9]+')"
+  total_bytes="$((partition_size_mib * 1024 * 1024))"
+  used_bytes="$((total_bytes - free_bytes))"
+  bytes_remaining="${free_bytes}"
+  percentage_bytes="$((used_bytes * 100 / total_bytes))"
+
+  jq -n \
+    --arg partition "${partition_name}" \
+    --argjson bytes_total "${total_bytes}" \
+    --argjson bytes_used "${used_bytes}" \
+    --argjson bytes_remaining "${bytes_remaining}" \
+    --argjson percentage_bytes "${percentage_bytes}" \
+    '{($partition): {bytes_total: $bytes_total, bytes_used: $bytes_used, bytes_remaining: $bytes_remaining, percentage_bytes: $percentage_bytes}}'
+}
+
 # Read back the real GPT unique partition GUID for a named partition from an
 # already-partitioned image. Must be called after sgdisk has created the
 # partition table (so the UUID exists to read).

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -801,18 +801,8 @@ if [[ "${UKI_IMAGE}" == "yes" ]]; then
   fi
   dd if="${BOOT_IMAGE}" of="${OS_IMAGE}" conv=notrunc bs=1M seek="${partoff["BOOT-A"]}"
 
-  # Report BOOT partition usage for vfat (use file size as approximation)
-  boot_used=$(stat -c %s "${BOOT_MOUNT}/EFI/Linux/bottlerocket.efi")
-  boot_total=$((partsize["BOOT-A"] * 1024 * 1024))
-  boot_remaining=$((boot_total - boot_used))
-  boot_percent=$((boot_used * 100 / boot_total))
-  boot_usage=$(jq -n \
-    --arg partition "BOOT-A" \
-    --argjson bytes_total "${boot_total}" \
-    --argjson bytes_used "${boot_used}" \
-    --argjson bytes_remaining "${boot_remaining}" \
-    --argjson percentage_bytes "${boot_percent}" \
-    '{($partition): {bytes_total: $bytes_total, bytes_used: $bytes_used, bytes_remaining: $bytes_remaining, percentage_bytes: $percentage_bytes}}')
+  # Report BOOT partition usage
+  boot_usage=$(get_fat_usage "${BOOT_IMAGE}" "BOOT-A" "${partsize["BOOT-A"]}")
 else
   mkdir -p "${BOOT_MOUNT}/lost+found"
   chmod -R go-rwx "${BOOT_MOUNT}"

--- a/twoliter/embedded/tests/test_esp_loader_config.sh
+++ b/twoliter/embedded/tests/test_esp_loader_config.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Test how the EFI system partition is populated for UKI images:
+#
+#   1. `provide_loader_config` in `imghelper` copies the systemd-boot
+#      configuration from the ESP staging directory into `\loader\loader.conf`
+#      on the FAT-formatted EFI image, byte for byte.
+#   2. A missing configuration file is not fatal: `provide_loader_config`
+#      warns and returns success, because systemd-boot falls back to its
+#      compiled-in defaults and the rest of the ESP is intact.
+#   3. `rpm2img` calls `provide_loader_config` only for UKI images, since
+#      GRUB does not read `\loader\loader.conf`.
+#   4. `rpm2img` still copies the loader binaries into `::/EFI/BOOT`, which is
+#      where shim looks for its second stage. The shim package is built with
+#      `DEFAULT_LOADER=systemd-boot<arch>.efi`, an unqualified name that shim
+#      resolves in its own directory, so the systemd-boot binary has to sit
+#      next to the shim rather than in `::/EFI/systemd`.
+#
+# Complements:
+#   - `test_partyplanner.sh`: partition-layout math.
+#   - `test_rpm2eif_args.sh`: EIF flag validation.
+#   - `test_guest_images_helper.sh`: artifact suffix allowlist.
+#
+# Run from the repo root:
+#   bash twoliter/embedded/tests/test_esp_loader_config.sh
+
+set -eu -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EMBEDDED_DIR="${SCRIPT_DIR}/.."
+IMGHELPER="${EMBEDDED_DIR}/imghelper"
+RPM2IMG="${EMBEDDED_DIR}/rpm2img"
+
+for f in "${IMGHELPER}" "${RPM2IMG}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "test_esp_loader_config: required file not found: ${f}" >&2
+    exit 1
+  fi
+done
+
+pass_count=0
+fail_count=0
+
+pass() { pass_count=$((pass_count + 1)); echo "  ok: $1"; }
+fail() { fail_count=$((fail_count + 1)); echo "  FAIL: $1" >&2; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+# Stand in for the FAT32 EFI-A partition image that `rpm2img` builds with
+# `mkfs.vfat`. `mformat` is used here because it needs no privileges and comes
+# from the same `mtools` package as the `mmd`/`mcopy` calls under test.
+make_efi_image() {
+  local image
+  image="${1:?}"
+  dd if=/dev/zero of="${image}" bs=1M count=8 status=none
+  mformat -i "${image}" -F -v EFI ::
+  mmd -i "${image}" ::/EFI
+  mmd -i "${image}" ::/EFI/BOOT
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: provide_loader_config copies loader.conf to ::/loader unchanged.
+# ---------------------------------------------------------------------------
+efi_mount="${tmp}/efi_mount"
+mkdir -p "${efi_mount}/EFI/BOOT" "${efi_mount}/loader"
+cat >"${efi_mount}/loader/loader.conf" <<'EOF'
+# systemd-boot configuration
+timeout 0
+editor no
+secure-boot-enroll off
+EOF
+
+efi_image="${tmp}/efi.img"
+make_efi_image "${efi_image}"
+
+(
+  VERSION_ID=x BUILD_ID=x IMAGE_NAME=x VARIANT=x ARCH=x86_64
+  # shellcheck disable=SC1090
+  . "${IMGHELPER}"
+  provide_loader_config "${efi_image}" "${efi_mount}"
+) && rc=0 || rc=$?
+
+if [[ "${rc}" -ne 0 ]]; then
+  fail "provide_loader_config returned ${rc} with a loader.conf present"
+else
+  got="${tmp}/loader.conf.roundtrip"
+  if mcopy -i "${efi_image}" -o "::/loader/loader.conf" "${got}" 2>/dev/null &&
+    cmp -s "${efi_mount}/loader/loader.conf" "${got}"; then
+    pass "provide_loader_config copies loader.conf to ::/loader unchanged"
+  else
+    fail "loader.conf missing from ::/loader or altered in transit"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: the configuration lands at ::/loader/loader.conf and nowhere else.
+# systemd-boot reads only that path, and only from the volume it was loaded
+# from, so a copy under ::/EFI/BOOT would be silently ignored.
+# ---------------------------------------------------------------------------
+if mdir -i "${efi_image}" -b "::/EFI/BOOT" 2>/dev/null | grep -qi "loader.conf"; then
+  fail "loader.conf was copied into ::/EFI/BOOT, where systemd-boot never looks"
+else
+  pass "loader.conf is not placed in ::/EFI/BOOT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: a missing loader.conf warns but does not fail the image build.
+# ---------------------------------------------------------------------------
+bare_mount="${tmp}/bare_mount"
+mkdir -p "${bare_mount}/EFI/BOOT"
+bare_image="${tmp}/bare.img"
+make_efi_image "${bare_image}"
+
+out=$(
+  VERSION_ID=x BUILD_ID=x IMAGE_NAME=x VARIANT=x ARCH=x86_64 \
+    bash -c "
+    set -eu -o pipefail
+    . '${IMGHELPER}'
+    provide_loader_config '${bare_image}' '${bare_mount}'
+  " 2>&1
+) && rc=0 || rc=$?
+
+if [[ "${rc}" -eq 0 && "${out}" == *"no systemd-boot configuration found"* ]]; then
+  pass "provide_loader_config warns and succeeds when loader.conf is absent"
+else
+  fail "absent loader.conf should warn and succeed; rc=${rc} out: ${out}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: rpm2img calls provide_loader_config, and only for UKI images.
+# ---------------------------------------------------------------------------
+if grep -q 'provide_loader_config "${EFI_IMAGE}" "${EFI_MOUNT}"' "${RPM2IMG}"; then
+  # The call must sit inside a `UKI_IMAGE == yes` guard; check the nearest
+  # preceding conditional.
+  guard=$(grep -B5 'provide_loader_config' "${RPM2IMG}" | grep -E 'if \[\[.*UKI_IMAGE' || true)
+  if [[ -n "${guard}" && "${guard}" == *'"yes"'* ]]; then
+    pass "rpm2img calls provide_loader_config under a UKI_IMAGE guard"
+  else
+    fail "rpm2img calls provide_loader_config outside a UKI_IMAGE == yes guard"
+  fi
+else
+  fail "rpm2img does not call provide_loader_config with EFI_IMAGE and EFI_MOUNT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: rpm2img still copies the loader binaries next to the shim, where
+# shim's compiled-in DEFAULT_LOADER expects to find systemd-boot.
+# ---------------------------------------------------------------------------
+if grep -q 'mcopy -i "${EFI_IMAGE}" "${EFI_MOUNT}/EFI/BOOT"/\*\.efi ::/EFI/BOOT' "${RPM2IMG}"; then
+  pass "rpm2img copies EFI binaries into ::/EFI/BOOT alongside the shim"
+else
+  fail 'rpm2img no longer copies ${EFI_MOUNT}/EFI/BOOT/*.efi into ::/EFI/BOOT'
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "test_esp_loader_config: ${pass_count} passed, ${fail_count} failed"
+[[ "${fail_count}" -eq 0 ]]

--- a/twoliter/embedded/tests/test_fat_usage.sh
+++ b/twoliter/embedded/tests/test_fat_usage.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Test `get_fat_usage` in `imghelper`:
+#
+#   1. The emitted JSON is keyed by the given partition name and carries
+#      exactly the same fields, in the same order, as `get_erofs_usage` and
+#      `get_ext4_usage`, since all three feed the same
+#      `jq -s 'add | {disk_usage: .}'` merge in `img2img` and `rpm2img`.
+#   2. `bytes_total` is computed from the partition size argument rather than
+#      read back from the image file, matching the `get_erofs_usage`
+#      signature.
+#   3. `bytes_used` reflects real FAT allocation accounting rather than a
+#      single file's size, so it rises when a file is added to the image.
+#
+# Run from the repo root:
+#   bash twoliter/embedded/tests/test_fat_usage.sh
+
+set -eu -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMGHELPER="${SCRIPT_DIR}/../imghelper"
+
+if [[ ! -f "${IMGHELPER}" ]]; then
+  echo "test_fat_usage: imghelper not found at ${IMGHELPER}" >&2
+  exit 1
+fi
+
+# imghelper's top-level `${VAR:?}` expansions require these to be set before
+# it can be sourced, even though this test only exercises `get_fat_usage`.
+IMAGE_NAME=x VARIANT=x ARCH=x86_64 VERSION_ID=x BUILD_ID=x
+export IMAGE_NAME VARIANT ARCH VERSION_ID BUILD_ID
+# shellcheck source=../imghelper
+. "${IMGHELPER}"
+
+pass_count=0
+fail_count=0
+
+pass() { pass_count=$((pass_count + 1)); echo "  ok: $1"; }
+fail() { fail_count=$((fail_count + 1)); echo "  FAIL: $1" >&2; }
+assert_eq() {
+  local got want label
+  got="$1"
+  want="$2"
+  label="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    pass "${label}"
+  else
+    fail "${label}: got '${got}', want '${want}'"
+  fi
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+# Stand in for the FAT32 BOOT-A image that `mkfs_boot_uki` builds with
+# `mkfs.vfat`. `mformat` is used here because it needs no privileges and comes
+# from the same `mtools` package as the `mdir` call under test.
+part_mib=20
+image="${tmp}/boot.img"
+dd if=/dev/zero of="${image}" bs=1M count="${part_mib}" status=none
+mformat -i "${image}" -F -v BOOTA ::
+mmd -i "${image}" ::/EFI
+mmd -i "${image}" ::/EFI/Linux
+
+# ---------------------------------------------------------------------------
+# Test 1: shape and keys match get_erofs_usage's output for the same
+# partition name and size, with only bytes_used and its dependents differing.
+# ---------------------------------------------------------------------------
+usage="$(get_fat_usage "${image}" "BOOT-A" "${part_mib}")"
+
+partition_key="$(echo "${usage}" | jq -r 'keys[0]')"
+assert_eq "${partition_key}" "BOOT-A" "output is keyed by the given partition name"
+
+fields="$(echo "${usage}" | jq -r '.["BOOT-A"] | keys | join(",")')"
+assert_eq "${fields}" "bytes_remaining,bytes_total,bytes_used,percentage_bytes" "output has exactly the four expected fields"
+
+bytes_total="$(echo "${usage}" | jq -r '.["BOOT-A"].bytes_total')"
+assert_eq "${bytes_total}" "$((part_mib * 1024 * 1024))" "bytes_total is partition_size_mib times 1024 times 1024"
+
+# ---------------------------------------------------------------------------
+# Test 2: bytes_used, bytes_remaining, and percentage_bytes are internally
+# consistent with bytes_total, and bytes_used is nonzero even though no
+# regular file has been copied in yet, since directory entries and reserved
+# regions already consume space.
+# ---------------------------------------------------------------------------
+bytes_used="$(echo "${usage}" | jq -r '.["BOOT-A"].bytes_used')"
+bytes_remaining="$(echo "${usage}" | jq -r '.["BOOT-A"].bytes_remaining')"
+percentage_bytes="$(echo "${usage}" | jq -r '.["BOOT-A"].percentage_bytes')"
+
+assert_eq "$((bytes_used + bytes_remaining))" "${bytes_total}" "bytes_used plus bytes_remaining equals bytes_total"
+assert_eq "${percentage_bytes}" "$((bytes_used * 100 / bytes_total))" "percentage_bytes is the truncating integer percent of bytes_used"
+
+if [[ "${bytes_used}" -gt 0 ]]; then
+  pass "bytes_used is nonzero before any file is copied in, reflecting FAT overhead"
+else
+  fail "bytes_used should be nonzero due to reserved sectors, FAT tables, and directory entries"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: bytes_used increases once a file is copied into the image, and by
+# at least the file's own size.
+# ---------------------------------------------------------------------------
+dd if=/dev/urandom of="${tmp}/bottlerocket.efi" bs=1K count=500 status=none
+mcopy -i "${image}" "${tmp}/bottlerocket.efi" ::/EFI/Linux/
+
+usage_after="$(get_fat_usage "${image}" "BOOT-A" "${part_mib}")"
+bytes_used_after="$(echo "${usage_after}" | jq -r '.["BOOT-A"].bytes_used')"
+
+if [[ "${bytes_used_after}" -ge "$((bytes_used + 500 * 1024))" ]]; then
+  pass "bytes_used grows by at least the copied file's size"
+else
+  fail "bytes_used_after (${bytes_used_after}) should be at least bytes_used (${bytes_used}) plus the file size"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "test_fat_usage: ${pass_count} passed, ${fail_count} failed"
+[[ "${fail_count}" -eq 0 ]]

--- a/twoliter/src/tool-crates/ukisys/Cargo.toml
+++ b/twoliter/src/tool-crates/ukisys/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "twoliter-tool-ukisys"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+ukisys.workspace = true
+include-env-compressed.workspace = true
+
+[lints]
+workspace = true

--- a/twoliter/src/tool-crates/ukisys/src/lib.rs
+++ b/twoliter/src/tool-crates/ukisys/src/lib.rs
@@ -1,0 +1,4 @@
+use include_env_compressed::{include_archive_from_env, Archive};
+
+/// Compressed archive containing the built `ukisys` binary.
+pub const UKISYS: Archive = include_archive_from_env!("CARGO_BIN_FILE_UKISYS");

--- a/twoliter/src/tools.rs
+++ b/twoliter/src/tools.rs
@@ -60,6 +60,7 @@ pub(crate) async fn install_tools(tools_dir: impl AsRef<Path>) -> Result<()> {
             &dir,
             mtime,
         ),
+        write_bin("ukisys", twoliter_tool_ukisys::UKISYS.reader(), &dir, mtime),
         write_bin(
             "eif-builder",
             twoliter_tool_eif_builder::EIF_BUILD_BIN.reader(),
@@ -170,6 +171,7 @@ async fn test_install_tools() {
     assert!(toolsdir.join("pubsys").is_file());
     assert!(toolsdir.join("pubsys-setup").is_file());
     assert!(toolsdir.join("tuftool").is_file());
+    assert!(toolsdir.join("ukisys").is_file());
     assert!(toolsdir.join("unplug").is_file());
 
     // Check that the mtimes match.


### PR DESCRIPTION
**Description of changes:**

This PR complements: https://github.com/bottlerocket-os/twoliter/pull/701 and closes the gap to support re-pack workflows with UKIs.

A new binary (ukisys) is provided, to extract the `stub` from the compiled UKI. This is needed to offer the same experience like in other re-pack workflows: all the artifacts used to build the final image come from the cracked-open rootfs and UKIs.

**Testing done:**

- Ran the `re-pack` workflow against a local build, using a custom certificate and new signing keys
- Publish the AMIs with the re-packed artifacts
- AMI booted, and cryptographic material matched that of the new keys


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
