### PR TITLE
Update PCR calculations to support UKI

### DIFF
--- a/tools/pcrsys/src/gpt.rs
+++ b/tools/pcrsys/src/gpt.rs
@@ -87,7 +87,7 @@ impl From<GptPrio> for u64 {
 /// Information about a single GPT partition.
 ///
 /// Contains the partition number and LBA range for calculating byte offsets.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PartitionInfo {
     /// 1-based partition number.
     pub number: u32,
@@ -151,20 +151,36 @@ const BOTTLEROCKET_PRIVATE: [u8; 16] = uuid_to_guid(hex!("440408bb eb0b 4328 a6e
 /// EFI System Partition type GUID.
 const EFI_SYSTEM_PARTITION: [u8; 16] = uuid_to_guid(hex!("c12a7328 f81f 11d2 ba4b 00a0c93ec93b"));
 
-/// Get the unique GUID of the first boot partition (BOOT-A).
+/// Whether a partition type GUID denotes a dedicated Bottlerocket boot partition.
+fn is_boot_type(guid: &[u8; 16]) -> bool {
+    guid == &BOTTLEROCKET_BOOT
+}
+
+/// Get the unique GUID of the boot partition.
+///
+/// For the grub layout this is the first dedicated Bottlerocket boot partition
+/// (BOOT-A). For the merged UKI layout there is no dedicated boot partition, so
+/// the ESP is the boot partition.
 pub fn get_boot_partuuid<R: Read + Seek>(disk: &mut R) -> Result<String> {
     let gpt = GPT::find_from(disk).whatever_context("failed to parse GPT")?;
     let (_, part) = gpt
         .iter()
-        .find(|(_, p)| p.partition_type_guid == BOTTLEROCKET_BOOT)
-        .whatever_context("BOOT-A partition not found")?;
+        .find(|(_, p)| is_boot_type(&p.partition_type_guid))
+        .or_else(|| {
+            gpt.iter()
+                .find(|(_, p)| p.partition_type_guid == EFI_SYSTEM_PARTITION)
+        })
+        .whatever_context("boot partition not found")?;
     Ok(Uuid::from_bytes_le(part.unique_partition_guid).to_string())
 }
 
 /// Find partitions by type GUID and return their layout.
 ///
 /// Parses GPT to find EFI-A, BOOT-A, BOOT-B (optional), and PRIVATE partitions.
-/// Single-bank images will not have BOOT-B.
+/// The grub layout has dedicated Bottlerocket-boot-typed BOOT-A/BOOT-B partitions.
+/// The UKI layout has no dedicated boot partition — the ESP holds the boot
+/// material — so `boot_a` resolves to the ESP (EFI-A) and `boot_b` is `None`.
+/// Single-bank grub images will not have BOOT-B either.
 pub fn find_partitions<R: Read + Seek>(disk: &mut R) -> Result<PartitionLayout> {
     let gpt = GPT::find_from(disk).whatever_context("failed to parse GPT")?;
 
@@ -180,9 +196,24 @@ pub fn find_partitions<R: Read + Seek>(disk: &mut R) -> Result<PartitionLayout> 
             })
     };
 
+    // Find nth dedicated boot partition (grub layout). The merged UKI layout has
+    // none, so callers fall back to the ESP.
+    let find_nth_boot = |n: usize| -> Option<PartitionInfo> {
+        gpt.iter()
+            .filter(|(_, p)| is_boot_type(&p.partition_type_guid))
+            .nth(n)
+            .map(|(num, p)| PartitionInfo {
+                number: num,
+                start_lba: p.starting_lba,
+                end_lba: p.ending_lba,
+            })
+    };
+
     let efi_a = find_nth(&EFI_SYSTEM_PARTITION, 0).whatever_context("EFI-A partition not found")?;
-    let boot_a = find_nth(&BOTTLEROCKET_BOOT, 0).whatever_context("BOOT-A partition not found")?;
-    let boot_b = find_nth(&BOTTLEROCKET_BOOT, 1); // Optional for single-bank
+    // grub: dedicated BOOT-A. merged UKI: no dedicated boot partition, so the ESP
+    // itself is the boot partition.
+    let boot_a = find_nth_boot(0).unwrap_or_else(|| efi_a.clone());
+    let boot_b = find_nth_boot(1); // Optional for single-bank / merged UKI
     let private =
         find_nth(&BOTTLEROCKET_PRIVATE, 0).whatever_context("PRIVATE partition not found")?;
 
@@ -532,15 +563,28 @@ mod tests {
     }
 
     #[test]
-    fn test_find_partitions_missing_boot() {
+    fn test_find_partitions_merged_uki_esp_is_boot() {
+        // UKI layout: no dedicated boot partition. The ESP holds the boot
+        // material, so find_partitions must resolve `boot_a` to the ESP (EFI-A)
+        // and get_boot_partuuid must return the ESP's unique GUID.
         let mut disk = mock_disk_with_partitions();
         disk[1024 + 128..1024 + 128 + 16].copy_from_slice(&[0u8; 16]);
         disk[1024 + 256..1024 + 256 + 16].copy_from_slice(&[0u8; 16]);
         recalc_disk_crcs(&mut disk);
 
         let mut cursor = Cursor::new(&disk[..]);
-        let err = find_partitions(&mut cursor).unwrap_err();
-        assert!(err.to_string().contains("BOOT-A"));
+        let layout = find_partitions(&mut cursor).unwrap();
+        // ESP is partition 1; boot_a falls back to it.
+        assert_eq!(layout.efi_a.number, 1);
+        assert_eq!(layout.boot_a.number, 1);
+        assert_eq!(layout.boot_a.start_lba, layout.efi_a.start_lba);
+        assert!(layout.boot_b.is_none());
+        assert_eq!(layout.private.number, 4);
+
+        let mut cursor = Cursor::new(&disk[..]);
+        // get_boot_partuuid must resolve to the ESP's unique GUID (0x11 in the mock).
+        let uuid = get_boot_partuuid(&mut cursor).unwrap();
+        assert_eq!(uuid, Uuid::from_bytes_le([0x11; 16]).to_string());
     }
 
     #[test]

--- a/tools/pcrsys/src/main.rs
+++ b/tools/pcrsys/src/main.rs
@@ -172,12 +172,32 @@ fn predict_pcrs(
 ) -> Result<PcrPredictions> {
     let gpt_bin = gpt::extract_primary_gpt(disk)?;
     let partitions = gpt::find_partitions(disk)?;
-    let shim = diskfs::extract_shim(disk, &partitions)?;
-    let grub = diskfs::extract_grub(disk, &partitions)?;
-    let vmlinuz = diskfs::extract_vmlinuz(disk, &partitions)?;
-    let grub_cfg = diskfs::extract_grub_cfg(disk, &partitions)?;
-    let bootconfig = diskfs::extract_bootconfig(disk, &partitions)?;
     let boot_partuuid = gpt::get_boot_partuuid(disk)?;
+
+    // The ESP removable-media fallback path (EFI/BOOT/BOOT{X64,AA64}.EFI) holds
+    // either a shim (grub variants) or the signed UKI (uki-image variants).
+    let boot_efi = diskfs::extract_shim(disk, &partitions)?;
+    let is_uki = pe::is_uki(&boot_efi);
+
+    // grub/vmlinuz/grub.cfg/bootconfig exist only in the shim->grub->vmlinuz
+    // layout. A direct-UKI image embeds the kernel and cmdline in the single UKI
+    // on the ESP (no dedicated BOOT-A), so those files are absent.
+    let (shim, uki, grub, vmlinuz, grub_cfg, bootconfig) = if is_uki {
+        (
+            Vec::new(),
+            boot_efi,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+    } else {
+        let grub = diskfs::extract_grub(disk, &partitions)?;
+        let vmlinuz = diskfs::extract_vmlinuz(disk, &partitions)?;
+        let grub_cfg = diskfs::extract_grub_cfg(disk, &partitions)?;
+        let bootconfig = diskfs::extract_bootconfig(disk, &partitions)?;
+        (boot_efi, Vec::new(), grub, vmlinuz, grub_cfg, bootconfig)
+    };
 
     let ctx = PcrContext::builder()
         .platform(platform)
@@ -185,6 +205,7 @@ fn predict_pcrs(
         .partitions(&partitions)
         .gpt_bin(&gpt_bin)
         .shim(&shim)
+        .uki(&uki)
         .grub(&grub)
         .vmlinuz(&vmlinuz)
         .grub_cfg(&grub_cfg)

--- a/tools/pcrsys/src/pcrs/pcr14.rs
+++ b/tools/pcrsys/src/pcrs/pcr14.rs
@@ -9,7 +9,14 @@ use sha2::{Digest, Sha256};
 /// Predict PCR 14 value.
 ///
 /// PCR 14 = extend(MokList ESL) -> extend(MokListX ESL) -> extend(MokListTrusted)
+///
+/// Returns `None` for a direct-UKI boot: MOK variables are populated and
+/// measured by shim, which is absent in the uki-image layout.
 pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
+    if !ctx.uki.is_empty() {
+        return Ok(None);
+    }
+
     let vendor_cert = extract_vendor_cert(ctx.shim)?;
 
     // MokList: X509 ESL containing vendor certificate
@@ -34,7 +41,7 @@ pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
 mod tests {
     use super::*;
     use crate::platform::Platform;
-    use crate::predict::test_support::{build_test_shim, MockCtx};
+    use crate::predict::test_support::{build_test_shim, build_test_uki, MockCtx};
 
     #[test]
     fn test_predict() {
@@ -66,5 +73,19 @@ mod tests {
             .build();
         let err = predict(&ctx).unwrap_err();
         assert!(err.to_string().contains("PE32+") || err.to_string().contains("parse"));
+    }
+
+    #[test]
+    fn test_predict_skipped_for_uki() {
+        // Direct-UKI boot has no shim and therefore no MOK measurements.
+        let uki = build_test_uki();
+        let m = MockCtx::new();
+        let ctx = PcrContext::builder()
+            .platform(Platform::Aws)
+            .efi_vars(&m.efi_vars)
+            .partitions(&m.layout)
+            .uki(&uki)
+            .build();
+        assert!(predict(&ctx).unwrap().is_none());
     }
 }

--- a/tools/pcrsys/src/pcrs/pcr4.rs
+++ b/tools/pcrsys/src/pcrs/pcr4.rs
@@ -12,16 +12,18 @@ use crate::predict::{
 ///
 /// AWS/Metal extend an action string before the separator, VMware does not.
 ///
+/// Shim->grub->vmlinuz layout:
 /// AWS/Metal: action -> separator -> shim -> grub -> vmlinuz
 /// VMware:              separator -> shim -> grub -> vmlinuz
+///
+/// UKI layout: firmware loads exactly one EFI application,
+/// the signed UKI, so only that single image is measured:
+/// AWS/Metal: action -> separator -> uki
+/// VMware:              separator -> uki
 pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
     if ctx.partitions.boot_b.is_some() {
         return Ok(None);
     }
-
-    let shim_hash = get_authenticode_hash(ctx.shim)?;
-    let grub_hash = get_authenticode_hash(ctx.grub)?;
-    let vmlinuz_hash = get_authenticode_hash(ctx.vmlinuz)?;
 
     // AWS/Metal: action string first, VMware: start with zeros
     let mut pcr = match ctx.platform {
@@ -30,12 +32,19 @@ pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
         }
         Platform::Vmware => PCR_INIT_VAL,
     };
-
-    // Common: separator -> shim -> grub -> vmlinuz
     pcr = extend_pcr_separator(&pcr);
-    pcr = extend_pcr(&pcr, &shim_hash);
-    pcr = extend_pcr(&pcr, &grub_hash);
-    pcr = extend_pcr(&pcr, &vmlinuz_hash);
+
+    if !ctx.uki.is_empty() {
+        let uki_hash = get_authenticode_hash(ctx.uki)?;
+        pcr = extend_pcr(&pcr, &uki_hash);
+    } else {
+        let shim_hash = get_authenticode_hash(ctx.shim)?;
+        let grub_hash = get_authenticode_hash(ctx.grub)?;
+        let vmlinuz_hash = get_authenticode_hash(ctx.vmlinuz)?;
+        pcr = extend_pcr(&pcr, &shim_hash);
+        pcr = extend_pcr(&pcr, &grub_hash);
+        pcr = extend_pcr(&pcr, &vmlinuz_hash);
+    }
 
     Ok(Some((PcrIndex::Pcr4, PcrRecord::new(pcr))))
 }
@@ -43,7 +52,7 @@ pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::predict::test_support::{build_test_shim, MockCtx};
+    use crate::predict::test_support::{build_test_shim, build_test_uki, MockCtx};
 
     #[test]
     fn test_predict_aws() {
@@ -98,5 +107,26 @@ mod tests {
             .vmlinuz(&pe)
             .build();
         assert!(predict(&ctx).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_predict_uki_aws() {
+        // Direct-UKI layout: only the single UKI application is measured
+        // (action -> separator -> uki), with no shim/grub/vmlinuz.
+        let uki = build_test_uki();
+        let m = MockCtx::new();
+        let ctx = PcrContext::builder()
+            .platform(Platform::Aws)
+            .efi_vars(&m.efi_vars)
+            .partitions(&m.layout)
+            .uki(&uki)
+            .build();
+        let result = predict(&ctx).unwrap().unwrap();
+        assert_eq!(result.0, PcrIndex::Pcr4);
+
+        assert_eq!(
+            result.1.sha256[0],
+            "b918b81b1a860c3934a6117896c5fcb3a92f210e9201793f4045a686bb5e8b14"
+        );
     }
 }

--- a/tools/pcrsys/src/pcrs/pcr7.rs
+++ b/tools/pcrsys/src/pcrs/pcr7.rs
@@ -24,16 +24,30 @@ const VMWARE_SIGNATURE_OWNER_GUID: [u8; 16] = [
 /// 1. SecureBoot variable (0x01)
 /// 2. PK, KEK, db, dbx variables
 /// 3. Separator
-/// 4. db authority (certificate used to verify shim)
-/// 5. SbatLevel (from shim's .sbatlevel section)
-/// 6. MokListRT (vendor certificate from shim)
+/// 4. db authority (certificate used to verify the loaded image)
+/// 5. SbatLevel (from shim's .sbatlevel section) — shim chain only
+/// 6. MokListRT (vendor certificate from shim) — shim chain only
+///
+/// Direct-UKI layout (uki-image): firmware verifies the UKI against `db`
+/// directly with no shim in the chain, so the shim-specific SbatLevel and
+/// MokListRT measurements (5 and 6) are absent.
 ///
 /// Platform differences:
 /// - AWS/Metal: uses SignatureOwner GUID from efi-vars.json
 /// - VMware: uses VMware's SignatureOwner GUID for enrolled keys
 pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
-    let vendor_cert = extract_vendor_cert(ctx.shim)?;
-    let sbat_level = extract_sbat_level(ctx.shim)?;
+    let is_uki = !ctx.uki.is_empty();
+
+    // shim contributes the vendor cert (MokListRT) and SbatLevel
+    // UKI has no shim, so neither is measured into PCR 7.
+    let (vendor_cert, sbat_level) = if is_uki {
+        (Vec::new(), Vec::new())
+    } else {
+        (
+            extract_vendor_cert(ctx.shim)?,
+            extract_sbat_level(ctx.shim)?,
+        )
+    };
 
     // Get EFI variables
     let pk = ctx
@@ -66,6 +80,7 @@ pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
             &dbx_data,
             &vendor_cert,
             &sbat_level,
+            is_uki,
         )?,
         Platform::Vmware => {
             // Replace SignatureOwner GUIDs with VMware's GUID
@@ -80,6 +95,7 @@ pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
                 &dbx_data,
                 &vendor_cert,
                 &sbat_level,
+                is_uki,
             )?
         }
     };
@@ -88,6 +104,9 @@ pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
 }
 
 /// Predict PCR 7 for a specific set of Secure Boot variables.
+///
+/// When `is_uki` is true, the shim-specific SbatLevel and MokListRT
+/// measurements are omitted (there is no shim in a direct-UKI boot).
 fn predict_variant(
     pk_data: &[u8],
     kek_data: &[u8],
@@ -95,6 +114,7 @@ fn predict_variant(
     dbx_data: &[u8],
     vendor_cert: &[u8],
     sbat_level: &[u8],
+    is_uki: bool,
 ) -> Result<[u8; 32]> {
     // 1. SecureBoot = 0x01
     let secure_boot_data =
@@ -121,22 +141,26 @@ fn predict_variant(
     // 6. Separator
     pcr = extend_pcr_separator(&pcr);
 
-    // 7. db authority - certificate used to verify shim
+    // 7. db authority - certificate used to verify the loaded image (shim or UKI)
     // Assumes single cert in db per Bottlerocket sbkeys profile.
     // If multiple signature lists with different sizes exist, only the first is extracted.
     let db_sig = extract_first_sig_from_esl(db_data)?;
     let db_authority = generate_efi_variable_data(&EFI_IMAGE_SECURITY_DATABASE_GUID, "db", &db_sig);
     pcr = extend_pcr(&pcr, &Sha256::digest(&db_authority).into());
 
-    // 8. SbatLevel
-    let sbat_var_data = generate_efi_variable_data(&SHIM_LOCK_GUID, "SbatLevel", sbat_level);
-    pcr = extend_pcr(&pcr, &Sha256::digest(&sbat_var_data).into());
+    // The remaining measurements are contributed by shim. A direct-UKI boot has
+    // no shim, so SbatLevel and MokListRT are not measured.
+    if !is_uki {
+        // 8. SbatLevel
+        let sbat_var_data = generate_efi_variable_data(&SHIM_LOCK_GUID, "SbatLevel", sbat_level);
+        pcr = extend_pcr(&pcr, &Sha256::digest(&sbat_var_data).into());
 
-    // 9. MokListRT - owner GUID + vendor certificate
-    let mut mok_data = SHIM_LOCK_GUID.to_bytes_le().to_vec();
-    mok_data.extend_from_slice(vendor_cert);
-    let mok_var_data = generate_efi_variable_data(&SHIM_LOCK_GUID, "MokListRT", &mok_data);
-    pcr = extend_pcr(&pcr, &Sha256::digest(&mok_var_data).into());
+        // 9. MokListRT - owner GUID + vendor certificate
+        let mut mok_data = SHIM_LOCK_GUID.to_bytes_le().to_vec();
+        mok_data.extend_from_slice(vendor_cert);
+        let mok_var_data = generate_efi_variable_data(&SHIM_LOCK_GUID, "MokListRT", &mok_data);
+        pcr = extend_pcr(&pcr, &Sha256::digest(&mok_var_data).into());
+    }
 
     Ok(pcr)
 }
@@ -170,7 +194,7 @@ fn extract_first_sig_from_esl(esl: &[u8]) -> Result<Vec<u8>> {
 mod tests {
     use super::*;
     use crate::efi::{EfiVar, EfiVars, EFI_CERT_X509_GUID};
-    use crate::predict::test_support::{build_test_shim, MockCtx};
+    use crate::predict::test_support::{build_test_shim, build_test_uki, MockCtx};
 
     #[test]
     fn test_extract_first_sig_from_esl() {
@@ -282,5 +306,30 @@ mod tests {
             .build();
         let err = predict(&ctx).unwrap_err();
         assert!(err.to_string().contains("invalid") || err.to_string().contains("hex"));
+    }
+
+    #[test]
+    fn test_predict_uki_aws() {
+        // Direct-UKI boot: no shim, so PCR 7 stops after the db authority
+        // measurement (no SbatLevel, no MokListRT). No shim is provided.
+        let uki = build_test_uki();
+        let efi_vars = build_efi_vars();
+        let m = MockCtx::new();
+        let ctx = PcrContext::builder()
+            .platform(Platform::Aws)
+            .efi_vars(&efi_vars)
+            .partitions(&m.layout)
+            .uki(&uki)
+            .build();
+        let result = predict(&ctx).unwrap().unwrap();
+        assert_eq!(result.0, PcrIndex::Pcr7);
+
+        // Expected == predict_variant with is_uki=true and empty shim material.
+        let pk = hex::decode(&efi_vars.get("PK").unwrap().data).unwrap();
+        let kek = hex::decode(&efi_vars.get("KEK").unwrap().data).unwrap();
+        let db = hex::decode(&efi_vars.get("db").unwrap().data).unwrap();
+        let dbx = hex::decode(&efi_vars.get("dbx").unwrap().data).unwrap();
+        let expected = predict_variant(&pk, &kek, &db, &dbx, &[], &[], true).unwrap();
+        assert_eq!(result.1.sha256[0], hex::encode(expected));
     }
 }

--- a/tools/pcrsys/src/pcrs/pcr9.rs
+++ b/tools/pcrsys/src/pcrs/pcr9.rs
@@ -6,10 +6,16 @@
 //!
 //! The final /proc/cmdline format is:
 //! `<kernel.* params> BOOT_IMAGE=<path> <grub params before --> -- <init.* params> <grub params after -->`
+//!
+//! For a direct-UKI boot there is no grub: PCR 9 instead covers the two events
+//! the Linux EFI stub measures — the `.cmdline` LoadOptions and the initrd.
 
 use crate::error::Result;
 use crate::parsers::{bootconfig, grub};
-use crate::predict::{extend_pcr_string, PcrContext, PcrIndex, PcrRecord, PCR_INIT_VAL};
+use crate::predict::{
+    extend_pcr, extend_pcr_string, PcrContext, PcrIndex, PcrRecord, PCR_INIT_VAL,
+};
+use sha2::{Digest, Sha256};
 use snafu::whatever;
 
 const KERNEL_PATH_PREFIX: &str = "()/vmlinuz ";
@@ -109,13 +115,37 @@ fn predict_cmdline(
     Ok(cmdline)
 }
 
-/// Predict PCR 9 value.
+/// Predict PCR 9 for a direct-UKI boot.
 ///
-/// PCR 9 = extend(init, SHA256(cmdline + newline))
-/// The trailing newline matches /proc/cmdline format.
+/// The Linux EFI stub extends PCR 9 twice: with the `.cmdline` LoadOptions,
+/// then the initrd. So `PCR9 = extend(extend(0, SHA256(load_options)), SHA256(initrd))`.
+fn predict_uki(uki: &[u8]) -> Result<[u8; 32]> {
+    let load_options = crate::pe::uki_cmdline_load_options(uki)?;
+    let lo_digest: [u8; 32] = Sha256::digest(&load_options).into();
+    let mut pcr9 = extend_pcr(&PCR_INIT_VAL, &lo_digest);
+
+    let initrd = crate::pe::build_uki_synthetic_initrd(uki)?;
+    if !initrd.is_empty() {
+        let initrd_digest: [u8; 32] = Sha256::digest(&initrd).into();
+        pcr9 = extend_pcr(&pcr9, &initrd_digest);
+    }
+
+    Ok(pcr9)
+}
+
+/// Predict PCR 9.
+///
+/// - shim->grub->vmlinuz: `extend(init, SHA256(cmdline + "\n"))` (matches /proc/cmdline)
+/// - UKI: LoadOptions + initrd
+/// - A/B images: `None`
 pub fn predict(ctx: &PcrContext) -> Result<Option<(PcrIndex, PcrRecord)>> {
     if ctx.partitions.boot_b.is_some() {
         return Ok(None);
+    }
+
+    if !ctx.uki.is_empty() {
+        let pcr9 = predict_uki(ctx.uki)?;
+        return Ok(Some((PcrIndex::Pcr9, PcrRecord::new(pcr9))));
     }
 
     let mut cmdline = predict_cmdline(ctx.grub_cfg, ctx.bootconfig, Some(ctx.boot_partuuid))?;
@@ -273,5 +303,38 @@ mod tests {
         let m = MockCtx::dual_bank();
         let ctx = m.build(crate::platform::Platform::Aws);
         assert!(predict(&ctx).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_predict_uki_from_cmdline() {
+        use crate::predict::test_support::{build_test_uki, MockCtx};
+
+        let uki = build_test_uki();
+        let m = MockCtx::new();
+        let ctx = PcrContext::builder()
+            .platform(crate::platform::Platform::Aws)
+            .efi_vars(&m.efi_vars)
+            .partitions(&m.layout)
+            .uki(&uki)
+            .build();
+
+        let result = predict(&ctx).unwrap().unwrap();
+        assert_eq!(result.0, PcrIndex::Pcr9);
+
+        // Golden PCR 9 = extend(extend(0, SHA256(UTF-16LE cmdline + NUL)),
+        // SHA256(os-release cpio)). Locks in UTF-16LE, verbatim quotes, no
+        // BOOT_IMAGE prefix, no trailing newline, and the os-release initrd.
+        assert_eq!(
+            result.1.sha256[0],
+            "f74187f18ddb9bc4f439722186ddd54689460b4dd98d535925e1ebb255055700"
+        );
+
+        // Cross-check the chain against the pe.rs building blocks.
+        let load_options = crate::pe::uki_cmdline_load_options(&uki).unwrap();
+        let d1: [u8; 32] = Sha256::digest(&load_options).into();
+        let initrd = crate::pe::build_uki_synthetic_initrd(&uki).unwrap();
+        let d2: [u8; 32] = Sha256::digest(&initrd).into();
+        let expected = extend_pcr(&extend_pcr(&PCR_INIT_VAL, &d1), &d2);
+        assert_eq!(result.1.sha256[0], hex::encode(expected));
     }
 }

--- a/tools/pcrsys/src/pe.rs
+++ b/tools/pcrsys/src/pe.rs
@@ -95,6 +95,33 @@ pub fn extract_sbat_level(pe_data: &[u8]) -> Result<Vec<u8>> {
     Ok(section_data[HEADER_SIZE..end].to_vec())
 }
 
+/// Determine whether a PE image is a Unified Kernel Image (UKI).
+///
+/// A UKI embeds the kernel in a `.linux` PE section (systemd-stub); shim and
+/// other chain loaders do not have one.
+pub fn is_uki(pe_data: &[u8]) -> bool {
+    get_section_data(pe_data, ".linux").is_ok()
+}
+
+/// Extract the kernel command line from a UKI's `.cmdline` PE section.
+pub fn extract_uki_cmdline(pe_data: &[u8]) -> Result<String> {
+    let section_data = get_section_data(pe_data, ".cmdline")?;
+
+    // Strip trailing NUL padding.
+    let end = section_data
+        .iter()
+        .rposition(|&b| b != 0)
+        .map(|p| p + 1)
+        .unwrap_or(0);
+
+    let cmdline = std::str::from_utf8(&section_data[..end])
+        .ok()
+        .whatever_context(".cmdline section is not valid UTF-8")?
+        .to_string();
+
+    Ok(cmdline)
+}
+
 /// Get raw data from a named PE section.
 fn get_section_data<'a>(pe_data: &'a [u8], name: &str) -> Result<&'a [u8]> {
     let pe = PeFile::<pe::ImageNtHeaders64>::parse(pe_data)
@@ -114,9 +141,31 @@ fn get_section_data<'a>(pe_data: &'a [u8], name: &str) -> Result<&'a [u8]> {
     whatever!("section '{name}' not found");
 }
 
+/// UTF-16LE `LoadOptions` bytes the Linux EFI stub measures into PCR 9.
+///
+/// systemd-stub passes the `.cmdline` section to the kernel verbatim as the EFI
+/// `LoadOptions` (UTF-16LE, NUL-terminated); the stub measures exactly those
+/// bytes (event `LOADED_IMAGE::LoadOptions`).
+pub fn uki_cmdline_load_options(pe_data: &[u8]) -> Result<Vec<u8>> {
+    let cmdline = extract_uki_cmdline(pe_data)?;
+    let mut load_options: Vec<u8> = cmdline
+        .encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect();
+    load_options.extend_from_slice(&[0, 0]); // UTF-16 NUL terminator, also measured
+    Ok(load_options)
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+
+    /// `.cmdline` contents for `build_test_uki` (shared with the PCR 9 test).
+    pub const TEST_UKI_CMDLINE: &str = r#"root=/dev/dm-0 rootwait ro dm-mod.create="root,,,ro,0 1 verity" -- systemd.log_target=journal"#;
+
+    /// `.osrel` contents for `build_test_uki`; wrapped into the `/.extra/os-release`
+    /// initrd cpio (shared with the PCR 9 test).
+    pub const TEST_UKI_OSREL: &str = "ID=bottlerocket-test\nVERSION_ID=0.0\n";
 
     /// Build a mock shim PE with .sbatlevel and .vendor_cert sections.
     ///
@@ -208,6 +257,84 @@ pub(crate) mod tests {
         pe
     }
 
+    /// Build a mock UKI PE (systemd-stub) with `.linux` (the `is_uki` marker),
+    /// `.cmdline` and `.osrel` sections, enough to exercise PCR 9 prediction.
+    pub fn build_test_uki() -> Vec<u8> {
+        let mut pe = vec![0u8; 0xa00];
+
+        // DOS header
+        pe[0..2].copy_from_slice(b"MZ");
+        pe[0x3c..0x40].copy_from_slice(&0x40u32.to_le_bytes()); // PE header offset
+
+        // PE signature + COFF header at 0x40
+        pe[0x40..0x44].copy_from_slice(b"PE\0\0");
+        pe[0x44..0x46].copy_from_slice(&0x8664u16.to_le_bytes()); // Machine: x86_64
+        pe[0x46..0x48].copy_from_slice(&4u16.to_le_bytes()); // NumberOfSections
+        pe[0x4c..0x50].copy_from_slice(&0u32.to_le_bytes()); // PointerToSymbolTable
+        pe[0x50..0x54].copy_from_slice(&0u32.to_le_bytes()); // NumberOfSymbols
+        pe[0x54..0x56].copy_from_slice(&0xf0u16.to_le_bytes()); // SizeOfOptionalHeader
+        pe[0x56..0x58].copy_from_slice(&0x22u16.to_le_bytes()); // Characteristics
+
+        // Optional header (PE32+) at 0x58
+        pe[0x58..0x5a].copy_from_slice(&0x20bu16.to_le_bytes()); // Magic: PE32+
+        pe[0x5a] = 0x01; // MajorLinkerVersion
+        pe[0x78..0x7c].copy_from_slice(&0x1000u32.to_le_bytes()); // SectionAlignment
+        pe[0x7c..0x80].copy_from_slice(&0x200u32.to_le_bytes()); // FileAlignment
+        pe[0x80..0x84].copy_from_slice(&1u32.to_le_bytes()); // MajorOperatingSystemVersion
+        pe[0x88..0x8c].copy_from_slice(&1u32.to_le_bytes()); // MajorSubsystemVersion
+        pe[0x90..0x94].copy_from_slice(&0x5000u32.to_le_bytes()); // SizeOfImage
+        pe[0x94..0x98].copy_from_slice(&0x200u32.to_le_bytes()); // SizeOfHeaders
+        pe[0x9c..0x9e].copy_from_slice(&10u16.to_le_bytes()); // Subsystem: EFI Application
+        pe[0xc4..0xc8].copy_from_slice(&16u32.to_le_bytes()); // NumberOfRvaAndSizes
+
+        // Section headers start at 0x148 (after optional header)
+        // Section 1: .text
+        pe[0x148..0x150].copy_from_slice(b".text\0\0\0");
+        pe[0x150..0x154].copy_from_slice(&0x10u32.to_le_bytes()); // VirtualSize
+        pe[0x154..0x158].copy_from_slice(&0x1000u32.to_le_bytes()); // VirtualAddress
+        pe[0x158..0x15c].copy_from_slice(&0x200u32.to_le_bytes()); // SizeOfRawData
+        pe[0x15c..0x160].copy_from_slice(&0x200u32.to_le_bytes()); // PointerToRawData
+        pe[0x16c..0x170].copy_from_slice(&0x60000020u32.to_le_bytes()); // Characteristics
+
+        // Section 2: .linux (short name, fits in 8 bytes)
+        pe[0x170..0x178].copy_from_slice(b".linux\0\0");
+        pe[0x178..0x17c].copy_from_slice(&0x40u32.to_le_bytes()); // VirtualSize
+        pe[0x17c..0x180].copy_from_slice(&0x2000u32.to_le_bytes()); // VirtualAddress
+        pe[0x180..0x184].copy_from_slice(&0x200u32.to_le_bytes()); // SizeOfRawData
+        pe[0x184..0x188].copy_from_slice(&0x400u32.to_le_bytes()); // PointerToRawData
+        pe[0x194..0x198].copy_from_slice(&0x40000040u32.to_le_bytes()); // Characteristics
+
+        // Section 3: .cmdline (short name, exactly 8 bytes)
+        pe[0x198..0x1a0].copy_from_slice(b".cmdline");
+        pe[0x1a0..0x1a4].copy_from_slice(&0x200u32.to_le_bytes()); // VirtualSize
+        pe[0x1a4..0x1a8].copy_from_slice(&0x3000u32.to_le_bytes()); // VirtualAddress
+        pe[0x1a8..0x1ac].copy_from_slice(&0x200u32.to_le_bytes()); // SizeOfRawData
+        pe[0x1ac..0x1b0].copy_from_slice(&0x600u32.to_le_bytes()); // PointerToRawData
+        pe[0x1bc..0x1c0].copy_from_slice(&0x40000040u32.to_le_bytes()); // Characteristics
+
+        // Section 4: .osrel. VirtualSize = exact length so the section (and its
+        // cpio) has no NUL padding; systemd-stub measures the virtual size.
+        let osrel = TEST_UKI_OSREL.as_bytes();
+        pe[0x1c0..0x1c8].copy_from_slice(b".osrel\0\0");
+        pe[0x1c8..0x1cc].copy_from_slice(&(osrel.len() as u32).to_le_bytes()); // VirtualSize
+        pe[0x1cc..0x1d0].copy_from_slice(&0x4000u32.to_le_bytes()); // VirtualAddress
+        pe[0x1d0..0x1d4].copy_from_slice(&0x200u32.to_le_bytes()); // SizeOfRawData
+        pe[0x1d4..0x1d8].copy_from_slice(&0x800u32.to_le_bytes()); // PointerToRawData
+        pe[0x1e4..0x1e8].copy_from_slice(&0x40000040u32.to_le_bytes()); // Characteristics
+
+        // .text data at 0x200
+        pe[0x200..0x210].fill(0xcc);
+        // .linux data at 0x400 (mock embedded kernel bytes)
+        pe[0x400..0x440].fill(0xab);
+        // .cmdline data at 0x600 (NUL-padded kernel command line)
+        let cmdline = TEST_UKI_CMDLINE.as_bytes();
+        pe[0x600..0x600 + cmdline.len()].copy_from_slice(cmdline);
+        // .osrel data at 0x800
+        pe[0x800..0x800 + osrel.len()].copy_from_slice(osrel);
+
+        pe
+    }
+
     #[test]
     fn test_authenticode_hash() {
         let pe = build_test_shim();
@@ -281,5 +408,53 @@ pub(crate) mod tests {
         let shim = build_test_shim();
         let err = get_section_data(&shim, ".nonexistent").unwrap_err();
         assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_is_uki_true() {
+        let uki = build_test_uki();
+        assert!(is_uki(&uki));
+    }
+
+    #[test]
+    fn test_is_uki_false_for_shim() {
+        // A shim has no `.linux` section.
+        let shim = build_test_shim();
+        assert!(!is_uki(&shim));
+    }
+
+    #[test]
+    fn test_authenticode_hash_uki() {
+        // The UKI test fixture must be Authenticode-hashable (used by PCR 4).
+        let uki = build_test_uki();
+        get_authenticode_hash(&uki).unwrap();
+    }
+
+    #[test]
+    fn test_extract_uki_cmdline() {
+        let uki = build_test_uki();
+        let cmdline = extract_uki_cmdline(&uki).unwrap();
+        // The extracted cmdline must equal the embedded string with the
+        // trailing NUL padding stripped.
+        assert_eq!(cmdline, TEST_UKI_CMDLINE);
+    }
+
+    #[test]
+    fn test_uki_cmdline_load_options() {
+        let uki = build_test_uki();
+        let lo = uki_cmdline_load_options(&uki).unwrap();
+
+        // The measured LoadOptions are the UTF-16LE encoding of the raw
+        // `.cmdline` (no quote repair, no newline) plus a UTF-16 NUL terminator.
+        let mut expected: Vec<u8> = TEST_UKI_CMDLINE
+            .encode_utf16()
+            .flat_map(|u| u.to_le_bytes())
+            .collect();
+        expected.extend_from_slice(&[0, 0]);
+        assert_eq!(lo, expected);
+        assert_eq!(lo.len(), TEST_UKI_CMDLINE.len() * 2 + 2);
+        // The dm-mod.create quotes are preserved verbatim (NOT quote-repaired):
+        // the `"` char (0x22) appears as the UTF-16LE unit 22 00.
+        assert!(lo.windows(2).any(|w| w == [0x22, 0x00]));
     }
 }

--- a/tools/pcrsys/src/pe.rs
+++ b/tools/pcrsys/src/pe.rs
@@ -156,6 +156,115 @@ pub fn uki_cmdline_load_options(pe_data: &[u8]) -> Result<Vec<u8>> {
     Ok(load_options)
 }
 
+/// Pad `buf` with NULs until its length since `start` is a multiple of 4;
+/// `newc` aligns every record (and file data) to a 4-byte boundary.
+fn pad4(buf: &mut Vec<u8>, start: usize) {
+    while !(buf.len() - start).is_multiple_of(4) {
+        buf.push(0);
+    }
+}
+
+/// Write a CPIO `newc` header (magic + 13 8-hex-digit fields). Every record we
+/// emit uses uid/gid/mtime/dev*/crc = 0 and nlink = 1, so only `inode`, `mode`,
+/// `filesize` and `namesize` vary.
+fn cpio_header(buf: &mut Vec<u8>, inode: u32, mode: u32, filesize: u32, namesize: u32) {
+    buf.extend_from_slice(b"070701");
+    // inode, mode, uid, gid, nlink, mtime, filesize, dev{major,minor},
+    // rdev{major,minor}, namesize, crc
+    let fields = [inode, mode, 0, 0, 1, 0, filesize, 0, 0, 0, 0, namesize, 0];
+    for f in fields {
+        buf.extend_from_slice(format!("{f:08x}").as_bytes());
+    }
+}
+
+/// CPIO `newc` directory inode (systemd-stub `pack_cpio_dir`).
+fn cpio_dir(buf: &mut Vec<u8>, path: &str, access_mode: u32, inode: u32) {
+    let start = buf.len();
+    cpio_header(buf, inode, access_mode | 0o040000, 0, path.len() as u32 + 1);
+    buf.extend_from_slice(path.as_bytes());
+    buf.push(0);
+    pad4(buf, start);
+}
+
+/// CPIO `newc` regular-file inode (systemd-stub `pack_cpio_one`), named
+/// `<dir_prefix>/<filename>`.
+fn cpio_file(
+    buf: &mut Vec<u8>,
+    dir_prefix: &str,
+    filename: &str,
+    data: &[u8],
+    access_mode: u32,
+    inode: u32,
+) {
+    let start = buf.len();
+    let namesize = dir_prefix.len() as u32 + filename.len() as u32 + 2; // '/' + NUL
+    cpio_header(
+        buf,
+        inode,
+        access_mode | 0o100000,
+        data.len() as u32,
+        namesize,
+    );
+    buf.extend_from_slice(dir_prefix.as_bytes());
+    buf.push(b'/');
+    buf.extend_from_slice(filename.as_bytes());
+    buf.push(0);
+    pad4(buf, start);
+    buf.extend_from_slice(data);
+    pad4(buf, start);
+}
+
+/// CPIO `newc` archive trailer (systemd-stub `pack_cpio_trailer`), measured
+/// verbatim. Kept as a literal rather than built via [`cpio_header`] because
+/// systemd emits the trailer's `namesize` in UPPERCASE hex (`0000000B`) while
+/// our other headers use lowercase; a live-TPM check confirmed the uppercase
+/// form. The four NUL bytes after `TRAILER!!!` are its name NUL plus padding to
+/// a 4-byte boundary.
+const CPIO_TRAILER: &[u8] = concat!(
+    "070701",   // magic
+    "00000000", // inode
+    "00000000", // mode
+    "00000000", // uid
+    "00000000", // gid
+    "00000001", // nlink
+    "00000000", // mtime
+    "00000000", // filesize
+    "00000000", // devmajor
+    "00000000", // devminor
+    "00000000", // rdevmajor
+    "00000000", // rdevminor
+    "0000000B", // namesize = 11 ("TRAILER!!!\0"), uppercase per systemd
+    "00000000", // crc
+    "TRAILER!!!",
+    "\0\0\0\0",
+)
+.as_bytes();
+
+/// The cpio systemd-stub's `pack_cpio_literal()` produces for one embedded
+/// section: the `.extra` dir (0555), the file `.extra/<filename>` (0444), and
+/// the trailer.
+fn build_extra_cpio(filename: &str, data: &[u8]) -> Vec<u8> {
+    let mut cpio = Vec::new();
+    cpio_dir(&mut cpio, ".extra", 0o555, 1);
+    cpio_file(&mut cpio, ".extra", filename, data, 0o444, 2);
+    cpio.extend_from_slice(CPIO_TRAILER);
+    cpio
+}
+
+/// Reconstruct the initrd byte stream a direct-UKI boot hands the kernel, which
+/// the Linux EFI stub hashes into PCR 9 (event `Linux initrd`).
+///
+/// systemd-stub embeds `.ucode`, `.initrd`, `.pcrsig`, `.pcrpkey`, `.osrel` and
+/// `.profile`. In a Bottlerocket UKI all but `.osrel` is empty, so we use only
+/// that for calculation. Any change in any of the above sections would break
+/// PCR9 calculations.
+pub fn build_uki_synthetic_initrd(pe_data: &[u8]) -> Result<Vec<u8>> {
+    match get_section_data(pe_data, ".osrel") {
+        Ok(osrel) => Ok(build_extra_cpio("os-release", osrel)),
+        Err(_) => Ok(Vec::new()),
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -456,5 +565,27 @@ pub(crate) mod tests {
         // The dm-mod.create quotes are preserved verbatim (NOT quote-repaired):
         // the `"` char (0x22) appears as the UTF-16LE unit 22 00.
         assert!(lo.windows(2).any(|w| w == [0x22, 0x00]));
+    }
+
+    #[test]
+    fn test_build_uki_synthetic_initrd_osrel_cpio() {
+        let uki = build_test_uki();
+        let initrd = build_uki_synthetic_initrd(&uki).unwrap();
+
+        // Golden SHA256 of the systemd-stub `/.extra/os-release` cpio built from
+        // TEST_UKI_OSREL. Computed independently from the cpio `newc` format.
+        let digest: [u8; 32] = Sha256::digest(&initrd).into();
+        assert_eq!(
+            hex::encode(digest),
+            "ce5bfa54adc1aba0973b10e43e2e45ca7037d11fc27ca066fe7fa293bdd86d08"
+        );
+
+        // Structural sanity: a newc archive containing the .extra dir, the
+        // os-release file and the trailer.
+        assert!(initrd.starts_with(b"070701"));
+        assert!(initrd.windows(6).any(|w| w == b".extra"));
+        assert!(initrd.windows(10).any(|w| w == b"os-release"));
+        assert!(initrd.windows(10).any(|w| w == b"TRAILER!!!"));
+        assert!(initrd.len().is_multiple_of(4));
     }
 }

--- a/tools/pcrsys/src/predict.rs
+++ b/tools/pcrsys/src/predict.rs
@@ -58,6 +58,8 @@ pub struct PcrContext<'a> {
     #[builder(default)]
     pub shim: &'a [u8],
     #[builder(default)]
+    pub uki: &'a [u8],
+    #[builder(default)]
     pub grub: &'a [u8],
     #[builder(default)]
     pub vmlinuz: &'a [u8],
@@ -203,7 +205,7 @@ pub mod test_support {
         }
     }
 
-    pub use crate::pe::tests::build_test_shim;
+    pub use crate::pe::tests::{build_test_shim, build_test_uki};
 
     /// Test context that owns EfiVars and PartitionLayout for convenient test setup.
     pub struct MockCtx {

--- a/twoliter/embedded/img2img
+++ b/twoliter/embedded/img2img
@@ -633,7 +633,7 @@ echo "${root_usage}" "${boot_usage}" | jq -s 'add | {disk_usage: .}' > "${OUTPUT
 
 # Predict PCR values after all signing is complete.
 # Skipped for UKI images, matching `rpm2img`.
-if [[ "${UEFI_SECURE_BOOT}" == "yes" && "${UKI_IMAGE}" == "no" ]]; then
+if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
   "${0%/*}/pcrsys" disk \
     --image "${OS_IMAGE}" \
     --efi-vars "${SBKEYS}/efi-vars.json" \

--- a/twoliter/embedded/rpm2img
+++ b/twoliter/embedded/rpm2img
@@ -844,7 +844,7 @@ fi
 # Skipped for UKI images: pcrsys currently assumes an ext4 BOOT-A partition
 # (for reading grub.cfg/vmlinuz), but UKI images use a FAT BOOT-A partition,
 # so PCR prediction would fail here.
-if [[ "${UEFI_SECURE_BOOT}" == "yes" && "${UKI_IMAGE}" == "no" ]]; then
+if [[ "${UEFI_SECURE_BOOT}" == "yes" ]]; then
   "${0%/*}/pcrsys" disk \
     --image "${OS_IMAGE}" \
     --efi-vars "${SBKEYS}/efi-vars.json" \


### PR DESCRIPTION
**Description of changes:**

`pcrsys` predicts expected TPM PCR values (written to `pcr-predictions.json`) for measured boot. It now supports AMIs with UKI. The following PCRs are updated:

- **PCR4:** Measure UKI
- **PCR7:** Firmware verifies the UKI directly against `db`, so the shim-contributed SbatLevel and MokListRT measurements are omitted; the db authority measurement remains.
- **PCR9:** Measures the kernel command line and a synthetic initrd generated by systemd-boot.
- **PCR14:** Returns `None` for UKI.
- **GPT parsing (`gpt.rs`):** Falls back to the ESP for the boot partition / boot PARTUUID when no dedicated BOOT partition exists (the merged UKI layout).
- **Enablement:** Removes the `UKI_IMAGE == "no"` guard in `rpm2img`/`img2img` so PCR prediction now runs for UKI images.

**Testing done:**

Tested together with:
- https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1042
- https://github.com/bottlerocket-os/bottlerocket/pull/4936
- https://github.com/bottlerocket-os/bottlerocket/pull/4937
- https://github.com/bottlerocket-os/twoliter/pull/742

**AMI / boot validation**

1. AMI builds and instance boots ✅
2. `pcr-predictions.json` values match `tpm2_pcrread sha256:{PCR}` on the live instance (PCR4/7/9 exact; PCR14 null) ✅
3. No failed services in the AMIs ✅

<details>
<summary>Click to expand logs</summary>

```
--- apiclient get os (bind evidence to variant/arch/flavor) ---
{
  "os": {
    "arch": "aarch64",
    "build_id": "bd293f6e-dirty",
    "pretty_name": "Bottlerocket OS 1.65.0 (aws-mantle-1-fips)",
    "variant_id": "aws-mantle-1-fips",
    "version_id": "1.65.0"
  }
}
===== GROUP A (boot health) =====
is_system_running=running
--- systemctl --failed (expect none) ---
failed_unit_count=0
===== GROUP C (Secure Boot + erofs + dm-verity) =====
--- C1: SecureBoot / SetupMode efivars (last byte: SecureBoot=1 enabled, SetupMode=0) ---
secureboot_last_byte=1
setupmode_last_byte=0
--- C2: root filesystem is erofs ---
/dev/dm-0 erofs
root_is_erofs=1
--- C3: dm-verity backing root (dm device + verity target) ---
NAME                     PARTLABEL               FSTYPE          SIZE TYPE  MOUNTPOINT
nvme0n1                                                            2G disk  
|-nvme0n1p1              BIOS-BOOT                                 4M part  
|-nvme0n1p2              EFI-SYSTEM              vfat             90M part  /boot
|-nvme0n1p3              BOTTLEROCKET-ROOT-A     erofs           1.8G part  
|-nvme0n1p4              BOTTLEROCKET-HASH-A     DM_verity_hash   20M part  
|-nvme0n1p5              BOTTLEROCKET-RESERVED-A                  50M part  
|-nvme0n1p6              BOTTLEROCKET-PRIVATE                     41M part  
| `-BOTTLEROCKET-PRIVATE                         ext4             41M crypt /var/lib/bottlerocket
`-nvme0n1p7                                                        1M part  
nvme1n1                                                         1000G disk  
`-nvme1n1p1              BOTTLEROCKET-DATA                      1000G part  
  `-BOTTLEROCKET-DATA                            xfs            1000G crypt /local
0 359656 verity 1 259:5 259:6 4096 4096 44957 1 sha256 83133aebd45376229be385829176d1f89805bc54041e3213aacbb02a9ecb3797 ac68086fbd4357c7e3af19667f016f692965c1bfc19267ef7b79052730bdb0d1 2 restart_on_corruption ignore_zero_blocks
root_verity_count=1
--- C4: /boot is vfat, read-only ---
/dev/nvme0n1p2 vfat ro,nosuid,nodev,noexec,noatime,context=system_u:object_r:os_t:s0,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=winnt,errors=remount-ro
boot_is_vfat=1
boot_is_ro=1
===== GROUP B (FIPS) =====
fips_enabled=1
fips_cmdline_token=fips=1
fips=1
fipscheck_target_active=active
--- B4 (UKI kernel-integrity, authoritative): check-kernel-integrity.service result ---
Result=success
ExecMainStatus=0
ActiveState=active
--- B4: generate-fips-hmac-path-uki.service (sets HMAC_PATH to the UKI .efi hmac) ---
Result=success
ExecMainStatus=0
ActiveState=active
```

</details>

4. UKI is placed at the correct destination (`EFI/BOOT/BOOT{X64,AA64}.EFI`) ✅

<details>
<summary>Click to expand logs</summary>

```
--- findmnt /boot — confirm the ESP (EFI-SYSTEM) is mounted read-only at /boot ---
/dev/nvme0n1p2 vfat ro,nosuid,nodev,noexec,noatime,context=system_u:object_r:os_t:s0,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=winnt,errors=remount-ro
--- findmnt / (expect erofs, dm-verity — no regression) ---
/dev/dm-0 erofs
--- FULL ESP file tree (/boot IS the ESP; every EFI executable firmware could load) ---
/boot/EFI/BOOT/db.crt
/boot/EFI/BOOT/db.cer
/boot/EFI/BOOT/BOOTX64.EFI
/boot/EFI/BOOT/.bottlerocket.efi.hmac
```

</details>

5. UKI is signed (chains to `db`) ✅

<details>
<summary>Click to expand logs</summary>

```
secureboot_od= 6 0 0 0 1
secureboot_last_byte=1
setupmode_od= 6 0 0 0 0
setupmode_last_byte=0
```

</details>

6. FIPS integrity check ✅ 

**Workload tests**

1. `dotnet-test` ✅

<details>
<summary>Click to expand logs</summary>

```
### CMD: apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "bd293f6e-dirty",
    "pretty_name": "Bottlerocket OS 1.65.0 (aws-mantle-1-fips)",
    "variant_id": "aws-mantle-1-fips",
    "version_id": "1.65.0"
  }
}
### CMD: ./scripts/dotnet-ctr.sh i-0ae5bef956134343f us-west-2
### target: i-0ae5bef956134343f  region=us-west-2  image=public.ecr.aws/s2v1a1q8/hello-dotnet:latest  runid=1789112907-2782392-0ae5bef956134343f
### [1/8] pull image (up to ~15m)
### [2/8] materialize writable rootfs -> /local/dotnet-rootfs-1789112907-2782392-0ae5bef956134343f
### [3/8] relabel rootfs -> data_t
### [4/8] capture image base OCI spec via a helper container
### [5/8] patch SELinux labels + writable rootfs into the spec (local; no CDI merge)
    spec bytes: 3383
### [6/8] deliver spec -> /local/dotnet-oci-spec-1789112907-2782392-0ae5bef956134343f.json
### DELIVER OK: /tmp/tmp.bUMDY8OLZj/dotnet-oci-spec.json -> /local/dotnet-oci-spec-1789112907-2782392-0ae5bef956134343f.json (1 chunks of 6000)
### [7/8] run dotnet-test via ctr — output below
-----------------------------------------------------------------

Welcome to .NET 10.0!
---------------------
SDK Version: 10.0.110

----------------
Installed an ASP.NET Core HTTPS development certificate.
To trust the certificate, run 'dotnet dev-certs https --trust'
Learn about HTTPS: https://aka.ms/dotnet-https

----------------
Write your first app: https://aka.ms/dotnet-hello-world
Find out what's new: https://aka.ms/dotnet-whats-new
Explore documentation: https://aka.ms/dotnet-docs
Report issues and find source on GitHub: https://github.com/dotnet/core
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
--------------------------------------------------------------------------------------
The template "Console App" was created successfully.

Processing post-creation actions...
Restoring /Hello/Hello.csproj:
  Determining projects to restore...
  Restored /Hello/Hello.csproj (in 134 ms).
Restore succeeded.


hello, dotnet-----------------------------------------------------------------
### [8/8] cleanup
### DONE (run rc=0) — expect the hello-dotnet greeting and rc=0
DOTNET_EXIT=0
```

</details>

2. `nvidia-smoke-test` ✅

<details>
<summary>Click to expand logs</summary>

```
### CMD: apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "bd293f6e-dirty",
    "pretty_name": "Bottlerocket OS 1.65.0 (aws-mantle-1-nvidia-fips)",
    "variant_id": "aws-mantle-1-nvidia-fips",
    "version_id": "1.65.0"
  }
}
### CMD: ./scripts/nvidia-smoke-ctr.sh i-04a4864b08ed03e5d us-west-2
### target: i-04a4864b08ed03e5d  region=us-west-2  image=public.ecr.aws/s2v1a1q8/nvidia-smoke-test:latest  runid=1789113013-2784420-04a4864b08ed03e5d
### [1/9] pull image (up to ~15m)
### [2/9] materialize writable rootfs -> /local/nvidia-rootfs-1789113013-2784420-04a4864b08ed03e5d
### [3/9] relabel rootfs -> data_t
### [4/9] capture image base OCI spec via a helper container
### [5/9] fetch boot-generated CDI spec (/etc/cdi/nvidia.json)
### [6/9] merge CDI containerEdits + patch SELinux/rootfs (local)
    spec bytes: 25488
### [7/9] deliver spec -> /local/nvidia-oci-spec-1789113013-2784420-04a4864b08ed03e5d.json
### DELIVER OK: /tmp/tmp.78oMii5SQl/spec.json -> /local/nvidia-oci-spec-1789113013-2784420-04a4864b08ed03e5d.json (6 chunks of 6000)
### [8/9] run nvidia-smoke-test via ctr (GPU) — output below
-----------------------------------------------------------------

=========================================
  Running sample UnifiedMemoryPerf
=========================================

GPU Device 0: "Ampere" with compute capability 8.6

Running ........................................................

Overall Time For matrixMultiplyPerf 

Printing Average of 20 measurements in (ms)
Size_KB     UMhint    UMhntAs     UMeasy      0Copy    MemCopy    CpAsync    CpHpglk    CpPglAs
4      0.271      0.339      0.382      0.016      0.053      0.030      0.040      0.028
16      0.271      0.350      0.607      0.032      0.052      0.043      0.058      0.040
64      0.402      0.505      0.892      0.100      0.109      0.101      0.103      0.090
256      0.771      0.765      1.560      0.535      0.327      0.305      0.288      0.279
1024      2.332      2.034      3.879      3.207      1.288      1.231      1.128      1.120
4096      8.316      6.801     14.997     23.193      5.515      5.475      5.377      5.342
16384     35.250     30.360     61.068    171.169     25.688     25.582     25.361     25.355

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA A10G"
  CUDA Driver Version / Runtime Version          13.0 / 12.9
  CUDA Capability Major/Minor version number:    8.6
  Total amount of global memory:                 22588 MBytes (23684841472 bytes)
  (080) Multiprocessors, (128) CUDA Cores/MP:    10240 CUDA Cores
  GPU Max Clock rate:                            1710 MHz (1.71 GHz)
  Memory Clock rate:                             6251 Mhz
  Memory Bus Width:                              384-bit
  L2 Cache Size:                                 6291456 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 30
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 13.0, CUDA Runtime Version = 12.9, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Ampere" with compute capability 8.6

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 2429.38 GFlop/s, Time= 1.726 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample immaTensorCoreGemm
=========================================

Initializing...
GPU Device 0: "Ampere" with compute capability 8.6

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma 
Time: 10.112000 ms
TOPS: 13.59

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Ampere" with compute capability 8.6

33554432 elements
numThreads: 768
numBlocks: 80

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.324410 ms
Bandwidth:    413.728826 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Ampere" with compute capability 8.6

> Detected Compute SM 8.6 hardware with 80 multi-processors
Starting shfl_scan
GPU Device 0: "Ampere" with compute capability 8.6

> Detected Compute SM 8.6 hardware with 80 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 3.126912
65536 elements scanned in 3.126912 ms -> 20.958696 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.164490 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.028672 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.113504 ms 
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Ampere" with compute capability 8.6

Launching normVecByDotProductAWBarrier kernel with numBlocks = 160 blockSize = 768
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================

simpleAtomicIntrinsics starting...
GPU Device 0: "Ampere" with compute capability 8.6

Processing time: 3.352000 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Ampere" with compute capability 8.6

> GPU device has 80 Multi-Processors, SM 8.6 compute capabilities

[VOTE Kernel Test 1/3]
    Running <<Vote.Any>> kernel1 ...
    OK

[VOTE Kernel Test 2/3]
    Running <<Vote.All>> kernel2 ...
    OK

[VOTE Kernel Test 3/3]
    Running <<Vote.Any>> kernel3 ...
    OK
    Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Ampere" with compute capability 8.6

CPU max matches GPU max

Warp Aggregated Atomics PASSED 
{'GL_VENDOR': 'NVIDIA Corporation', 'GL_RENDERER': 'NVIDIA A10G/PCIe/SSE2', 'GL_VERSION': '3.3.0 NVIDIA 580.178.04', 'GL_POINT_SIZE_RANGE': (1.0, 2047.0), 'GL_SMOOTH_LINE_WIDTH_RANGE': (0.5, 10.0), 'GL_ALIASED_LINE_WIDTH_RANGE': (1.0, 10.0), 'GL_POINT_FADE_THRESHOLD_SIZE': 1.0, 'GL_POINT_SIZE_GRANULARITY': 0.125, 'GL_SMOOTH_LINE_WIDTH_GRANULARITY': 0.125, 'GL_MIN_PROGRAM_TEXEL_OFFSET': -8.0, 'GL_MAX_PROGRAM_TEXEL_OFFSET': 7.0, 'GL_MINOR_VERSION': 3, 'GL_MAJOR_VERSION': 3, 'GL_SAMPLE_BUFFERS': 0, 'GL_SUBPIXEL_BITS': 8, 'GL_CONTEXT_PROFILE_MASK': 1, 'GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT': 256, 'GL_DOUBLEBUFFER': False, 'GL_STEREO': False, 'GL_MAX_VIEWPORT_DIMS': (32768, 32768), 'GL_MAX_3D_TEXTURE_SIZE': 16384, 'GL_MAX_ARRAY_TEXTURE_LAYERS': 2048, 'GL_MAX_CLIP_DISTANCES': 8, 'GL_MAX_COLOR_ATTACHMENTS': 8, 'GL_MAX_COLOR_TEXTURE_SAMPLES': 64, 'GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS': 233472, 'GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS': 231424, 'GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS': 192, 'GL_MAX_COMBINED_UNIFORM_BLOCKS': 84, 'GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS': 233472, 'GL_MAX_CUBE_MAP_TEXTURE_SIZE': 32768, 'GL_MAX_DEPTH_TEXTURE_SAMPLES': 64, 'GL_MAX_DRAW_BUFFERS': 8, 'GL_MAX_DUAL_SOURCE_DRAW_BUFFERS': 1, 'GL_MAX_ELEMENTS_INDICES': 1048576, 'GL_MAX_ELEMENTS_VERTICES': 1048576, 'GL_MAX_FRAGMENT_INPUT_COMPONENTS': 128, 'GL_MAX_FRAGMENT_UNIFORM_COMPONENTS': 4096, 'GL_MAX_FRAGMENT_UNIFORM_VECTORS': 1024, 'GL_MAX_FRAGMENT_UNIFORM_BLOCKS': 14, 'GL_MAX_GEOMETRY_INPUT_COMPONENTS': 128, 'GL_MAX_GEOMETRY_OUTPUT_COMPONENTS': 128, 'GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS': 32, 'GL_MAX_GEOMETRY_UNIFORM_BLOCKS': 14, 'GL_MAX_GEOMETRY_UNIFORM_COMPONENTS': 2048, 'GL_MAX_GEOMETRY_OUTPUT_VERTICES': 1024, 'GL_MAX_INTEGER_SAMPLES': 64, 'GL_MAX_SAMPLES': 64, 'GL_MAX_RECTANGLE_TEXTURE_SIZE': 32768, 'GL_MAX_RENDERBUFFER_SIZE': 32768, 'GL_MAX_SAMPLE_MASK_WORDS': 2, 'GL_MAX_TEXTURE_BUFFER_SIZE': 134217728, 'GL_MAX_TEXTURE_IMAGE_UNITS': 32, 'GL_MAX_TEXTURE_LOD_BIAS': 15, 'GL_MAX_TEXTURE_SIZE': 32768, 'GL_MAX_UNIFORM_BUFFER_BINDINGS': 84, 'GL_MAX_UNIFORM_BLOCK_SIZE': 65536, 'GL_MAX_VARYING_VECTORS': 31, 'GL_MAX_VERTEX_ATTRIBS': 16, 'GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS': 32, 'GL_MAX_VERTEX_UNIFORM_COMPONENTS': 4096, 'GL_MAX_VERTEX_UNIFORM_VECTORS': 1024, 'GL_MAX_VERTEX_OUTPUT_COMPONENTS': 128, 'GL_MAX_VERTEX_UNIFORM_BLOCKS': 14, 'GL_MAX_SERVER_WAIT_TIMEOUT': -1}-----------------------------------------------------------------
### [9/9] cleanup
### DONE (run rc=0) — expect deviceQuery 'Device 0: "NVIDIA <gpu>"', NumDevs = 1, Result = PASS, vectorAdd Test PASSED
NVIDIA_EXIT=0
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
