### PR TITLE
fix(repo): select fat or ext4 boot image for cargo make repo

### DIFF
--- a/twoliter/embedded/Makefile.toml
+++ b/twoliter/embedded/Makefile.toml
@@ -1060,7 +1060,13 @@ trap 'cleanup' EXIT
 
 export PATH="${TWOLITER_TOOLS_DIR}:${PATH}"
 
-bootlz4="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-boot.ext4.lz4"
+# BOOT-A is FAT for UKI images (see the UKI_IMAGE branch in rpm2img/img2img),
+# and ext4 otherwise. The variant's image format isn't plumbed through to
+# cargo-make, so pick whichever boot artifact 'cargo make' actually produced.
+bootlz4="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-boot.fat.lz4"
+if [ ! -s "${bootlz4}" ]; then
+   bootlz4="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-boot.ext4.lz4"
+fi
 rootlz4="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-root.ext4.lz4"
 hashlz4="${BUILDSYS_VARIANT_DIR}/${BUILDSYS_NAME_FULL}-root.verity.lz4"
 if [ ! -s "${bootlz4}" ] || [ ! -s "${rootlz4}" ] || [ ! -s "${hashlz4}" ]; then


### PR DESCRIPTION
**Description of changes:**

`cargo make repo` fails for any variant built with `image-format = "uki"`.

The embedded `[tasks.repo]` cargo-make task hardcoded the boot artifact path as `${BUILDSYS_NAME_FULL}-boot.ext4.lz4`. For UKI variants, `rpm2img`/`img2img` instead produce `-boot.fat.lz4`, because BOOT-A is a FAT filesystem for UKI images (systemd-boot cannot read ext4). The task's own pre-flight existence check therefore failed and aborted with:

```
Image files don't exist for the current version/commit - <version> - please run 'cargo make'
```

even immediately after a successful `cargo make`. The message is misleading: the build had succeeded and produced the correct artifact under a different name.

This change resolves `bootlz4` by checking which of `-boot.fat.lz4` / `-boot.ext4.lz4` the build actually produced, mirroring the suffix selection already present in `rpm2img`/`img2img`, since the variant's image format is not plumbed through to cargo-make.

**Testing done:**

- `shellcheck` on the extracted `[tasks.repo]` script block: no new warnings (pre-existing `SC2048`/`SC2086` findings on unrelated lines remain).
- `twoliter/embedded/tests/test_partyplanner.sh`: 57/57 passed. `twoliter/embedded/tests/test_guest_images_helper.sh`: 6/6 passed.
- Confirmed no filename collision with `imghelper`'s `symlink_image` outputs (symlink names omit the build-id component that `BUILDSYS_NAME_FULL` includes).
- Ran a full `cargo make -e BUILDSYS_VARIANT=aws-mantle-1 build`, which succeeded and produced `-boot.fat.lz4` (and no `-boot.ext4.lz4`) for the `aws-mantle-1` UKI variant.
- Ran `cargo make -e BUILDSYS_VARIANT=aws-mantle-1 repo` against that build output with the fixed binary: exit 0, no error. The generated TUF `manifest.json` recorded `"boot": "bottlerocket-aws-mantle-1-x86_64-1.65.0-0be31b34d-boot.fat.lz4"` alongside the expected `-root.ext4.lz4` and `-root.verity.lz4` entries.
- Confirmed the pinned pre-fix `v0.24.0` twoliter binary reproduces the original failure verbatim on the same artifacts: `Image files don't exist for the current version/commit - 1.65.0-0be31b34d - please run 'cargo make'`, exit code 105.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.