### PR TITLE
fix: install ca certs from SDK in EIFs

### DIFF
--- a/twoliter/embedded/rpm2eif
+++ b/twoliter/embedded/rpm2eif
@@ -426,6 +426,9 @@ BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
 DOCUMENTATION_URL="https://bottlerocket.dev"
 EOF
 
+echo "=== Installing CA certificates ==="
+install_ca_certs "${INSTALL_ROOT}"
+
 echo "=== Creating rootfs.erofs ==="
 # Remove only the top-level /boot from rootfs (kernel is shipped separately).
 [[ -d "${INSTALL_ROOT}/boot" ]] && rm -rf "${INSTALL_ROOT}/boot"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

install CA certs from the SDK in `rpm2eif`

**Testing done:**

* `make build`
* built image with `image-format = "eif"`. mounted rootfs, checked `/tmp/check-eif-ca/usr/share/factory/etc/pki/tls/certs/`, checked that rule in `tmp/check-eif-ca/usr/lib/tmpfiles.d/release-ca-certificates.conf` copies as expected


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
