### PR TITLE
chore: prepare for release 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.23.0-rc1...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.23.0...HEAD
 
-## [0.23.0-rc1] - 2026-08-19
+## [0.23.0] - 2026-08-19
 
 ### Breaking Changes
 * `testsys` is now officially deprecated and removed from the twoliter binary. ([#697])
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#724]: https://github.com/bottlerocket-os/twoliter/pull/724
 [#725]: https://github.com/bottlerocket-os/twoliter/pull/725
 
-[0.23.0-rc1]: https://github.com/bottlerocket-os/twoliter/compare/v0.22.1...v0.23.0-rc1
+[0.23.0]: https://github.com/bottlerocket-os/twoliter/compare/v0.22.1...v0.23.0
 
 ## [0.22.1] - 2026-08-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.23.0-rc1"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 serde-templated = { version = "0.1", path = "tools/serde-templated" }
 serde-templated-derive = { version = "0.1", path = "tools/serde-templated-derive" }
 
-twoliter = { version = "0.23.0-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.23.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
 twoliter-tool-advisory-checker = { version = "0.1", path = "twoliter/src/tool-crates/advisory-checker" }
 twoliter-tool-buildsys = { version = "0.1", path = "twoliter/src/tool-crates/buildsys" }
 twoliter-tool-eif-builder = { version = "0.1", path = "twoliter/src/tool-crates/eif-builder" }

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.23.0-rc1"
+version = "0.23.0"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Prep for version 0.23.0 release


**Testing done:**
- https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1011
- https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/530
- Built Bottlerocket AMIs and confirmed instances boot successfully across variants and architectures:
  - `aws-k8s-1.34` (x86_64)
  - `aws-k8s-1.36-nvidia` (aarch64)
- Ran the `repack-variant` on `aws-k8s-1.36-nvidia` (aarch64) successfully
```
cargo make \
  -e BUILDSYS_VARIANT=aws-k8s-1.36-nvidia \
  -e BUILDSYS_ARCH=aarch64 \
  -e BUILDSYS_CACERTS_BUNDLE_OVERRIDE=/tmp/custom-ca-bundle.crt \
  repack-variant
...
[cargo-make][1] INFO - Running Task: cargo-metadata
[cargo-make][1] INFO - Running Task: repack-variant
[cargo-make][1] INFO - Build Done in 49.02 seconds.
[cargo-make] INFO - Build Done in 50.12 seconds.
```
Registered the repacked image and boot, confirmed the overridden CA bundle was present in `/etc/pki/tls/certs/ca-bundle.crt` on the running host.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
