### PR TITLE
fix: install guest artifacts as real files with mode 0644

### DIFF
--- a/tests/integration-tests/src/guest_images_helper.rs
+++ b/tests/integration-tests/src/guest_images_helper.rs
@@ -16,7 +16,8 @@ fn helper_path() -> PathBuf {
 /// build. Includes:
 ///   - the bootable image artifacts that should be copied (standard + EIF)
 ///   - the build-metadata files that must NOT be copied (the bug we're guarding against)
-///   - a stable-name symlink (`os_image.img.lz4` -> `bottlerocket-…img.lz4`)
+///   - stable-name symlinks (`os_image.img.lz4`, `latest.eif`, `latest-disk.img`,
+///     `latest-kernel`) that must be dereferenced
 fn populate_synthetic_guest_dir(dir: &Path) {
     // Bootable artifacts (these are the ones that SHOULD be copied).
     for f in [
@@ -49,6 +50,16 @@ fn populate_synthetic_guest_dir(dir: &Path) {
     std::os::unix::fs::symlink(
         "bottlerocket-inner-x86_64-1.0.0-0.eif",
         dir.join("latest.eif"),
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(
+        "bottlerocket-inner-x86_64-1.0.0-0-disk.img",
+        dir.join("latest-disk.img"),
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(
+        "bottlerocket-inner-x86_64-1.0.0-0-kernel",
+        dir.join("latest-kernel"),
     )
     .unwrap();
 
@@ -133,6 +144,8 @@ fn test_copy_guest_image_artifacts_filters_metadata_and_sboms() {
         "bottlerocket-inner-x86_64-1.0.0-0-kernel",
         "os_image.img.lz4",
         "latest.eif",
+        "latest-disk.img",
+        "latest-kernel",
     ] {
         assert!(
             copied.iter().any(|n| n == required),
@@ -157,19 +170,34 @@ fn test_copy_guest_image_artifacts_filters_metadata_and_sboms() {
         );
     }
 
-    // The symlink must remain a symlink (so its target name is preserved verbatim) and
-    // must point at one of the real artifacts in the same directory.
-    let symlink_meta = std::fs::symlink_metadata(dst.join("os_image.img.lz4")).unwrap();
-    assert!(
-        symlink_meta.file_type().is_symlink(),
-        "os_image.img.lz4 should remain a symlink at the destination"
-    );
-    let target = std::fs::read_link(dst.join("os_image.img.lz4")).unwrap();
-    assert_eq!(
-        target.to_string_lossy(),
-        "bottlerocket-inner-x86_64-1.0.0-0.img.lz4",
-        "symlink target should be preserved verbatim"
-    );
+    // Symlinks must be dereferenced — the destination must contain regular files,
+    // not symlinks, so the host rootfs has self-contained artifacts.
+    for name in [
+        "os_image.img.lz4",
+        "latest.eif",
+        "latest-disk.img",
+        "latest-kernel",
+    ] {
+        let meta = std::fs::symlink_metadata(dst.join(name)).unwrap();
+        assert!(
+            meta.file_type().is_file(),
+            "{name} should be a regular file at the destination, not a symlink"
+        );
+    }
+
+    // All copied artifacts must have mode 0644 (world-readable).
+    use std::os::unix::fs::PermissionsExt;
+    for entry in std::fs::read_dir(&dst).unwrap() {
+        let entry = entry.unwrap();
+        let mode = entry.metadata().unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode,
+            0o644,
+            "{:?} should have mode 0644, got {:o}",
+            entry.file_name(),
+            mode
+        );
+    }
 }
 
 /// If a guest directory holds no recognizable image artifacts, the helper returns non-zero so

--- a/twoliter/embedded/guest-images-helper
+++ b/twoliter/embedded/guest-images-helper
@@ -15,13 +15,12 @@ if [[ -z "${IMAGE_ARTIFACT_SUFFIXES+x}" ]]; then
   exit 1
 fi
 
-# Copy bootable image artifacts (and their stable-name symlinks) from `${1}`
-# into `${2}`, rejecting build metadata such as `*.json` and `*-sbom-*`.
+# Copy bootable image artifacts from `${1}` into `${2}`, rejecting build
+# metadata such as `*.json` and `*-sbom-*`.
 #
 # Returns 0 on success, 1 if no matching artifacts were found. Robust to spaces
-# in filenames; preserves symlinks so that e.g.
-# `os_image.img.lz4 -> bottlerocket-…img.lz4` continues to resolve at the
-# destination.
+# in filenames. Symlinks (e.g. `latest.eif`) are dereferenced and installed as
+# regular files with mode 0644 so they are world-readable in the host rootfs.
 copy_guest_image_artifacts() {
   local src="${1}"
   local dst="${2}"
@@ -43,7 +42,7 @@ copy_guest_image_artifacts() {
   find_args+=( \) -print0 )
   local copied=0 file
   while IFS= read -r -d '' file; do
-    if cp -a "${file}" "${dst}/"; then
+    if install -p -m 0644 "${file}" "${dst}/"; then
       copied=$((copied + 1))
     else
       echo "guest-images: failed to copy '${file}' to '${dst}/'" >&2

--- a/twoliter/embedded/tests/test_guest_images_helper.sh
+++ b/twoliter/embedded/tests/test_guest_images_helper.sh
@@ -152,6 +152,8 @@ touch "${src}/bottlerocket-1.0.0.eif"
 touch "${src}/bottlerocket-1.0.0-disk.img"
 touch "${src}/bottlerocket-1.0.0-kernel"
 ln -s "bottlerocket-1.0.0.eif" "${src}/latest.eif"
+ln -s "bottlerocket-1.0.0-disk.img" "${src}/latest-disk.img"
+ln -s "bottlerocket-1.0.0-kernel" "${src}/latest-kernel"
 touch "${src}/application-inventory.json"
 touch "${src}/spdx-sbom.json"
 touch "${src}/artifact-metadata.json"
@@ -171,7 +173,7 @@ else
   # Verify allowlisted artifacts landed at the destination.
   wanted=("bottlerocket-1.0.0.img.lz4" "bottlerocket-1.0.0.ext4.lz4" "os_image.img.lz4"
           "bottlerocket-1.0.0.eif" "bottlerocket-1.0.0-disk.img" "bottlerocket-1.0.0-kernel"
-          "latest.eif")
+          "latest.eif" "latest-disk.img" "latest-kernel")
   missing=""
   for f in "${wanted[@]}"; do
     [[ -e "${dst}/${f}" ]] || missing+=" ${f}"
@@ -182,14 +184,29 @@ else
   for f in "${unwanted[@]}"; do
     [[ -e "${dst}/${f}" ]] && leaked+=" ${f}"
   done
-  # Verify the symlink was preserved as a symlink (not dereferenced).
-  sym_ok="yes"
-  [[ -L "${dst}/os_image.img.lz4" ]] || sym_ok="no"
+  # Verify that symlinks were dereferenced — they must be regular files, not
+  # symlinks, so the host rootfs contains self-contained artifacts.
+  deref_ok="yes"
+  for f in "os_image.img.lz4" "latest.eif" "latest-disk.img" "latest-kernel"; do
+    if [[ -L "${dst}/${f}" ]]; then
+      deref_ok="no"
+    elif [[ ! -f "${dst}/${f}" ]]; then
+      deref_ok="no"
+    fi
+  done
+  # Verify that all copied artifacts have mode 0644.
+  mode_ok="yes"
+  while IFS= read -r -d '' f; do
+    perms="$(stat -c '%a' "${f}")"
+    if [[ "${perms}" != "644" ]]; then
+      mode_ok="no"
+    fi
+  done < <(find "${dst}" -maxdepth 1 -type f -print0)
 
-  if [[ -z "${missing}" && -z "${leaked}" && "${sym_ok}" == "yes" ]]; then
-    pass "copy_guest_image_artifacts copies allowlisted files, drops metadata, preserves symlinks"
+  if [[ -z "${missing}" && -z "${leaked}" && "${deref_ok}" == "yes" && "${mode_ok}" == "yes" ]]; then
+    pass "copy_guest_image_artifacts copies allowlisted files, drops metadata, dereferences symlinks, mode 0644"
   else
-    fail "copy_guest_image_artifacts had issues:${missing:+ missing:${missing}}${leaked:+ leaked:${leaked}}${sym_ok:+ symlink_ok=${sym_ok}}"
+    fail "copy_guest_image_artifacts had issues:${missing:+ missing:${missing}}${leaked:+ leaked:${leaked}}${deref_ok:+ deref_ok=${deref_ok}}${mode_ok:+ mode_ok=${mode_ok}}"
   fi
 fi
 

--- a/twoliter/src/tool-crates/embedded-bundle/tests/guest_images_helper.rs
+++ b/twoliter/src/tool-crates/embedded-bundle/tests/guest_images_helper.rs
@@ -10,8 +10,8 @@
 //! * every `compress_image "<ext>"` call site in `rpm2img` and `img2img`
 //!   uses a declared suffix;
 //! * `copy_guest_image_artifacts` copies allowlisted files, drops
-//!   sidecar metadata (SBOM, inventory, artifact-metadata), and
-//!   preserves symlinks.
+//!   metadata (SBOM, inventory, artifact-metadata),
+//!   dereferences symlinks, and sets mode 0644.
 //!
 //! This Rust wrapper exists so the bash tests run under `cargo test`
 //! alongside the other embedded-bundle and buildsys tests.


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #743

**Description of changes:**

Replace `cp -a` with `install -p -m 0644` in copy_guest_image_artifacts so embedded guest image artifacts are world-readable in the host rootfs instead of inheriting restrictive modes (e.g. 0600 from mktemp).

This also dereferences symlinks: the stable-name entries produced by rpm2eif (latest.eif, latest-disk.img, latest-kernel) are now copied as regular files rather than preserved as symlinks.

**Testing done:**

* `make build`
* local test project with a guest `image-format = "eif"` in a parent variant, embedded artifacts given `0644`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
