### PR TITLE
chore: prepare for release 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.24.0-rc1...HEAD
+[unreleased]: https://github.com/bottlerocket-os/twoliter/compare/v0.24.0...HEAD
 
-## [0.24.0-rc1] - 2026-08-28
+## [0.24.0] - 2026-08-28
 
 ### Added
 * Add support for signing and repacking EIFs ([#715], [#716], [#717], [#718], [#719], [#720], [#731])
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#730]: https://github.com/bottlerocket-os/twoliter/pull/730
 [#731]: https://github.com/bottlerocket-os/twoliter/pull/731
 
-[0.24.0-rc1]: https://github.com/bottlerocket-os/twoliter/compare/v0.23.0...v0.24.0-rc1
+[0.24.0]: https://github.com/bottlerocket-os/twoliter/compare/v0.23.0...v0.24.0
 
 ## [0.23.0] - 2026-08-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "twoliter"
-version = "0.24.0-rc1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ pubsys-setup = { version = "0.1", path = "tools/pubsys-setup", artifact = [ "bin
 serde-templated = { version = "0.1", path = "tools/serde-templated" }
 serde-templated-derive = { version = "0.1", path = "tools/serde-templated-derive" }
 
-twoliter = { version = "0.24.0-rc1", path = "twoliter", artifact = [ "bin:twoliter" ] }
+twoliter = { version = "0.24.0", path = "twoliter", artifact = [ "bin:twoliter" ] }
 twoliter-tool-advisory-checker = { version = "0.1", path = "twoliter/src/tool-crates/advisory-checker" }
 twoliter-tool-buildsys = { version = "0.1", path = "twoliter/src/tool-crates/buildsys" }
 twoliter-tool-eif-builder = { version = "0.1", path = "twoliter/src/tool-crates/eif-builder" }

--- a/twoliter/Cargo.toml
+++ b/twoliter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twoliter"
-version = "0.24.0-rc1"
+version = "0.24.0"
 edition = "2021"
 description = "A command line tool for creating custom builds of Bottlerocket"
 authors = ["Matthew James Briggs <brigmatt@amazon.com>"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

prepare for release 0.24.0

**Testing done:**

RC builds in first commits to

* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1026
* https://github.com/bottlerocket-os/bottlerocket/pull/4918
* https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/538


Built and launched aws-ecs-2 for both x86_64 and aarch64.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
